### PR TITLE
PIMS-1250: Update local docker/api to run more similarly to openshift.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS base
 WORKDIR /app
-EXPOSE 80 443
+EXPOSE 443 8080
 
 # Copy csproj and restore as distinct layers
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,4 +17,4 @@ The API is configured to run in a Docker container and has the following depende
 
 Health checks are configured to run against /api/live and /api/ready endpoints. These correspond to the kubernetes concepts of liveliness and readiness, see [here](https://docs.openshift.com/container-platform/3.11/dev_guide/application_health.html). 
 
-Health Checks UI is a UI wrapper around the above health check endpoints. Configuration is provided within appsettings.json. The webhook URI should be provided separately as an environment variable `HealthChecksUI__Webhooks__0__Uri`
+Health Checks UI is a UI wrapper around the above health check endpoints. Configuration is provided within appsettings.json. The webhook URI should be provided separately as an environment variable `HealthChecksUI__Webhooks__0__Uri`. See [here](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks#webhooks-and-failure-notifications) for more information about the structure of the Payload and RestorePayload configuration options.

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -27,6 +27,7 @@ namespace Pims.Api
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
             .UseContentRoot(Directory.GetCurrentDirectory())
+            .UseUrls("http://*:8080")
             .UseStartup<Startup>();
     }
 }

--- a/backend/api/Startup.cs
+++ b/backend/api/Startup.cs
@@ -173,12 +173,12 @@ namespace Pims.Api
 
             app.UseAuthentication();
             app.UseAuthorization();
-            app.UseHealthChecks("/api/live", new HealthCheckOptions
+            app.UseHealthChecks("/api/live", 8080, new HealthCheckOptions
             {
                 Predicate = r => r.Name.Contains("liveliness"),
                 ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
             });
-            app.UseHealthChecks("/api/ready", new HealthCheckOptions
+            app.UseHealthChecks("/api/ready", 8080, new HealthCheckOptions
             {
                 Predicate = r => r.Tags.Contains("services"),
                 ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
@@ -186,7 +186,18 @@ namespace Pims.Api
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
-                endpoints.MapHealthChecksUI();
+                endpoints.MapHealthChecksUI(
+                    setup =>
+                    {
+                        setup.UIPath = "/api/healthchecks-ui"; // this is ui path in your browser
+                        setup.ApiPath = "/api";
+                        setup.ResourcesPath = "/api/ui/resources";
+                        setup.WebhookPath = "/api/hooks";
+                        setup.UseRelativeResourcesPath = false;
+                        setup.UseRelativeApiPath = false;
+                        setup.UseRelativeWebhookPath = false;
+                    }
+                );
             });
         }
 

--- a/backend/api/appsettings.json
+++ b/backend/api/appsettings.json
@@ -3,11 +3,11 @@
     "HealthChecks": [
       {
         "Name": "liveliness",
-        "Uri": "http://localhost/api/live"
+        "Uri": "http://localhost:8080/api/live"
       },
       {
         "Name": "readiness",
-        "Uri": "http://localhost/api/ready"
+        "Uri": "http://localhost:8080/api/ready"
       }
     ],
     "Webhooks": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,8 @@ services:
       context: backend
     env_file: backend/api/.env
     ports:
-      - "5000:80"
       - "5001:443"
+      - "5000:8080"
     depends_on:
       - database
       - keycloak

--- a/openshift/templates/secrets/README.md
+++ b/openshift/templates/secrets/README.md
@@ -58,7 +58,7 @@ oc process -f api-sso-secrets.yaml \
 oc project $namespace_dev
 oc process -f api-health-secrets.yaml \
   -p ENV_NAME=dev \
-  -p KEYCLOAK_AUTHORITY=[health-dev realm URL] \
+  -p ROCKETCHAT_HEALTH_HOOK_URI=[health-dev webhook URL] \
   | oc create -f -
 
 oc project $namespace_test
@@ -70,7 +70,7 @@ oc process -f api-sso-secrets.yaml \
 oc project $namespace_test
 oc process -f api-health-secrets.yaml \
   -p ENV_NAME=test \
-  -p KEYCLOAK_AUTHORITY=[health-test realm URL] \
+  -p ROCKETCHAT_HEALTH_HOOK_URI=[health-test webhook URL] \
   | oc create -f -
 
 oc project $namespace_prod
@@ -82,7 +82,7 @@ oc process -f api-sso-secrets.yaml \
 oc project $namespace_prod
 oc process -f api-health-secrets.yaml \
   -p ENV_NAME=prod \
-  -p KEYCLOAK_AUTHORITY=[health-production realm URL] \
+  -p ROCKETCHAT_HEALTH_HOOK_URI=[health-production webhook URL] \
   | oc create -f -
 ```
 


### PR DESCRIPTION
Update healthchecksui config to match.

Note: This change forces the api to run on port 8080. This already appears to be the case when the api is running on openshift, so it shouldn't change anything there. Let me know if there are concerns - in theory we could just override the appsettings using an openshift configmap, then my change to 8080 wouldn't be necessary.