### PR TITLE
PIMS-1226, PIMS-1227, PIMS-1228, PIMS-1229, PIMS-1230

### DIFF
--- a/backend/Pims.sln
+++ b/backend/Pims.sln
@@ -9,13 +9,38 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pims.Api.Test", "test\Pims.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pims.Dal", "dal\Pims.Dal.csproj", "{6DFFF5E1-1B87-403B-99D0-A9E03D8A8EB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pims.Dal.Entities", "entities\Pims.Dal.Entities.csproj", "{1C724CD5-CD24-46CD-835A-A83F673F97B5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pims.Dal.Entities", "entities\Pims.Dal.Entities.csproj", "{1C724CD5-CD24-46CD-835A-A83F673F97B5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pims.Keycloak", "keycloak\Pims.Keycloak.csproj", "{970903E9-BC53-436F-BA77-C62349546425}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pims.Keycloak", "keycloak\Pims.Keycloak.csproj", "{970903E9-BC53-436F-BA77-C62349546425}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pims.Core", "core\Pims.Core.csproj", "{768D5D0A-A3B7-4599-B5CF-E32FC407AD9A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pims.Core", "core\Pims.Core.csproj", "{768D5D0A-A3B7-4599-B5CF-E32FC407AD9A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pims.Dal.Keycloak", "dal.keycloak\Pims.Dal.Keycloak.csproj", "{5697DD19-62CC-4377-ABA8-1E192376F4F6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pims.Dal.Keycloak", "dal.keycloak\Pims.Dal.Keycloak.csproj", "{5697DD19-62CC-4377-ABA8-1E192376F4F6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{8D3E4CB2-41D6-4AA6-B9E4-CFCAB0E2F5BC}"
+	ProjectSection(SolutionItems) = preProject
+		.dockerignore = .dockerignore
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		Dockerfile = Dockerfile
+		Dockerfile.bak = Dockerfile.bak
+		entrypoint.sh = entrypoint.sh
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libraries", "libraries", "{5237F8A4-67F5-4751-B8B2-B93A06791480}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{A0343C94-486E-4A06-9A64-0584D20A4728}"
+	ProjectSection(SolutionItems) = preProject
+		docs\API.md = docs\API.md
+		docs\DAL.md = docs\DAL.md
+		docs\DATABASE.md = docs\DATABASE.md
+		docs\SETUP.md = docs\SETUP.md
+		docs\TOOLS.md = docs\TOOLS.md
+		docs\VERSIONING.md = docs\VERSIONING.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F256F2A5-0DBF-4137-A7D6-21F08111BD4A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -114,6 +139,14 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{19A6829C-20D8-4F66-9889-55C553ACE2B2} = {F256F2A5-0DBF-4137-A7D6-21F08111BD4A}
+		{6DFFF5E1-1B87-403B-99D0-A9E03D8A8EB3} = {5237F8A4-67F5-4751-B8B2-B93A06791480}
+		{1C724CD5-CD24-46CD-835A-A83F673F97B5} = {5237F8A4-67F5-4751-B8B2-B93A06791480}
+		{970903E9-BC53-436F-BA77-C62349546425} = {5237F8A4-67F5-4751-B8B2-B93A06791480}
+		{768D5D0A-A3B7-4599-B5CF-E32FC407AD9A} = {5237F8A4-67F5-4751-B8B2-B93A06791480}
+		{5697DD19-62CC-4377-ABA8-1E192376F4F6} = {5237F8A4-67F5-4751-B8B2-B93A06791480}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3433C5DD-DC49-4A96-A1AE-90C1A1EBA87C}

--- a/backend/api/Areas/Admin/Models/Parcel/AddressModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/AddressModel.cs
@@ -1,10 +1,8 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Model = Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
 {
-    public class AddressModel : Model.BaseModel, IEquatable<AddressModel>
+    public class AddressModel : Model.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -22,32 +20,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         public string Province { get; set; }
 
         public string Postal { get; set; }
-        #endregion
-
-        #region Methods
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AddressModel);
-        }
-
-        public bool Equals([AllowNull] AddressModel other)
-        {
-            return other != null &&
-                   Id == other.Id &&
-                   Line1 == other.Line1 &&
-                   Line2 == other.Line2 &&
-                   CityId == other.CityId &&
-                   City == other.City &&
-                   ProvinceId == other.ProvinceId &&
-                   Province == other.Province &&
-                   Postal == other.Postal;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Line1, Line2, CityId, City, ProvinceId, Province, Postal);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/AgencyModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/AgencyModel.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
@@ -7,7 +5,7 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
     /// <summary>
     /// AgencyModel class, provides a model that represents the agency.
     /// </summary>
-    public class AgencyModel : BaseModel, IEquatable<AgencyModel>
+    public class AgencyModel : BaseModel
     {
         #region Properties
         /// <summary>
@@ -39,28 +37,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         /// </summary>
         /// <value></value>
         public int? ParentId { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AgencyModel);
-        }
-
-        public bool Equals([AllowNull] AgencyModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Code == other.Code &&
-                   Description == other.Description &&
-                   ParentId == other.ParentId;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Code, Description, ParentId);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/BuildingEvaluationModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/BuildingEvaluationModel.cs
@@ -1,10 +1,8 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Model = Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
 {
-    public class BuildingEvaluationModel : Model.BaseModel, IEquatable<BuildingEvaluationModel>
+    public class BuildingEvaluationModel : Model.BaseModel
     {
         #region Properties
         public int BuildingId { get; set; }
@@ -18,38 +16,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         public float AssessedValue { get; set; }
 
         public float NetBookValue { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BuildingEvaluationModel);
-        }
-
-        public bool Equals([AllowNull] BuildingEvaluationModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                BuildingId == other.BuildingId &&
-                FiscalYear == other.FiscalYear &&
-                EstimatedValue == other.EstimatedValue &&
-                AppraisedValue == other.AppraisedValue &&
-                AssessedValue == other.AssessedValue &&
-                NetBookValue == other.NetBookValue;
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(BuildingId);
-            hash.Add(FiscalYear);
-            hash.Add(EstimatedValue);
-            hash.Add(AppraisedValue);
-            hash.Add(AssessedValue);
-            hash.Add(NetBookValue);
-            return hash.ToHashCode();
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/BuildingModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/BuildingModel.cs
@@ -1,12 +1,9 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Model = Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
 {
-    public class BuildingModel : Model.BaseModel, IEquatable<BuildingModel>
+    public class BuildingModel : Model.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -38,54 +35,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         public float RentableArea { get; set; }
 
         public IEnumerable<BuildingEvaluationModel> Evaluations { get; set; } = new List<BuildingEvaluationModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BuildingModel);
-        }
-
-        public bool Equals([AllowNull] BuildingModel other)
-        {
-            return other != null &&
-                Id == other.Id &&
-                ParcelId == other.ParcelId &&
-                LocalId == other.LocalId &&
-                Description == other.Description &&
-                EqualityComparer<AddressModel>.Default.Equals(Address, other.Address) &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                BuildingConstructionTypeId == other.BuildingConstructionTypeId &&
-                BuildingConstructionType == other.BuildingConstructionType &&
-                BuildingFloorCount == other.BuildingFloorCount &&
-                BuildingPredominateUseId == other.BuildingPredominateUseId &&
-                BuildingPredominateUse == other.BuildingPredominateUse &&
-                BuildingTenancy == other.BuildingTenancy &&
-                RentableArea == other.RentableArea &&
-                Enumerable.SequenceEqual(Evaluations, other.Evaluations);
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Id);
-            hash.Add(ParcelId);
-            hash.Add(LocalId);
-            hash.Add(Description);
-            hash.Add(Address);
-            hash.Add(Latitude);
-            hash.Add(Longitude);
-            hash.Add(BuildingConstructionTypeId);
-            hash.Add(BuildingConstructionType);
-            hash.Add(BuildingFloorCount);
-            hash.Add(BuildingPredominateUseId);
-            hash.Add(BuildingPredominateUse);
-            hash.Add(BuildingTenancy);
-            hash.Add(RentableArea);
-            hash.Add(Evaluations);
-            return hash.ToHashCode();
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/CodeLookupModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/CodeLookupModel.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
@@ -7,7 +5,7 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
     /// <summary>
     /// LookupCodeModel class, provides a model that represents look up objects.
     /// </summary>
-    public class LookupCodeModel : BaseModel, IEquatable<LookupCodeModel>
+    public class LookupCodeModel : BaseModel
     {
         #region Properties
         /// <summary>
@@ -27,26 +25,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as LookupCodeModel);
-        }
-
-        public bool Equals([AllowNull] LookupCodeModel other)
-        {
-            return other != null &&
-                   Name == other.Name &&
-                   Code == other.Code &&
-                   Description == other.Description;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Name, Code, Description);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/ParcelBuildingModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/ParcelBuildingModel.cs
@@ -1,12 +1,9 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Model = Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
 {
-    public class ParcelBuildingModel : Model.BaseModel, IEquatable<ParcelBuildingModel>
+    public class ParcelBuildingModel : Model.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -42,56 +39,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         public bool IsSensitive { get; set; }
 
         public IEnumerable<BuildingEvaluationModel> Evaluations { get; set; } = new List<BuildingEvaluationModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelBuildingModel);
-        }
-
-        public bool Equals([AllowNull] ParcelBuildingModel other)
-        {
-            return other != null &&
-                Id == other.Id &&
-                LocalId == other.LocalId &&
-                ParcelId == other.ParcelId &&
-                AgencyId == other.AgencyId &&
-                Description == other.Description &&
-                EqualityComparer<AddressModel>.Default.Equals(Address, other.Address) &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                BuildingConstructionTypeId == other.BuildingConstructionTypeId &&
-                BuildingConstructionType == other.BuildingConstructionType &&
-                BuildingFloorCount == other.BuildingFloorCount &&
-                BuildingPredominateUseId == other.BuildingPredominateUseId &&
-                BuildingPredominateUse == other.BuildingPredominateUse &&
-                BuildingTenancy == other.BuildingTenancy &&
-                RentableArea == other.RentableArea &&
-                Enumerable.SequenceEqual(Evaluations, other.Evaluations);
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Id);
-            hash.Add(LocalId);
-            hash.Add(ParcelId);
-            hash.Add(AgencyId);
-            hash.Add(Description);
-            hash.Add(Address);
-            hash.Add(Latitude);
-            hash.Add(Longitude);
-            hash.Add(BuildingConstructionTypeId);
-            hash.Add(BuildingConstructionType);
-            hash.Add(BuildingFloorCount);
-            hash.Add(BuildingPredominateUseId);
-            hash.Add(BuildingPredominateUse);
-            hash.Add(BuildingTenancy);
-            hash.Add(RentableArea);
-            hash.Add(Evaluations);
-            return hash.ToHashCode();
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/ParcelEvaluationModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/ParcelEvaluationModel.cs
@@ -1,10 +1,8 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Model = Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
 {
-    public class ParcelEvaluationModel : Model.BaseModel, IEquatable<ParcelEvaluationModel>
+    public class ParcelEvaluationModel : Model.BaseModel
     {
         #region Properties
         public int ParcelId { get; set; }
@@ -18,39 +16,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         public float AssessedValue { get; set; }
 
         public float NetBookValue { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelEvaluationModel);
-        }
-
-        public bool Equals([AllowNull] ParcelEvaluationModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                ParcelId == other.ParcelId &&
-                FiscalYear == other.FiscalYear &&
-                EstimatedValue == other.EstimatedValue &&
-                AppraisedValue == other.AppraisedValue &&
-                AssessedValue == other.AssessedValue &&
-                NetBookValue == other.NetBookValue;
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(ParcelId);
-            hash.Add(FiscalYear);
-            hash.Add(EstimatedValue);
-            hash.Add(AppraisedValue);
-            hash.Add(AssessedValue);
-            hash.Add(NetBookValue);
-            return hash.ToHashCode();
-        }
-
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/ParcelModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/ParcelModel.cs
@@ -1,12 +1,9 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Model = Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
 {
-    public class ParcelModel : Model.BaseModel, IEquatable<ParcelModel>
+    public class ParcelModel : Model.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -45,63 +42,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
 
         public IEnumerable<ParcelEvaluationModel> Evaluations { get; set; } = new List<ParcelEvaluationModel>();
         public IEnumerable<ParcelBuildingModel> Buildings { get; set; } = new List<ParcelBuildingModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelModel);
-        }
-
-        public bool Equals([AllowNull] ParcelModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                Id == other.Id &&
-                PID == other.PID &&
-                PIN == other.PIN &&
-                StatusId == other.StatusId &&
-                Status == other.Status &&
-                ClassificationId == other.ClassificationId &&
-                Classification == other.Classification &&
-                AgencyId == other.AgencyId &&
-                SubAgency == other.SubAgency &&
-                Agency == other.Agency &&
-                EqualityComparer<AddressModel>.Default.Equals(Address, other.Address) &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                LandArea == other.LandArea &&
-                Description == other.Description &&
-                LandLegalDescription == other.LandLegalDescription &&
-                Enumerable.SequenceEqual(Buildings, other.Buildings) &&
-                Enumerable.SequenceEqual(Evaluations, other.Evaluations);
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(Id);
-            hash.Add(PID);
-            hash.Add(PIN);
-            hash.Add(StatusId);
-            hash.Add(Status);
-            hash.Add(ClassificationId);
-            hash.Add(Classification);
-            hash.Add(AgencyId);
-            hash.Add(SubAgency);
-            hash.Add(Agency);
-            hash.Add(Address);
-            hash.Add(Latitude);
-            hash.Add(Longitude);
-            hash.Add(LandArea);
-            hash.Add(Description);
-            hash.Add(LandLegalDescription);
-            hash.Add(Buildings);
-            hash.Add(Evaluations);
-            return hash.ToHashCode();
-        }
-
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/PartialBuildingModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/PartialBuildingModel.cs
@@ -1,10 +1,8 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Model = Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
 {
-    public class PartialBuildingModel : Model.BaseModel, IEquatable<PartialBuildingModel>
+    public class PartialBuildingModel : Model.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -16,28 +14,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         public double Latitude { get; set; }
 
         public double Longitude { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as PartialBuildingModel);
-        }
-
-        public bool Equals([AllowNull] PartialBuildingModel other)
-        {
-            return other != null &&
-                   Id == other.Id &&
-                   LocalId == other.LocalId &&
-                   Description == other.Description &&
-                   Latitude == other.Latitude &&
-                   Longitude == other.Longitude;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, LocalId, Description, Latitude, Longitude);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/Parcel/PartialParcelModel.cs
+++ b/backend/api/Areas/Admin/Models/Parcel/PartialParcelModel.cs
@@ -1,10 +1,8 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Model = Pims.Api.Models;
 
 namespace Pims.Api.Areas.Admin.Models.Parcel
 {
-    public class PartialParcelModel : Model.BaseModel, IEquatable<PartialParcelModel>
+    public class PartialParcelModel : Model.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -22,31 +20,6 @@ namespace Pims.Api.Areas.Admin.Models.Parcel
         public double Longitude { get; set; }
 
         public string Description { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as PartialParcelModel);
-        }
-
-        public bool Equals([AllowNull] PartialParcelModel other)
-        {
-            return other != null &&
-                Id == other.Id &&
-                PID == other.PID &&
-                PIN == other.PIN &&
-                StatusId == other.StatusId &&
-                ClassificationId == other.ClassificationId &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                Description == other.Description;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, PID, PIN, StatusId, ClassificationId, Latitude, Longitude, Description);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/User/AccessRequestRoleModel.cs
+++ b/backend/api/Areas/Admin/Models/User/AccessRequestRoleModel.cs
@@ -1,39 +1,15 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Admin.Models.User
 {
     /// <summary>
     /// AccessRequestRoleModel class, provides a model that represents a role attached to an access request.
     /// </summary>
-    public class AccessRequestRoleModel : Pims.Api.Models.CodeModel, IEquatable<AccessRequestRoleModel>
+    public class AccessRequestRoleModel : Pims.Api.Models.CodeModel
     {
         #region Properties
         public string Description { get; set; }
         public ICollection<UserModel> Users { get; } = new List<UserModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AccessRequestRoleModel);
-        }
-
-        public bool Equals([AllowNull] AccessRequestRoleModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Description == other.Description &&
-                   IsDisabled == other.IsDisabled &&
-                   EqualityComparer<ICollection<UserModel>>.Default.Equals(Users, other.Users);
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Description, IsDisabled, Users);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/User/AccessRequestUserModel.cs
+++ b/backend/api/Areas/Admin/Models/User/AccessRequestUserModel.cs
@@ -1,13 +1,11 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Admin.Models.User
 {
     /// <summary>
     /// AccessRequestUserModel class, provides a model that represents a user attached to an access request.
     /// </summary>
-    public class AccessRequestUserModel : Pims.Api.Models.BaseModel, IEquatable<AccessRequestUserModel>
+    public class AccessRequestUserModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         /// <summary>
@@ -45,29 +43,6 @@ namespace Pims.Api.Areas.Admin.Models.User
         /// </summary>
         /// <value></value>
         public string Email { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AccessRequestUserModel);
-        }
-
-        public bool Equals([AllowNull] AccessRequestUserModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   DisplayName == other.DisplayName &&
-                   FirstName == other.FirstName &&
-                   MiddleName == other.MiddleName &&
-                   LastName == other.LastName &&
-                   Email == other.Email;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, DisplayName, FirstName, MiddleName, LastName, Email);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/User/AgencyModel.cs
+++ b/backend/api/Areas/Admin/Models/User/AgencyModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Admin.Models.User
 {
     /// <summary>
     /// AgencyModel class, provides a model that represents the agency.
     /// </summary>
-    public class AgencyModel : Pims.Api.Models.BaseModel, IEquatable<AgencyModel>
+    public class AgencyModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         /// <summary>
@@ -38,28 +35,6 @@ namespace Pims.Api.Areas.Admin.Models.User
         /// </summary>
         /// <value></value>
         public int? ParentId { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AgencyModel);
-        }
-
-        public bool Equals([AllowNull] AgencyModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Code == other.Code &&
-                   Description == other.Description &&
-                   ParentId == other.ParentId;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Code, Description, ParentId);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/User/UserModel.cs
+++ b/backend/api/Areas/Admin/Models/User/UserModel.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Admin.Models.User
 {
     /// <summary>
     /// UserModel class, provides a model that represents a user.
     /// </summary>
-    public class UserModel : Pims.Api.Models.BaseModel, IEquatable<UserModel>
+    public class UserModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         /// <summary>
@@ -76,32 +75,6 @@ namespace Pims.Api.Areas.Admin.Models.User
         /// get/set - An array of roles the user is a member of.
         /// </summary>
         public IEnumerable<RoleModel> Roles { get; set; } = new List<RoleModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as UserModel);
-        }
-
-        public bool Equals([AllowNull] UserModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Username == other.Username &&
-                   Position == other.Position &&
-                   DisplayName == other.DisplayName &&
-                   FirstName == other.FirstName &&
-                   MiddleName == other.MiddleName &&
-                   LastName == other.LastName &&
-                   Email == other.Email &&
-                   Note == other.Note;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Username, Position, DisplayName, FirstName, MiddleName, LastName, Email);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Profiles/User/AccessRequestProfile.cs
+++ b/backend/api/Areas/Admin/Profiles/User/AccessRequestProfile.cs
@@ -25,6 +25,7 @@ namespace Pims.Api.Areas.Admin.Profiles.User
                 .ForMember(dest => dest.AccessRequestId, opt => opt.Ignore())
                 .ForMember(dest => dest.Agency, opt => opt.Ignore())
                 .ForMember(dest => dest.AgencyId, opt => opt.MapFrom(src => src.Id));
+
             CreateMap<Model.AccessRequestRoleModel, Entity.AccessRequestRole>()
                 .ForMember(dest => dest.AccessRequest, opt => opt.Ignore())
                 .ForMember(dest => dest.AccessRequestId, opt => opt.Ignore())

--- a/backend/api/Areas/Keycloak/Models/Role/RoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/Role/RoleModel.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Keycloak.Models.Role
 {
     /// <summary>
     /// RoleModel class, provides a model that represents a role.
     /// </summary>
-    public class RoleModel : Pims.Api.Models.BaseModel, IEquatable<RoleModel>
+    public class RoleModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         /// <summary>
@@ -26,26 +25,6 @@ namespace Pims.Api.Areas.Keycloak.Models.Role
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as RoleModel);
-        }
-
-        public bool Equals([AllowNull] RoleModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Description == other.Description;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Description);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/Role/Update/BaseModel.cs
+++ b/backend/api/Areas/Keycloak/Models/Role/Update/BaseModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Keycloak.Models.Role.Update
 {
     /// <summary>
     /// BaseModel class, provides a model that represents the base properties of an update model.
     /// </summary>
-    public abstract class BaseModel : IEquatable<BaseModel>
+    public abstract class BaseModel
     {
         #region Properties
         /// <summary>
@@ -14,24 +11,6 @@ namespace Pims.Api.Areas.Keycloak.Models.Role.Update
         /// </summary>
         /// <value></value>
         public string RowVersion { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BaseModel);
-        }
-
-        public bool Equals([AllowNull] BaseModel other)
-        {
-            return other != null &&
-                   RowVersion == other.RowVersion;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(RowVersion);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/Role/Update/RoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/Role/Update/RoleModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Keycloak.Models.Role.Update
 {
     /// <summary>
     /// RoleModel class, provides a model that represents a role.
     /// </summary>
-    public class RoleModel : BaseModel, IEquatable<RoleModel>
+    public class RoleModel : BaseModel
     {
         #region Properties
         /// <summary>
@@ -20,25 +17,6 @@ namespace Pims.Api.Areas.Keycloak.Models.Role.Update
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as RoleModel);
-        }
-
-        public bool Equals([AllowNull] RoleModel other)
-        {
-            return other != null &&
-                   Name == other.Name &&
-                   Description == other.Description;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Name, Description);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/AccessRequestRoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/AccessRequestRoleModel.cs
@@ -1,34 +1,15 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Keycloak.Models.User
 {
     /// <summary>
     /// AccessRequestRoleModel class, provides a model that represents a role attached to an access request.
     /// </summary>
-    public class AccessRequestRoleModel : Pims.Api.Models.CodeModel, IEquatable<RoleModel>
+    public class AccessRequestRoleModel : Pims.Api.Models.CodeModel
     {
+        #region Properties
         public string Description { get; set; }
         public ICollection<UserModel> Users { get; } = new List<UserModel>();
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as RoleModel);
-        }
-
-        public bool Equals([AllowNull] RoleModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Description == other.Description &&
-                   IsDisabled == other.IsDisabled;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Description, IsDisabled, Users);
-        }
+        #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/AccessRequestUserModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/AccessRequestUserModel.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Keycloak.Models.User
 {
     /// <summary>
     /// AccessRequestUserModel class, provides a model that represents a user attached to an access request.
     /// </summary>
-    public class AccessRequestUserModel : Pims.Api.Models.BaseModel, IEquatable<AccessRequestUserModel>
+    public class AccessRequestUserModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         /// <summary>
@@ -44,29 +43,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User
         /// </summary>
         /// <value></value>
         public string Email { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AccessRequestUserModel);
-        }
-
-        public bool Equals([AllowNull] AccessRequestUserModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   DisplayName == other.DisplayName &&
-                   FirstName == other.FirstName &&
-                   MiddleName == other.MiddleName &&
-                   LastName == other.LastName &&
-                   Email == other.Email;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, DisplayName, FirstName, MiddleName, LastName, Email);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/AgencyModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/AgencyModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Keycloak.Models.User
 {
     /// <summary>
     /// AgencyModel class, provides a model to represent the agency.
     /// </summary>
-    public class AgencyModel : Pims.Api.Models.BaseModel, IEquatable<AgencyModel>
+    public class AgencyModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         /// <summary>
@@ -38,28 +35,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User
         /// </summary>
         /// <value></value>
         public int? ParentId { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AgencyModel);
-        }
-
-        public bool Equals([AllowNull] AgencyModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Description == other.Description &&
-                   Code == other.Code &&
-                   ParentId == other.ParentId;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Description, Code, ParentId);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/RoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/RoleModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Keycloak.Models.User
 {
     /// <summary>
     /// RoleModel class, provides a model that represents a role.
     /// </summary>
-    public class RoleModel : Pims.Api.Models.CodeModel, IEquatable<RoleModel>
+    public class RoleModel : Pims.Api.Models.CodeModel
     {
         #region Properties
         /// <summary>
@@ -14,26 +11,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as RoleModel);
-        }
-
-        public bool Equals([AllowNull] RoleModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Description == other.Description;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Description);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/Update/BaseModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/Update/BaseModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Keycloak.Models.User.Update
 {
     /// <summary>
     /// BaseModel class, provides a model that represents the base properties of an update model.
     /// </summary>
-    public abstract class BaseModel : IEquatable<BaseModel>
+    public abstract class BaseModel
     {
         #region Properties
         /// <summary>
@@ -14,24 +11,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User.Update
         /// </summary>
         /// <value></value>
         public string RowVersion { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BaseModel);
-        }
-
-        public bool Equals([AllowNull] BaseModel other)
-        {
-            return other != null &&
-                   RowVersion == other.RowVersion;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(RowVersion);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/Update/RoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/Update/RoleModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Keycloak.Models.User.Update
 {
     /// <summary>
     /// RoleModel class, provides a model that represents a role.
     /// </summary>
-    public class RoleModel : BaseModel, IEquatable<RoleModel>
+    public class RoleModel : BaseModel
     {
         #region Properties
         /// <summary>
@@ -20,25 +17,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User.Update
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as RoleModel);
-        }
-
-        public bool Equals([AllowNull] RoleModel other)
-        {
-            return other != null &&
-                   Name == other.Name &&
-                   Description == other.Description;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Name, Description);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/Update/UserAgencyModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/Update/UserAgencyModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Keycloak.Models.User.Update
 {
     /// <summary>
     /// UserAgencyModel class, provides a model to represent a user agency.
     /// </summary>
-    public class UserAgencyModel : IEquatable<UserAgencyModel>
+    public class UserAgencyModel
     {
         #region Properties
         /// <summary>
@@ -20,25 +17,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User.Update
         /// </summary>
         /// <value></value>
         public string Name { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as UserAgencyModel);
-        }
-
-        public bool Equals([AllowNull] UserAgencyModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/Update/UserModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/Update/UserModel.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Keycloak.Models.User.Update
 {
     /// <summary>
     /// UserModel class, provides a model that represents a user.
     /// </summary>
-    public class UserModel : BaseModel, IEquatable<UserModel>
+    public class UserModel : BaseModel
     {
         #region Properties
         /// <summary>
@@ -87,31 +86,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User.Update
         /// </summary>
         /// <returns></returns>
         public IEnumerable<UserRoleModel> Roles { get; set; } = new List<UserRoleModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as UserModel);
-        }
-
-        public bool Equals([AllowNull] UserModel other)
-        {
-            return other != null &&
-                   Username == other.Username &&
-                   Position == other.Position &&
-                   DisplayName == other.DisplayName &&
-                   FirstName == other.FirstName &&
-                   MiddleName == other.MiddleName &&
-                   LastName == other.LastName &&
-                   Note == other.Note &&
-                   Email == other.Email;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Username, Position, DisplayName, FirstName, MiddleName, LastName, Email, Note);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/Update/UserRoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/Update/UserRoleModel.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Keycloak.Models.User.Update
 {
     /// <summary>
     /// UserRoleModel class, provides a model that represents a user role model.
     /// </summary>
-    public class UserRoleModel : IEquatable<UserRoleModel>
+    public class UserRoleModel
     {
         #region Properties
         /// <summary>
@@ -20,25 +19,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User.Update
         /// </summary>
         /// <value></value>
         public string Name { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as UserRoleModel);
-        }
-
-        public bool Equals([AllowNull] UserRoleModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/UserModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/UserModel.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Areas.Keycloak.Models.User
 {
     /// <summary>
     /// UserModel class, provides a model to represent a user.
     /// </summary>
-    public class UserModel : Pims.Api.Models.BaseModel, IEquatable<UserModel>
+    public class UserModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         /// <summary>
@@ -87,31 +86,6 @@ namespace Pims.Api.Areas.Keycloak.Models.User
         /// </summary>
         /// <returns></returns>
         public IEnumerable<RoleModel> Roles { get; set; } = new List<RoleModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as UserModel);
-        }
-
-        public bool Equals([AllowNull] UserModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Username == other.Username &&
-                   Position == other.Position &&
-                   DisplayName == other.DisplayName &&
-                   FirstName == other.FirstName &&
-                   MiddleName == other.MiddleName &&
-                   LastName == other.LastName &&
-                   Email == other.Email;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Username, Position, DisplayName, FirstName, MiddleName, LastName, Email);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Profiles/Role/BaseProfile.cs
+++ b/backend/api/Areas/Keycloak/Profiles/Role/BaseProfile.cs
@@ -14,7 +14,7 @@ namespace Pims.Api.Areas.Keycloak.Profiles.Role
         public BaseProfile()
         {
             CreateMap<Entity.BaseEntity, Model.Update.BaseModel>()
-                .ForMember(dest => dest.RowVersion, opt => opt.MapFrom(src => Convert.ToBase64String(src.RowVersion)));
+                .ForMember(dest => dest.RowVersion, opt => opt.MapFrom(src => src.RowVersion.Length == 0 ? null : Convert.ToBase64String(src.RowVersion)));
 
             CreateMap<Model.Update.BaseModel, Entity.BaseEntity>()
                 .AfterMap((source, dest) =>

--- a/backend/api/Areas/Keycloak/Profiles/Role/UpdateRoleProfile.cs
+++ b/backend/api/Areas/Keycloak/Profiles/Role/UpdateRoleProfile.cs
@@ -14,9 +14,13 @@ namespace Pims.Api.Areas.Keycloak.Profiles.Role
         public UpdateRoleProfile()
         {
             CreateMap<Entity.Role, Model.Update.RoleModel>()
+                .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
+                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
                 .IncludeBase<Entity.BaseEntity, Model.Update.BaseModel>();
             
             CreateMap<Model.Update.RoleModel, Entity.Role>()
+                .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
+                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
                 .IncludeBase<Model.Update.BaseModel, Entity.BaseEntity>();
 
             CreateMap<Model.Update.RoleModel, KModel.RoleModel>();

--- a/backend/api/Areas/Keycloak/Profiles/User/AccessRequestProfile.cs
+++ b/backend/api/Areas/Keycloak/Profiles/User/AccessRequestProfile.cs
@@ -1,6 +1,6 @@
 using AutoMapper;
 using Entity = Pims.Dal.Entities;
-using Model = Pims.Api.Models.User;
+using Model = Pims.Api.Areas.Keycloak.Models.User;
 using System.Linq;
 using System;
 
@@ -27,7 +27,8 @@ namespace Pims.Api.Areas.Keycloak.Profiles.User
                 .ForMember(dest => dest.AccessRequest, opt => opt.Ignore())
                 .ForMember(dest => dest.AccessRequestId, opt => opt.Ignore())
                 .ForMember(dest => dest.Agency, opt => opt.Ignore())
-                .ForMember(dest => dest.AgencyId, opt => opt.MapFrom(src => Int32.Parse(src.Id)));
+                .ForMember(dest => dest.AgencyId, opt => opt.MapFrom(src => src.Id));
+
             CreateMap<Model.AccessRequestRoleModel, Entity.AccessRequestRole>()
                 .ForMember(dest => dest.AccessRequest, opt => opt.Ignore())
                 .ForMember(dest => dest.AccessRequestId, opt => opt.Ignore())

--- a/backend/api/Areas/Tools/Models/Import/AddressModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/AddressModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Tools.Models.Import
 {
-    public class AddressModel : Pims.Api.Models.BaseModel, IEquatable<AddressModel>
+    public class AddressModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -21,31 +18,6 @@ namespace Pims.Api.Areas.Tools.Models.Import
         public string Province { get; set; }
 
         public string Postal { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AddressModel);
-        }
-
-        public bool Equals([AllowNull] AddressModel other)
-        {
-            return other != null &&
-                   Id == other.Id &&
-                   Line1 == other.Line1 &&
-                   Line2 == other.Line2 &&
-                   CityId == other.CityId &&
-                   City == other.City &&
-                   ProvinceId == other.ProvinceId &&
-                   Province == other.Province &&
-                   Postal == other.Postal;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Line1, Line2, CityId, City, ProvinceId, Province, Postal);
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Tools/Models/Import/BuildingEvaluationModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/BuildingEvaluationModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Tools.Models.Import
 {
-    public class BuildingEvaluationModel : Pims.Api.Models.BaseModel, IEquatable<BuildingEvaluationModel>
+    public class BuildingEvaluationModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         public int PropertyId { get; set; }
@@ -17,38 +14,6 @@ namespace Pims.Api.Areas.Tools.Models.Import
         public float AssessedValue { get; set; }
 
         public float NetBookValue { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BuildingEvaluationModel);
-        }
-
-        public bool Equals([AllowNull] BuildingEvaluationModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                PropertyId == other.PropertyId &&
-                FiscalYear == other.FiscalYear &&
-                EstimatedValue == other.EstimatedValue &&
-                AppraisedValue == other.AppraisedValue &&
-                AssessedValue == other.AssessedValue &&
-                NetBookValue == other.NetBookValue;
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(PropertyId);
-            hash.Add(FiscalYear);
-            hash.Add(EstimatedValue);
-            hash.Add(AppraisedValue);
-            hash.Add(AssessedValue);
-            hash.Add(NetBookValue);
-            return hash.ToHashCode();
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Tools/Models/Import/ParcelBuildingModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/ParcelBuildingModel.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Pims.Api.Areas.Tools.Models.Import
 {
-    public class ParcelBuildingModel : Pims.Api.Models.BaseModel, IEquatable<ParcelBuildingModel>
+    public class ParcelBuildingModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -41,56 +38,6 @@ namespace Pims.Api.Areas.Tools.Models.Import
         public bool IsSensitive { get; set; }
 
         public IEnumerable<BuildingEvaluationModel> Evaluations { get; set; } = new List<BuildingEvaluationModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelBuildingModel);
-        }
-
-        public bool Equals([AllowNull] ParcelBuildingModel other)
-        {
-            return other != null &&
-                Id == other.Id &&
-                LocalId == other.LocalId &&
-                ParcelId == other.ParcelId &&
-                AgencyId == other.AgencyId &&
-                Description == other.Description &&
-                EqualityComparer<AddressModel>.Default.Equals(Address, other.Address) &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                BuildingConstructionTypeId == other.BuildingConstructionTypeId &&
-                BuildingConstructionType == other.BuildingConstructionType &&
-                BuildingFloorCount == other.BuildingFloorCount &&
-                BuildingPredominateUseId == other.BuildingPredominateUseId &&
-                BuildingPredominateUse == other.BuildingPredominateUse &&
-                BuildingTenancy == other.BuildingTenancy &&
-                RentableArea == other.RentableArea &&
-                Enumerable.SequenceEqual(Evaluations, other.Evaluations);
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Id);
-            hash.Add(LocalId);
-            hash.Add(ParcelId);
-            hash.Add(AgencyId);
-            hash.Add(Description);
-            hash.Add(Address);
-            hash.Add(Latitude);
-            hash.Add(Longitude);
-            hash.Add(BuildingConstructionTypeId);
-            hash.Add(BuildingConstructionType);
-            hash.Add(BuildingFloorCount);
-            hash.Add(BuildingPredominateUseId);
-            hash.Add(BuildingPredominateUse);
-            hash.Add(BuildingTenancy);
-            hash.Add(RentableArea);
-            hash.Add(Evaluations);
-            return hash.ToHashCode();
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Tools/Models/Import/ParcelEvaluationModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/ParcelEvaluationModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Areas.Tools.Models.Import
 {
-    public class ParcelEvaluationModel : Pims.Api.Models.BaseModel, IEquatable<ParcelEvaluationModel>
+    public class ParcelEvaluationModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         public int PropertyId { get; set; }
@@ -17,38 +14,6 @@ namespace Pims.Api.Areas.Tools.Models.Import
         public float AssessedValue { get; set; }
 
         public float NetBookValue { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelEvaluationModel);
-        }
-
-        public bool Equals([AllowNull] ParcelEvaluationModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                PropertyId == other.PropertyId &&
-                FiscalYear == other.FiscalYear &&
-                EstimatedValue == other.EstimatedValue &&
-                AppraisedValue == other.AppraisedValue &&
-                AssessedValue == other.AssessedValue &&
-                NetBookValue == other.NetBookValue;
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(PropertyId);
-            hash.Add(FiscalYear);
-            hash.Add(EstimatedValue);
-            hash.Add(AppraisedValue);
-            hash.Add(AssessedValue);
-            hash.Add(NetBookValue);
-            return hash.ToHashCode();
-        }
         #endregion
     }
 }

--- a/backend/api/Areas/Tools/Models/Import/ParcelModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/ParcelModel.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Pims.Api.Areas.Tools.Models.Import
 {
-    public class ParcelModel : Pims.Api.Models.BaseModel, IEquatable<ParcelModel>
+    public class ParcelModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -44,63 +41,6 @@ namespace Pims.Api.Areas.Tools.Models.Import
 
         public IEnumerable<ParcelEvaluationModel> Evaluations { get; set; } = new List<ParcelEvaluationModel>();
         public IEnumerable<ParcelBuildingModel> Buildings { get; set; } = new List<ParcelBuildingModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelModel);
-        }
-
-        public bool Equals([AllowNull] ParcelModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                Id == other.Id &&
-                PID == other.PID &&
-                PIN == other.PIN &&
-                StatusId == other.StatusId &&
-                Status == other.Status &&
-                ClassificationId == other.ClassificationId &&
-                Classification == other.Classification &&
-                AgencyId == other.AgencyId &&
-                SubAgency == other.SubAgency &&
-                Agency == other.Agency &&
-                EqualityComparer<AddressModel>.Default.Equals(Address, other.Address) &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                LandArea == other.LandArea &&
-                Description == other.Description &&
-                LandLegalDescription == other.LandLegalDescription &&
-                Enumerable.SequenceEqual(Buildings, other.Buildings) &&
-                Enumerable.SequenceEqual(Evaluations, other.Evaluations);
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(Id);
-            hash.Add(PID);
-            hash.Add(PIN);
-            hash.Add(StatusId);
-            hash.Add(Status);
-            hash.Add(ClassificationId);
-            hash.Add(Classification);
-            hash.Add(AgencyId);
-            hash.Add(SubAgency);
-            hash.Add(Agency);
-            hash.Add(Address);
-            hash.Add(Latitude);
-            hash.Add(Longitude);
-            hash.Add(LandArea);
-            hash.Add(Description);
-            hash.Add(LandLegalDescription);
-            hash.Add(Buildings);
-            hash.Add(Evaluations);
-            return hash.ToHashCode();
-        }
-
         #endregion
     }
 }

--- a/backend/api/Helpers/Extensions/MemberConfigurationExpressionExtensions.cs
+++ b/backend/api/Helpers/Extensions/MemberConfigurationExpressionExtensions.cs
@@ -1,0 +1,25 @@
+using AutoMapper;
+using Pims.Api.Profiles.Resolvers;
+using System;
+
+namespace Pims.Api.Helpers.Extensions
+{
+    /// <summary>
+    /// MemberConfigurationExpressionExtensions static class, provides extension methods for MemberConfigurationExpression objects.
+    /// </summary>
+    public static class MemberConfigurationExpressionExtensions
+    {
+        /// <summary>
+        /// Provides a way to use a lambda function to map a member.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TDestination"></typeparam>
+        /// <typeparam name="TMember"></typeparam>
+        /// <param name="config"></param>
+        /// <param name="action"></param>
+        public static void MapFrom<TSource, TDestination, TMember>(this IMemberConfigurationExpression<TSource, TDestination, TMember> config, Func<TSource, TDestination, TMember, ResolutionContext ,TMember> action)
+        {
+            config.MapFrom(new ObjectResolver<TSource, TDestination, TMember>(action));
+        }
+    }
+}

--- a/backend/api/Models/BaseModel.cs
+++ b/backend/api/Models/BaseModel.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Models
 {
-    public abstract class BaseModel : IEquatable<BaseModel>
+    public abstract class BaseModel
     {
         #region Properties
         public DateTime CreatedOn { get; set; }
@@ -11,26 +10,6 @@ namespace Pims.Api.Models
         public DateTime? UpdatedOn { get; set; }
 
         public string RowVersion { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BaseModel);
-        }
-
-        public bool Equals([AllowNull] BaseModel other)
-        {
-            return other != null &&
-                   CreatedOn == other.CreatedOn &&
-                   UpdatedOn == other.UpdatedOn &&
-                   RowVersion == other.RowVersion;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(CreatedOn, UpdatedOn, RowVersion);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/Building/AddressModel.cs
+++ b/backend/api/Models/Building/AddressModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Building
 {
-    public class AddressModel : BaseModel, IEquatable<AddressModel>
+    public class AddressModel : BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -21,31 +18,6 @@ namespace Pims.Api.Models.Building
         public string Province { get; set; }
 
         public string Postal { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AddressModel);
-        }
-
-        public bool Equals([AllowNull] AddressModel other)
-        {
-            return other != null &&
-                   Id == other.Id &&
-                   Line1 == other.Line1 &&
-                   Line2 == other.Line2 &&
-                   CityId == other.CityId &&
-                   City == other.City &&
-                   ProvinceId == other.ProvinceId &&
-                   Province == other.Province &&
-                   Postal == other.Postal;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Line1, Line2, CityId, City, ProvinceId, Province, Postal);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/Building/BuildingEvaluationModel.cs
+++ b/backend/api/Models/Building/BuildingEvaluationModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Building
 {
-    public class BuildingEvaluationModel : BaseModel, IEquatable<BuildingEvaluationModel>
+    public class BuildingEvaluationModel : BaseModel
     {
         #region Properties
         public int PropertyId { get; set; }
@@ -17,39 +14,6 @@ namespace Pims.Api.Models.Building
         public float AssessedValue { get; set; }
 
         public float NetBookValue { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BuildingEvaluationModel);
-        }
-
-        public bool Equals([AllowNull] BuildingEvaluationModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                PropertyId == other.PropertyId &&
-                FiscalYear == other.FiscalYear &&
-                EstimatedValue == other.EstimatedValue &&
-                AppraisedValue == other.AppraisedValue &&
-                AssessedValue == other.AssessedValue &&
-                NetBookValue == other.NetBookValue;
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(PropertyId);
-            hash.Add(FiscalYear);
-            hash.Add(EstimatedValue);
-            hash.Add(AppraisedValue);
-            hash.Add(AssessedValue);
-            hash.Add(NetBookValue);
-            return hash.ToHashCode();
-        }
-
         #endregion
     }
 }

--- a/backend/api/Models/Building/BuildingModel.cs
+++ b/backend/api/Models/Building/BuildingModel.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Pims.Api.Models.Building
 {
-    public class BuildingModel : BaseModel, IEquatable<BuildingModel>
+    public class BuildingModel : BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -37,52 +34,6 @@ namespace Pims.Api.Models.Building
         public float RentableArea { get; set; }
 
         public IEnumerable<BuildingEvaluationModel> Evaluations { get; set; } = new List<BuildingEvaluationModel>();
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BuildingModel);
-        }
-
-        public bool Equals([AllowNull] BuildingModel other)
-        {
-            return other != null &&
-                Id == other.Id &&
-                ParcelId == other.ParcelId &&
-                LocalId == other.LocalId &&
-                Description == other.Description &&
-                EqualityComparer<AddressModel>.Default.Equals(Address, other.Address) &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                BuildingConstructionTypeId == other.BuildingConstructionTypeId &&
-                BuildingConstructionType == other.BuildingConstructionType &&
-                BuildingFloorCount == other.BuildingFloorCount &&
-                BuildingPredominateUseId == other.BuildingPredominateUseId &&
-                BuildingPredominateUse == other.BuildingPredominateUse &&
-                BuildingTenancy == other.BuildingTenancy &&
-                RentableArea == other.RentableArea &&
-                Enumerable.SequenceEqual(Evaluations, other.Evaluations);
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Id);
-            hash.Add(ParcelId);
-            hash.Add(LocalId);
-            hash.Add(Description);
-            hash.Add(Address);
-            hash.Add(Latitude);
-            hash.Add(Longitude);
-            hash.Add(BuildingConstructionTypeId);
-            hash.Add(BuildingConstructionType);
-            hash.Add(BuildingFloorCount);
-            hash.Add(BuildingPredominateUseId);
-            hash.Add(BuildingPredominateUse);
-            hash.Add(BuildingTenancy);
-            hash.Add(RentableArea);
-            hash.Add(Evaluations);
-            return hash.ToHashCode();
-        }
         #endregion
     }
 }

--- a/backend/api/Models/Building/PartialBuildingModel.cs
+++ b/backend/api/Models/Building/PartialBuildingModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Parts
 {
-    public class PartialBuildingModel : BaseModel, IEquatable<PartialBuildingModel>
+    public class PartialBuildingModel : BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -15,28 +12,6 @@ namespace Pims.Api.Models.Parts
         public double Latitude { get; set; }
 
         public double Longitude { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as PartialBuildingModel);
-        }
-
-        public bool Equals([AllowNull] PartialBuildingModel other)
-        {
-            return other != null &&
-                   Id == other.Id &&
-                   LocalId == other.LocalId &&
-                   Description == other.Description &&
-                   Latitude == other.Latitude &&
-                   Longitude == other.Longitude;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, LocalId, Description, Latitude, Longitude);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/CodeModel.cs
+++ b/backend/api/Models/CodeModel.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models
 {
     /// <summary>
     /// CodeModel class, provides a model that represents a code lookup item.
     /// </summary>
-    public class CodeModel : BaseModel, IEquatable<CodeModel>
+    public class CodeModel : BaseModel
     {
         #region Properties
         /// <summary>
@@ -44,27 +41,6 @@ namespace Pims.Api.Models
         /// </summary>
         /// <value></value>
         public string Type { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as CodeModel);
-        }
-
-        public bool Equals([AllowNull] CodeModel other)
-        {
-            return other != null &&
-                Name == other.Name &&
-                Id == other.Id &&
-                IsDisabled == other.IsDisabled &&
-                Type == other.Type;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Name, Id, IsDisabled);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/Parcel/AddressModel.cs
+++ b/backend/api/Models/Parcel/AddressModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Parcel
 {
-    public class AddressModel : BaseModel, IEquatable<AddressModel>
+    public class AddressModel : BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -21,31 +18,6 @@ namespace Pims.Api.Models.Parcel
         public string Province { get; set; }
 
         public string Postal { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AddressModel);
-        }
-
-        public bool Equals([AllowNull] AddressModel other)
-        {
-            return other != null &&
-                   Id == other.Id &&
-                   Line1 == other.Line1 &&
-                   Line2 == other.Line2 &&
-                   CityId == other.CityId &&
-                   City == other.City &&
-                   ProvinceId == other.ProvinceId &&
-                   Province == other.Province &&
-                   Postal == other.Postal;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Line1, Line2, CityId, City, ProvinceId, Province, Postal);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/Parcel/BuildingEvaluationModel.cs
+++ b/backend/api/Models/Parcel/BuildingEvaluationModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Parcel
 {
-    public class BuildingEvaluationModel : BaseModel, IEquatable<BuildingEvaluationModel>
+    public class BuildingEvaluationModel : BaseModel
     {
         #region Properties
         public int PropertyId { get; set; }
@@ -17,39 +14,6 @@ namespace Pims.Api.Models.Parcel
         public float AssessedValue { get; set; }
 
         public float NetBookValue { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BuildingEvaluationModel);
-        }
-
-        public bool Equals([AllowNull] BuildingEvaluationModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                PropertyId == other.PropertyId &&
-                FiscalYear == other.FiscalYear &&
-                EstimatedValue == other.EstimatedValue &&
-                AppraisedValue == other.AppraisedValue &&
-                AssessedValue == other.AssessedValue &&
-                NetBookValue == other.NetBookValue;
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(PropertyId);
-            hash.Add(FiscalYear);
-            hash.Add(EstimatedValue);
-            hash.Add(AppraisedValue);
-            hash.Add(AssessedValue);
-            hash.Add(NetBookValue);
-            return hash.ToHashCode();
-        }
-
         #endregion
     }
 }

--- a/backend/api/Models/Parcel/ParcelBuildingModel.cs
+++ b/backend/api/Models/Parcel/ParcelBuildingModel.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Pims.Api.Models.Parcel
 {
-    public class ParcelBuildingModel : BaseModel, IEquatable<ParcelBuildingModel>
+    public class ParcelBuildingModel : BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -41,56 +38,6 @@ namespace Pims.Api.Models.Parcel
         public bool IsSensitive { get; set; }
 
         public IEnumerable<BuildingEvaluationModel> Evaluations { get; set; } = new List<BuildingEvaluationModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelBuildingModel);
-        }
-
-        public bool Equals([AllowNull] ParcelBuildingModel other)
-        {
-            return other != null &&
-                Id == other.Id &&
-                LocalId == other.LocalId &&
-                ParcelId == other.ParcelId &&
-                AgencyId == other.AgencyId &&
-                Description == other.Description &&
-                EqualityComparer<AddressModel>.Default.Equals(Address, other.Address) &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                BuildingConstructionTypeId == other.BuildingConstructionTypeId &&
-                BuildingConstructionType == other.BuildingConstructionType &&
-                BuildingFloorCount == other.BuildingFloorCount &&
-                BuildingPredominateUseId == other.BuildingPredominateUseId &&
-                BuildingPredominateUse == other.BuildingPredominateUse &&
-                BuildingTenancy == other.BuildingTenancy &&
-                RentableArea == other.RentableArea &&
-                Enumerable.SequenceEqual(Evaluations, other.Evaluations);
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Id);
-            hash.Add(LocalId);
-            hash.Add(ParcelId);
-            hash.Add(AgencyId);
-            hash.Add(Description);
-            hash.Add(Address);
-            hash.Add(Latitude);
-            hash.Add(Longitude);
-            hash.Add(BuildingConstructionTypeId);
-            hash.Add(BuildingConstructionType);
-            hash.Add(BuildingFloorCount);
-            hash.Add(BuildingPredominateUseId);
-            hash.Add(BuildingPredominateUse);
-            hash.Add(BuildingTenancy);
-            hash.Add(RentableArea);
-            hash.Add(Evaluations);
-            return hash.ToHashCode();
-        }
         #endregion
     }
 }

--- a/backend/api/Models/Parcel/ParcelEvaluationModel.cs
+++ b/backend/api/Models/Parcel/ParcelEvaluationModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Parcel
 {
-    public class ParcelEvaluationModel : BaseModel, IEquatable<ParcelEvaluationModel>
+    public class ParcelEvaluationModel : BaseModel
     {
         #region Properties
         public int PropertyId { get; set; }
@@ -17,39 +14,6 @@ namespace Pims.Api.Models.Parcel
         public float AssessedValue { get; set; }
 
         public float NetBookValue { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelEvaluationModel);
-        }
-
-        public bool Equals([AllowNull] ParcelEvaluationModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                PropertyId == other.PropertyId &&
-                FiscalYear == other.FiscalYear &&
-                EstimatedValue == other.EstimatedValue &&
-                AppraisedValue == other.AppraisedValue &&
-                AssessedValue == other.AssessedValue &&
-                NetBookValue == other.NetBookValue;
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(PropertyId);
-            hash.Add(FiscalYear);
-            hash.Add(EstimatedValue);
-            hash.Add(AppraisedValue);
-            hash.Add(AssessedValue);
-            hash.Add(NetBookValue);
-            return hash.ToHashCode();
-        }
-
         #endregion
     }
 }

--- a/backend/api/Models/Parcel/ParcelModel.cs
+++ b/backend/api/Models/Parcel/ParcelModel.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Pims.Api.Models.Parcel
 {
-    public class ParcelModel : BaseModel, IEquatable<ParcelModel>
+    public class ParcelModel : BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -44,61 +41,6 @@ namespace Pims.Api.Models.Parcel
 
         public IEnumerable<ParcelEvaluationModel> Evaluations { get; set; } = new List<ParcelEvaluationModel>();
         public IEnumerable<ParcelBuildingModel> Buildings { get; set; } = new List<ParcelBuildingModel>();
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as ParcelModel);
-        }
-
-        public bool Equals([AllowNull] ParcelModel other)
-        {
-            return other != null &&
-                base.Equals(other) &&
-                Id == other.Id &&
-                PID == other.PID &&
-                PIN == other.PIN &&
-                StatusId == other.StatusId &&
-                Status == other.Status &&
-                ClassificationId == other.ClassificationId &&
-                Classification == other.Classification &&
-                AgencyId == other.AgencyId &&
-                SubAgency == other.SubAgency &&
-                Agency == other.Agency &&
-                EqualityComparer<AddressModel>.Default.Equals(Address, other.Address) &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                LandArea == other.LandArea &&
-                Description == other.Description &&
-                LandLegalDescription == other.LandLegalDescription &&
-                Enumerable.SequenceEqual(Buildings, other.Buildings) &&
-                Enumerable.SequenceEqual(Evaluations, other.Evaluations);
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(base.GetHashCode());
-            hash.Add(Id);
-            hash.Add(PID);
-            hash.Add(PIN);
-            hash.Add(StatusId);
-            hash.Add(Status);
-            hash.Add(ClassificationId);
-            hash.Add(Classification);
-            hash.Add(AgencyId);
-            hash.Add(SubAgency);
-            hash.Add(Agency);
-            hash.Add(Address);
-            hash.Add(Latitude);
-            hash.Add(Longitude);
-            hash.Add(LandArea);
-            hash.Add(Description);
-            hash.Add(LandLegalDescription);
-            hash.Add(Buildings);
-            hash.Add(Evaluations);
-            return hash.ToHashCode();
-        }
-
         #endregion
     }
 }

--- a/backend/api/Models/Parcel/PartialParcelModel.cs
+++ b/backend/api/Models/Parcel/PartialParcelModel.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Parcel
 {
-    public class PartialParcelModel : BaseModel, IEquatable<PartialParcelModel>
+    public class PartialParcelModel : BaseModel
     {
         #region Properties
         public int Id { get; set; }
@@ -21,31 +18,6 @@ namespace Pims.Api.Models.Parcel
         public double Longitude { get; set; }
 
         public string Description { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as PartialParcelModel);
-        }
-
-        public bool Equals([AllowNull] PartialParcelModel other)
-        {
-            return other != null &&
-                Id == other.Id &&
-                PID == other.PID &&
-                PIN == other.PIN &&
-                StatusId == other.StatusId &&
-                ClassificationId == other.ClassificationId &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                Description == other.Description;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, PID, PIN, StatusId, ClassificationId, Latitude, Longitude, Description);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/Property/PropertyModel.cs
+++ b/backend/api/Models/Property/PropertyModel.cs
@@ -1,10 +1,7 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Property
 {
 
-    public class PropertyModel : IEquatable<PropertyModel>
+    public class PropertyModel
     {
         #region Properties
         public int Id { get; set; }
@@ -30,32 +27,6 @@ namespace Pims.Api.Models.Property
 
         #region Building Properties
         #endregion
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as PropertyModel);
-        }
-
-        public bool Equals([AllowNull] PropertyModel other)
-        {
-            return other != null &&
-                Id == other.Id &&
-                PropertyTypeId == other.PropertyTypeId &&
-                Latitude == other.Latitude &&
-                Longitude == other.Longitude &&
-                Description == other.Description &&
-                PID == other.PID &&
-                PIN == other.PIN &&
-                StatusId == other.StatusId &&
-                ClassificationId == other.ClassificationId;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, PID, PIN, StatusId, ClassificationId, Latitude, Longitude, Description);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/Update/BaseModel.cs
+++ b/backend/api/Models/Update/BaseModel.cs
@@ -1,30 +1,9 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Pims.Api.Models.Update
 {
-    public abstract class BaseModel : IEquatable<BaseModel>
+    public abstract class BaseModel
     {
         #region Properties
         public string RowVersion { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as BaseModel);
-        }
-
-        public bool Equals([AllowNull] BaseModel other)
-        {
-            return other != null &&
-                   RowVersion == other.RowVersion;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(RowVersion);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/User/AccessRequestRoleModel.cs
+++ b/backend/api/Models/User/AccessRequestRoleModel.cs
@@ -1,35 +1,15 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Models.User
 {
     /// <summary>
     /// AccessRequestRoleModel class, provides a model that represents a role attached to an access request.
     /// </summary>
-    public class AccessRequestRoleModel : CodeModel, IEquatable<RoleModel>
+    public class AccessRequestRoleModel : CodeModel
     {
+        #region Properties
         public string Description { get; set; }
         public ICollection<UserModel> Users { get; } = new List<UserModel>();
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as RoleModel);
-        }
-
-        public bool Equals([AllowNull] RoleModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Description == other.Description &&
-                   IsDisabled == other.IsDisabled &&
-                   EqualityComparer<ICollection<UserModel>>.Default.Equals(Users, other.Users);
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Description, IsDisabled, Users);
-        }
+        #endregion
     }
 }

--- a/backend/api/Models/User/AccessRequestUserModel.cs
+++ b/backend/api/Models/User/AccessRequestUserModel.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Models.User
 {
     /// <summary>
     /// AccessRequestUserModel class, provides a model that represents a user attached to an access request.
     /// </summary>
-    public class AccessRequestUserModel : BaseModel, IEquatable<AccessRequestUserModel>
+    public class AccessRequestUserModel : BaseModel
     {
         #region Properties
         /// <summary>
@@ -44,29 +43,6 @@ namespace Pims.Api.Models.User
         /// </summary>
         /// <value></value>
         public string Email { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AccessRequestUserModel);
-        }
-
-        public bool Equals([AllowNull] AccessRequestUserModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   DisplayName == other.DisplayName &&
-                   FirstName == other.FirstName &&
-                   MiddleName == other.MiddleName &&
-                   LastName == other.LastName &&
-                   Email == other.Email;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, DisplayName, FirstName, MiddleName, LastName, Email);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/User/AgencyModel.cs
+++ b/backend/api/Models/User/AgencyModel.cs
@@ -1,35 +1,14 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Models.User
 {
-    public class AgencyModel : CodeModel, IEquatable<AgencyModel>
+    public class AgencyModel : CodeModel
     {
         #region Properties
         public string Description { get; set; }
         public AgencyModel Parent { get; set; }
         public ICollection<AgencyModel> Children { get; } = new List<AgencyModel>();
         public ICollection<UserModel> Users { get; } = new List<UserModel>();
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as AgencyModel);
-        }
-
-        public bool Equals([AllowNull] AgencyModel other)
-        {
-            return other != null &&
-                   base.Equals(other) &&
-                   Description == other.Description;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(base.GetHashCode(), Description, Parent, Children, Users);
-        }
         #endregion
     }
 }

--- a/backend/api/Models/User/RoleModel.cs
+++ b/backend/api/Models/User/RoleModel.cs
@@ -1,32 +1,12 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Models.User
 {
-    public class RoleModel : CodeModel, IEquatable<RoleModel>
+    public class RoleModel : CodeModel
     {
+        #region Properties
         public string Description { get; set; }
         public ICollection<UserModel> Users { get; } = new List<UserModel>();
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as RoleModel);
-        }
-
-        public bool Equals([AllowNull] RoleModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   Name == other.Name &&
-                   Description == other.Description &&
-                   IsDisabled == other.IsDisabled &&
-                   EqualityComparer<ICollection<UserModel>>.Default.Equals(Users, other.Users);
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name, Description, IsDisabled, Users);
-        }
+        #endregion
     }
 }

--- a/backend/api/Models/User/UserModel.cs
+++ b/backend/api/Models/User/UserModel.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Pims.Api.Models.User
 {
-    public class UserModel : Pims.Api.Models.BaseModel, IEquatable<UserModel>
+    public class UserModel : Pims.Api.Models.BaseModel
     {
         #region Properties
         public Guid Id { get; set; }
@@ -30,45 +29,6 @@ namespace Pims.Api.Models.User
         public IEnumerable<AgencyModel> Agencies { get; set; }
 
         public IEnumerable<RoleModel> Roles { get; set; }
-        #endregion
-
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as UserModel);
-        }
-
-        public bool Equals([AllowNull] UserModel other)
-        {
-            return other != null &&
-                   Id.Equals(other.Id) &&
-                   IsDisabled == other.IsDisabled &&
-                   Username == other.Username &&
-                   DisplayName == other.DisplayName &&
-                   FirstName == other.FirstName &&
-                   MiddleName == other.MiddleName &&
-                   LastName == other.LastName &&
-                   Position == other.Position &&
-                   Note == other.Note &&
-                   Email == other.Email;
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Id);
-            hash.Add(IsDisabled);
-            hash.Add(Username);
-            hash.Add(DisplayName);
-            hash.Add(FirstName);
-            hash.Add(MiddleName);
-            hash.Add(LastName);
-            hash.Add(Email);
-            hash.Add(Position);
-            hash.Add(Note);
-            return hash.ToHashCode();
-        }
-
         #endregion
     }
 }

--- a/backend/api/Pims.Api.csproj
+++ b/backend/api/Pims.Api.csproj
@@ -10,9 +10,13 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="Models\Lookup\**" />
     <Compile Remove="Profiles\Extensions\**" />
+    <Content Remove="Models\Lookup\**" />
     <Content Remove="Profiles\Extensions\**" />
+    <EmbeddedResource Remove="Models\Lookup\**" />
     <EmbeddedResource Remove="Profiles\Extensions\**" />
+    <None Remove="Models\Lookup\**" />
     <None Remove="Profiles\Extensions\**" />
   </ItemGroup>
   <ItemGroup>
@@ -49,8 +53,5 @@
     <ProjectReference Include="..\dal.keycloak\Pims.Dal.Keycloak.csproj" />
     <ProjectReference Include="..\entities\Pims.Dal.Entities.csproj" />
     <ProjectReference Include="..\keycloak\Pims.Keycloak.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Models\Lookup\" />
   </ItemGroup>
 </Project>

--- a/backend/api/Profiles/BaseProfile.cs
+++ b/backend/api/Profiles/BaseProfile.cs
@@ -14,7 +14,7 @@ namespace Pims.Api.Profiles
 
             CreateMap<Entity.BaseEntity, BaseModel>()
                 .IncludeAllDerived()
-                .ForMember(dest => dest.RowVersion, opt => opt.MapFrom(src => Convert.ToBase64String(src.RowVersion)));
+                .ForMember(dest => dest.RowVersion, opt => opt.MapFrom(src => src.RowVersion.Length == 0 ? null : Convert.ToBase64String(src.RowVersion)));
 
             CreateMap<BaseModel, Entity.BaseEntity>()
                 .IncludeAllDerived()

--- a/backend/api/Profiles/Resolvers/ObjectResolver`.cs
+++ b/backend/api/Profiles/Resolvers/ObjectResolver`.cs
@@ -1,0 +1,47 @@
+using AutoMapper;
+using System;
+
+namespace Pims.Api.Profiles.Resolvers
+{
+    /// <summary>
+    /// ObjectResolver class, provides a way to debug AutoMapper when it is resolving one type to another.
+    /// </summary>
+    /// <example>
+    ///     .ForMember(dest => dest.Property, opt.MapFrom(new ObjectResolver'SourceType, DestType, MemberType'((s,d,m,c) => { // Do stuff here.})));
+    /// </example>
+    /// <typeparam name="ST"></typeparam>
+    /// <typeparam name="DT"></typeparam>
+    /// <typeparam name="DMT"></typeparam>
+    public class ObjectResolver<ST, DT, DMT> : IValueResolver<ST, DT, DMT>
+    {
+        #region Variables
+        private readonly Func<ST, DT, DMT, ResolutionContext, DMT> _action;
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Creates a new instance of a ObjectResolver object, initializes with specified arguments.
+        /// </summary>
+        /// <param name="action"></param>
+        public ObjectResolver(Func<ST, DT, DMT, ResolutionContext, DMT> action)
+        {
+            _action = action;
+        }
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Resolve the source and return the 'destMember'.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="destination"></param>
+        /// <param name="destMember"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public DMT Resolve(ST source, DT destination, DMT destMember, ResolutionContext context)
+        {
+            return _action(source, destination, destMember, context);
+        }
+        #endregion
+    }
+}

--- a/backend/api/Profiles/User/AccessRequestProfile.cs
+++ b/backend/api/Profiles/User/AccessRequestProfile.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using Entity = Pims.Dal.Entities;
 using Model = Pims.Api.Models.User;
-using System.Linq;
 using System;
 
 namespace Pims.Api.Profiles.User
@@ -12,29 +11,54 @@ namespace Pims.Api.Profiles.User
         public AccessRequestProfile()
         {
             CreateMap<Entity.AccessRequest, Model.AccessRequestModel>()
-                .ForMember(dest => dest.Agencies, opt => opt.MapFrom(src => src.Agencies.Select(a => a.Agency)))
-                .ForMember(dest => dest.Roles, opt => opt.MapFrom(src => src.Roles.Select(r => r.Role)))
-                .ForMember(dest => dest.User, opt => opt.MapFrom(src => src.User));
+                .ForMember(dest => dest.Agencies, opt => opt.MapFrom(src => src.Agencies))
+                .ForMember(dest => dest.Roles, opt => opt.MapFrom(src => src.Roles))
+                .ForMember(dest => dest.User, opt => opt.MapFrom(src => src.User))
+                .ForMember(dest => dest.User, opt => opt.MapFrom((s, d, m, c) =>
+                {
+                    if (s.User == null && s.UserId.HasValue) return new Model.AccessRequestUserModel() { Id = s.UserId.Value };
+
+                    return c.Mapper.Map<Model.AccessRequestUserModel>(s.User);
+                }));
 
             CreateMap<Model.AccessRequestModel, Entity.AccessRequest>()
                 .ForMember(dest => dest.User, opt => opt.Ignore())
-                .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.User.Id));
+                .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.User.Id))
+                .ForMember(dest => dest.Agencies, opt => opt.MapFrom(src => src.Agencies))
+                .ForMember(dest => dest.Roles, opt => opt.MapFrom(src => src.Roles));
 
+            // User
+            CreateMap<Entity.User, Model.AccessRequestUserModel>()
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+                .ForMember(dest => dest.DisplayName, opt => opt.MapFrom(src => src.DisplayName))
+                .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.FirstName))
+                .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.MiddleName))
+                .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.LastName))
+                .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.Email))
+                .IncludeBase<Entity.BaseEntity, Pims.Api.Models.BaseModel>();
+
+            // Agency
             CreateMap<Model.AgencyModel, Entity.AccessRequestAgency>()
                 .ForMember(dest => dest.AccessRequest, opt => opt.Ignore())
                 .ForMember(dest => dest.AccessRequestId, opt => opt.Ignore())
                 .ForMember(dest => dest.Agency, opt => opt.Ignore())
                 .ForMember(dest => dest.AgencyId, opt => opt.MapFrom(src => Int32.Parse(src.Id)));
+
+            // Role
             CreateMap<Model.AccessRequestRoleModel, Entity.AccessRequestRole>()
                 .ForMember(dest => dest.AccessRequest, opt => opt.Ignore())
                 .ForMember(dest => dest.AccessRequestId, opt => opt.Ignore())
                 .ForMember(dest => dest.Role, opt => opt.Ignore())
                 .ForMember(dest => dest.RoleId, opt => opt.MapFrom(src => Guid.Parse(src.Id)));
 
-            CreateMap<Entity.User, Model.AccessRequestUserModel>();
-            CreateMap<Model.AccessRequestUserModel, Entity.User>();
+            CreateMap<Entity.AccessRequestRole, Model.AccessRequestRoleModel>()
+                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Role.Name))
+                .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Role.Description))
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.RoleId));
+
             CreateMap<Model.AccessRequestRoleModel, Entity.Role>()
                 .IncludeBase<Pims.Api.Models.CodeModel, Entity.LookupEntity>();
+
             CreateMap<Entity.Role, Model.AccessRequestRoleModel>()
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id.ToString()))
                 .IncludeBase<Entity.LookupEntity, Pims.Api.Models.CodeModel>();

--- a/backend/api/Profiles/User/AgencyProfile.cs
+++ b/backend/api/Profiles/User/AgencyProfile.cs
@@ -14,6 +14,19 @@ namespace Pims.Api.Profiles.User
 
             CreateMap<Model.AgencyModel, Entity.Agency>()
                 .IncludeBase<Pims.Api.Models.CodeModel, Entity.CodeEntity>();
+
+            CreateMap<Entity.AccessRequestAgency, Model.AgencyModel>()
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.AgencyId))
+                .ForMember(dest => dest.Code, opt => opt.Ignore())
+                .ForMember(dest => dest.Type, opt => opt.Ignore())
+                .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Agency.Description))
+                .ForMember(dest => dest.IsDisabled, opt => opt.MapFrom(src => src.Agency.IsDisabled))
+                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Agency.Name))
+                .ForMember(dest => dest.SortOrder, opt => opt.MapFrom(src => src.Agency.SortOrder))
+                .ForMember(dest => dest.Children, opt => opt.Ignore())
+                .ForMember(dest => dest.Parent, opt => opt.MapFrom(src => src.Agency.Parent))
+                .ForMember(dest => dest.Users, opt => opt.Ignore())
+                .IncludeBase<Entity.BaseEntity, Pims.Api.Models.BaseModel>();
         }
         #endregion
     }

--- a/backend/core/Comparers/DeepPropertyCompare.cs
+++ b/backend/core/Comparers/DeepPropertyCompare.cs
@@ -1,0 +1,114 @@
+using Pims.Core.Extensions;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+
+namespace Pims.Core.Comparers
+{
+    /// <summary>
+    /// DeepPropertyCompare class, provides a simple way to deep compare two objects of the same type.
+    /// </summary>
+    public class DeepPropertyCompare : IEqualityComparer<object>
+    {
+        /// <summary>
+        /// Determines if the objects public properties are equal.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public new bool Equals([AllowNull] object x, [AllowNull] object y)
+        {
+            // Only root objects cannot be null.  Child objects that are null will be equal.
+            if (x == null || y == null || GetHashCode(x) != GetHashCode(y)) return false;
+
+            var type = x.GetType();
+            var children = type.GetCachedProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty).Where(p => !p.PropertyType.IsValueType && p.PropertyType != typeof(string) && !p.PropertyType.IsEnumerable());
+            foreach (var p in children)
+            {
+                var cx = p.GetValue(x);
+                var cy = p.GetValue(y);
+                if ((cx == null && cy != null) || (cx != null && cy == null)) return false;
+                if (cx == null && cy == null) return true; // Both are null, therefore equal.
+
+                var sct = typeof(DeepPropertyCompare<>);
+                var scgt = sct.MakeGenericType(p.PropertyType);
+                var csc = Activator.CreateInstance(scgt);
+                var method = scgt.GetMethod(nameof(Equals), BindingFlags.Public | BindingFlags.Instance, null, new[] { p.PropertyType, p.PropertyType }, null)
+                        ?? scgt.GetMethod(nameof(Equals), BindingFlags.Public | BindingFlags.Instance, null, new[] { typeof(object), typeof(object) }, null);
+
+                if (!(bool)method.Invoke(csc, new[] { cx, cy })) return false;
+            }
+
+            var collections = type.GetCachedProperties().Where(p => p.PropertyType != typeof(string) && p.PropertyType.IsEnumerable());
+            foreach (var p in collections)
+            {
+                var cx = p.GetValue(x);
+                var cy = p.GetValue(y);
+
+                // Have to manually force them into lists... I hate this way.
+                var lcx = new ArrayList();
+                foreach (var item in (IEnumerable)cx)
+                {
+                    lcx.Add(item);
+                }
+
+                var lcy = new ArrayList();
+                foreach (var item in (IEnumerable)cy)
+                {
+                    lcy.Add(item);
+                }
+
+                if (lcx.Count != lcy.Count) return false;
+
+                for (var i = 0; i < lcx.Count; i++)
+                {
+                    var cxitem = lcx[i];
+                    var cyitem = lcy[i];
+
+                    if ((cxitem == null && cyitem != null) || (cxitem != null && cyitem == null)) return false;
+                    if (cxitem == null && cyitem == null) return true; // Both are null, therefore equal.
+
+                    var ctype = p.PropertyType.GetItemType();
+                    var sct = typeof(DeepPropertyCompare<>);
+                    var scgt = sct.MakeGenericType(ctype);
+                    var csc = Activator.CreateInstance(scgt);
+                    var method = scgt.GetMethod(nameof(Equals), BindingFlags.Public | BindingFlags.Instance, null, new[] { ctype, ctype }, null)
+                        ?? scgt.GetMethod(nameof(Equals), BindingFlags.Public | BindingFlags.Instance, null, new[] { typeof(object), typeof(object) }, null);
+
+                    if (!(bool)method.Invoke(csc, new[] { cxitem, cyitem })) return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Get the hash code for all the public properties.
+        /// Ignores child objects.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public int GetHashCode([DisallowNull] object obj)
+        {
+            var hash = new HashCode();
+
+            var props = obj.GetType().GetCachedProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
+
+            foreach (var p in props)
+            {
+                if (p.PropertyType.IsValueType || p.PropertyType == typeof(string) || p.PropertyType.IsNullableType())
+                    hash.Add(p.GetValue(obj));
+                else if (p.PropertyType == typeof(byte[]))
+                {
+                    var value = (byte[])p.GetValue(obj);
+                    value.ForEach(v => hash.Add(v));
+                }
+            }
+
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/backend/core/Comparers/DeepPropertyCompare`.cs
+++ b/backend/core/Comparers/DeepPropertyCompare`.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Pims.Core.Comparers
+{
+    /// <summary>
+    /// DeepPropertyCompare class, provides a simple way to deep compare two objects of the same type.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class DeepPropertyCompare<T> : DeepPropertyCompare
+    {
+        /// <summary>
+        /// Determines if the objects public properties are equal.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public bool Equals([AllowNull] T x, [AllowNull] T y)
+        {
+            return base.Equals(x, y);
+        }
+
+        /// <summary>
+        /// Get the hash code for all the public properties.
+        /// Ignores child objects.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public int GetHashCode([DisallowNull] T obj)
+        {
+            return base.GetHashCode(obj);
+        }
+    }
+}

--- a/backend/core/Comparers/ShallowPropertyCompare.cs
+++ b/backend/core/Comparers/ShallowPropertyCompare.cs
@@ -1,0 +1,53 @@
+using Pims.Core.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace Pims.Core.Comparers
+{
+    /// <summary>
+    /// ShallowPropertyCompare class, provides a simple way to shallow compare two objects of the same type.
+    /// This compares only public properties, but ignores most non-value type properties (i.e Classes)
+    /// </summary>
+    public class ShallowPropertyCompare : IEqualityComparer<object>
+    {
+        /// <summary>
+        /// Determines if the objects public properties are equal.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public new bool Equals([AllowNull] object x, [AllowNull] object y)
+        {
+            if (x == null || y == null || GetHashCode(x) != GetHashCode(y)) return false;
+            return true;
+        }
+
+        /// <summary>
+        /// Get the hash code for all the public properties.
+        /// Ignores child objects.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public int GetHashCode(object obj)
+        {
+            var hash = new HashCode();
+
+            var props = obj.GetType().GetCachedProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
+
+            foreach (var p in props)
+            {
+                if (p.PropertyType.IsValueType || p.PropertyType == typeof(string) || p.PropertyType.IsNullableType())
+                    hash.Add(p.GetValue(obj));
+                else if (p.PropertyType == typeof(byte[]))
+                {
+                    var value = (byte[])p.GetValue(obj);
+                    value.ForEach(v => hash.Add(v));
+                }
+            }
+
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/backend/core/Comparers/ShallowPropertyCompare`.cs
+++ b/backend/core/Comparers/ShallowPropertyCompare`.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Pims.Core.Comparers
+{
+    /// <summary>
+    /// ShallowPropertyCompare class, provides a simple way to shallow compare two objects of the same type.
+    /// This compares only public properties, but ignores most non-value type properties (i.e Classes)
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ShallowPropertyCompare<T> : ShallowPropertyCompare
+    {
+        /// <summary>
+        /// Determines if the objects public properties are equal.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public bool Equals([AllowNull] T x, [AllowNull] T y)
+        {
+            return base.Equals(x, y);
+        }
+
+        /// <summary>
+        /// Get the hash code for all the public properties.
+        /// Ignores child objects.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public int GetHashCode([DisallowNull] T obj)
+        {
+            return base.GetHashCode(obj);
+        }
+    }
+}

--- a/backend/core/Extensions/TypeExtensions.cs
+++ b/backend/core/Extensions/TypeExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System;
+using System.Collections;
 
 namespace Pims.Core.Extensions
 {
@@ -80,15 +81,25 @@ namespace Pims.Core.Extensions
         /// <returns></returns>
         public static bool IsEnumerable(this Type type)
         {
+            return typeof(IEnumerable).IsAssignableFrom(type);
+        }
+
+        /// <summary>
+        /// Determine if the specified type is an IEnumerable.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static bool IsIEnumerable(this Type type)
+        {
             return type.GetInterfaces().Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>));
         }
 
         /// <summary>
-        /// Determine if the specified type is a collection.
+        /// Determine if the specified type is a ICollection.
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        public static bool IsCollection(this Type type)
+        public static bool IsICollection(this Type type)
         {
             return type.GetInterfaces().Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(ICollection<>));
         }
@@ -106,6 +117,18 @@ namespace Pims.Core.Extensions
             if (!type.IsValueType) return true;
             if (Nullable.GetUnderlyingType(type) != null) return true;
             return false;
+        }
+
+        /// <summary>
+        /// Determine if the type/object is a nullable type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="obj"></param>
+        /// <returns>True if the type/object is nullable.</returns>
+        public static bool IsNullableType<T>(this T obj)
+        {
+            var type = typeof(T);
+            return Nullable.GetUnderlyingType(type) != null;
         }
 
         /// <summary>

--- a/backend/core/Pims.Core.csproj
+++ b/backend/core/Pims.Core.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/backend/test/Controllers/Admin/ParcelControllerTest.cs
+++ b/backend/test/Controllers/Admin/ParcelControllerTest.cs
@@ -9,12 +9,13 @@ using Pims.Dal.Security;
 using Pims.Dal.Services.Admin;
 using System.Linq;
 using Xunit;
+using Pims.Core.Comparers;
 
 namespace Pims.Api.Test.Controllers.Admin
 {
     [Trait("category", "unit")]
     [Trait("category", "api")]
-    [Trait("area", "admine")]
+    [Trait("area", "admin")]
     [Trait("group", "parcel")]
     public class ParcelControllerTest
     {
@@ -45,8 +46,8 @@ namespace Pims.Api.Test.Controllers.Admin
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcel = Assert.IsType<Model.ParcelModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.ParcelModel>(parcel), actualParcel);
+            var actualResult = Assert.IsType<Model.ParcelModel>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.ParcelModel>(parcel), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Remove(It.IsAny<Entity.Parcel>()), Times.Once());
         }
         #endregion
@@ -97,8 +98,8 @@ namespace Pims.Api.Test.Controllers.Admin
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcel = Assert.IsType<Model.ParcelModel>(actionResult.Value);
-            Assert.Equal(model, actualParcel);
+            var actualResult = Assert.IsType<Model.ParcelModel>(actionResult.Value);
+            Assert.Equal(model, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Update(It.IsAny<Entity.Parcel>()), Times.Once());
         }
 

--- a/backend/test/Controllers/Admin/UserControllerTest.cs
+++ b/backend/test/Controllers/Admin/UserControllerTest.cs
@@ -9,6 +9,7 @@ using Pims.Dal.Security;
 using Pims.Dal.Services.Admin;
 using System;
 using Xunit;
+using Pims.Core.Comparers;
 
 namespace PimsApi.Test.Admin.Controllers
 {
@@ -101,8 +102,8 @@ namespace PimsApi.Test.Admin.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualAccessRequest = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(expectedAccessRequests), actualAccessRequest.Items);
+            var actualResult = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(expectedAccessRequests), actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.User.GetAccessRequests(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool?>()), Times.Once());
         }
 
@@ -124,8 +125,8 @@ namespace PimsApi.Test.Admin.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualAccessRequest = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(expectedAccessRequests), actualAccessRequest.Items);
+            var actualResult = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(expectedAccessRequests), actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.User.GetAccessRequests(1, 1, null, null), Times.Once());
         }
 
@@ -147,8 +148,8 @@ namespace PimsApi.Test.Admin.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualAccessRequest = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(expectedAccessRequests), actualAccessRequest.Items);
+            var actualResult = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(expectedAccessRequests), actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.User.GetAccessRequests(2, 20, null, null), Times.Once());
         }
         #endregion
@@ -174,7 +175,7 @@ namespace PimsApi.Test.Admin.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             var actualAccessRequest = Assert.IsType<Entity.Models.Paged<Model.UserModel>>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.UserModel[]>(expectedUsers), actualAccessRequest.Items);
+            Assert.Equal(mapper.Map<Model.UserModel[]>(expectedUsers), actualAccessRequest.Items, new DeepPropertyCompare());
             service.Verify(m => m.User.Get(It.IsAny<Entity.Models.UserFilter>()), Times.Once());
         }
         #endregion

--- a/backend/test/Controllers/Keycloak/RoleControllerTest.cs
+++ b/backend/test/Controllers/Keycloak/RoleControllerTest.cs
@@ -10,6 +10,7 @@ using AutoMapper;
 using Pims.Dal.Keycloak;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Pims.Core.Comparers;
 
 namespace PimsApi.Test.Keycloak.Controllers
 {
@@ -50,7 +51,7 @@ namespace PimsApi.Test.Keycloak.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             var data = Assert.IsType<Model.RoleModel[]>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.RoleModel[]>(eroles), data);
+            Assert.Equal(mapper.Map<Model.RoleModel[]>(eroles), data, new DeepPropertyCompare());
             service.Verify(m => m.SyncRolesAsync(), Times.Once());
         }
         #endregion
@@ -76,7 +77,7 @@ namespace PimsApi.Test.Keycloak.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             var data = Assert.IsType<Model.RoleModel[]>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.RoleModel[]>(eroles), data);
+            Assert.Equal(mapper.Map<Model.RoleModel[]>(eroles), data, new DeepPropertyCompare());
             service.Verify(m => m.GetRolesAsync(1, 10, It.IsAny<string>()), Times.Once());
         }
         #endregion
@@ -100,8 +101,8 @@ namespace PimsApi.Test.Keycloak.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var data = Assert.IsType<Model.RoleModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.RoleModel>(erole), data);
+            var actualResult = Assert.IsType<Model.RoleModel>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.RoleModel>(erole), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.GetRoleAsync(It.IsAny<Guid>()), Times.Once());
         }
         #endregion
@@ -117,21 +118,20 @@ namespace PimsApi.Test.Keycloak.Controllers
 
             var mapper = helper.GetService<IMapper>();
             var service = helper.GetService<Mock<IPimsKeycloakService>>();
-            var erole = new Entity.Role(Guid.NewGuid(), "test");
+            var erole = new Entity.Role(Guid.NewGuid(), "test") { Description = "description" };
             service.Setup(m => m.UpdateRoleAsync(It.IsAny<Entity.Role>())).Returns(Task.FromResult(erole));
-            var model = new Model.Update.RoleModel()
-            {
-                Name = erole.Name,
-                Description = erole.Description
-            };
+            var model = mapper.Map<Model.Update.RoleModel>(erole);
 
             // Act
             var result = await controller.UpdateRoleAsync(erole.Id, model);
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var data = Assert.IsType<Model.RoleModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.RoleModel>(erole), data);
+            var actualResult = Assert.IsType<Model.RoleModel>(actionResult.Value);
+            var expectedResult = mapper.Map<Model.RoleModel>(erole);
+            Assert.Equal(expectedResult.Id, actualResult.Id);
+            Assert.Equal(expectedResult.Name, actualResult.Name);
+            Assert.Equal(expectedResult.Description, actualResult.Description);
             service.Verify(m => m.UpdateRoleAsync(It.IsAny<Entity.Role>()), Times.Once());
         }
         #endregion

--- a/backend/test/Controllers/Keycloak/UserControllerTest.cs
+++ b/backend/test/Controllers/Keycloak/UserControllerTest.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
+using Pims.Core.Comparers;
 
 namespace PimsApi.Test.Keycloak.Controllers
 {
@@ -50,7 +51,7 @@ namespace PimsApi.Test.Keycloak.Controllers
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
             var data = Assert.IsType<Model.UserModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.UserModel>(user), data);
+            Assert.Equal(mapper.Map<Model.UserModel>(user), data, new DeepPropertyCompare());
             service.Verify(m => m.SyncUserAsync(It.IsAny<Guid>()), Times.Once());
         }
         #endregion
@@ -76,7 +77,7 @@ namespace PimsApi.Test.Keycloak.Controllers
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
             var data = Assert.IsType<Model.UserModel[]>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.UserModel[]>(users), data);
+            Assert.Equal(mapper.Map<Model.UserModel[]>(users), data, new DeepPropertyCompare());
             service.Verify(m => m.GetUsersAsync(1, 10, It.IsAny<string>()), Times.Once());
         }
         #endregion
@@ -101,7 +102,7 @@ namespace PimsApi.Test.Keycloak.Controllers
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
             var data = Assert.IsType<Model.UserModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.UserModel>(user), data);
+            Assert.Equal(mapper.Map<Model.UserModel>(user), data, new DeepPropertyCompare());
             service.Verify(m => m.GetUserAsync(It.IsAny<Guid>()), Times.Once());
         }
         #endregion
@@ -126,8 +127,21 @@ namespace PimsApi.Test.Keycloak.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var data = Assert.IsType<Model.UserModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.UserModel>(user), data);
+            var actualResult = Assert.IsType<Model.UserModel>(actionResult.Value);
+            var expectedResult = mapper.Map<Model.UserModel>(user);
+            Assert.Equal(expectedResult.Id, actualResult.Id);
+            Assert.Equal(expectedResult.DisplayName, actualResult.DisplayName);
+            Assert.Equal(expectedResult.FirstName, actualResult.FirstName);
+            Assert.Equal(expectedResult.MiddleName, actualResult.MiddleName);
+            Assert.Equal(expectedResult.LastName, actualResult.LastName);
+            Assert.Equal(expectedResult.Username, actualResult.Username);
+            Assert.Equal(expectedResult.Email, actualResult.Email);
+            Assert.Equal(expectedResult.IsDisabled, actualResult.IsDisabled);
+            Assert.Equal(expectedResult.EmailVerified, actualResult.EmailVerified);
+            Assert.Equal(expectedResult.Position, actualResult.Position);
+            Assert.Equal(expectedResult.Note, actualResult.Note);
+            Assert.Equal(expectedResult.Agencies, actualResult.Agencies, new DeepPropertyCompare());
+            Assert.Equal(expectedResult.Roles, actualResult.Roles, new DeepPropertyCompare());
             service.Verify(m => m.UpdateUserAsync(It.IsAny<Entity.User>()), Times.Once());
         }
         #endregion

--- a/backend/test/Controllers/LookupControllerTest.cs
+++ b/backend/test/Controllers/LookupControllerTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Entity = Pims.Dal.Entities;
 using AutoMapper;
 using Pims.Api.Test.Helpers;
+using Pims.Core.Comparers;
 
 namespace Pims.Api.Test.Controllers
 {
@@ -49,9 +50,9 @@ namespace Pims.Api.Test.Controllers
             var result = controller.GetAgencies();
 
             // Assert
-            JsonResult actionResult = Assert.IsType<JsonResult>(result);
-            Model.CodeModel[] resultValue = Assert.IsType<Model.CodeModel[]>(actionResult.Value);
-            Assert.Equal(new[] { mapper.Map<Model.CodeModel>(agency) }, resultValue);
+            var actionResult = Assert.IsType<JsonResult>(result);
+            var actualResult = Assert.IsType<Model.CodeModel[]>(actionResult.Value);
+            Assert.Equal(new[] { mapper.Map<Model.CodeModel>(agency) }, actualResult, new DeepPropertyCompare());
             pimsService.Verify(m => m.Lookup.GetAgencies(), Times.Once());
         }
 
@@ -75,9 +76,9 @@ namespace Pims.Api.Test.Controllers
             var result = controller.GetPropertyClassifications();
 
             // Assert
-            JsonResult actionResult = Assert.IsType<JsonResult>(result);
-            Model.CodeModel[] resultValue = Assert.IsType<Model.CodeModel[]>(actionResult.Value);
-            Assert.Equal(new[] { mapper.Map<Model.CodeModel>(propertyClassification) }, resultValue);
+            var actionResult = Assert.IsType<JsonResult>(result);
+            var actualResult = Assert.IsType<Model.CodeModel[]>(actionResult.Value);
+            Assert.Equal(new[] { mapper.Map<Model.CodeModel>(propertyClassification) }, actualResult, new DeepPropertyCompare());
             pimsService.Verify(m => m.Lookup.GetPropertyClassifications(), Times.Once());
         }
 
@@ -103,9 +104,9 @@ namespace Pims.Api.Test.Controllers
             var result = controller.GetRoles();
 
             // Assert
-            JsonResult actionResult = Assert.IsType<JsonResult>(result);
-            Model.CodeModel[] resultValue = Assert.IsType<Model.CodeModel[]>(actionResult.Value);
-            Assert.Equal(new[] { mapper.Map<Model.CodeModel>(role) }, resultValue);
+            var actionResult = Assert.IsType<JsonResult>(result);
+            var actualResult = Assert.IsType<Model.CodeModel[]>(actionResult.Value);
+            Assert.Equal(new[] { mapper.Map<Model.CodeModel>(role) }, actualResult, new DeepPropertyCompare());
             pimsService.Verify(m => m.Lookup.GetRoles(), Times.Once());
         }
 
@@ -148,10 +149,10 @@ namespace Pims.Api.Test.Controllers
             var result = controller.GetAll();
 
             // Assert
-            JsonResult actionResult = Assert.IsType<JsonResult>(result); // TODO: Should not be testing all four functions.
-            JsonResult agencyAction = Assert.IsType<JsonResult>(agencyResult);
-            JsonResult roleAction = Assert.IsType<JsonResult>(roleResult);
-            JsonResult classificationAction = Assert.IsType<JsonResult>(classificationResult);
+            var actionResult = Assert.IsType<JsonResult>(result); // TODO: Should not be testing all four functions.
+            var agencyAction = Assert.IsType<JsonResult>(agencyResult);
+            var roleAction = Assert.IsType<JsonResult>(roleResult);
+            var classificationAction = Assert.IsType<JsonResult>(classificationResult);
 
             string allResult = JsonConvert.SerializeObject(actionResult.Value);
             string agenciesResult = JsonConvert.SerializeObject(agencyAction.Value);

--- a/backend/test/Controllers/ParcelControllerTest.cs
+++ b/backend/test/Controllers/ParcelControllerTest.cs
@@ -12,6 +12,7 @@ using Pims.Dal.Security;
 using System;
 using System.Collections.Generic;
 using Xunit;
+using Pims.Core.Comparers;
 
 namespace Pims.Api.Test.Controllers
 {
@@ -47,8 +48,8 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcels = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.PartialParcelModel[]>(parcels), actualParcels);
+            var actualResult = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.PartialParcelModel[]>(parcels), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(filter), Times.Once());
         }
 
@@ -71,8 +72,8 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcels = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.PartialParcelModel[]>(parcels), actualParcels);
+            var actualResult = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.PartialParcelModel[]>(parcels), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(filter), Times.Once());
         }
 
@@ -98,8 +99,8 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcels = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.PartialParcelModel[]>(parcels), actualParcels);
+            var actualResult = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.PartialParcelModel[]>(parcels), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(filter), Times.Once());
         }
 
@@ -125,8 +126,8 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcels = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.PartialParcelModel[]>(parcels), actualParcels);
+            var actualResult = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.PartialParcelModel[]>(parcels), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(filter), Times.Once());
         }
 
@@ -147,8 +148,8 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcels = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
-            Assert.Empty(actualParcels);
+            var actualResult = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
+            Assert.Empty(actualResult);
             service.Verify(m => m.Parcel.Get(filter), Times.Once());
         }
 
@@ -176,9 +177,9 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcels = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
+            var actualResult = Assert.IsType<Model.PartialParcelModel[]>(actionResult.Value);
             var expectedParcels = mapper.Map<Model.PartialParcelModel[]>(parcels);
-            Assert.Equal(expectedParcels, actualParcels);
+            Assert.Equal(expectedParcels, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Once());
         }
 
@@ -257,8 +258,8 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcelDetail = Assert.IsType<Model.ParcelModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.ParcelModel>(expectedTestParcel), actualParcelDetail);
+            var actualResult = Assert.IsType<Model.ParcelModel>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.ParcelModel>(expectedTestParcel), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(expectedParcelId), Times.Once());
         }
         #endregion
@@ -308,7 +309,7 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcel = Assert.IsType<Model.ParcelModel>(actionResult.Value);
+            var actualResult = Assert.IsType<Model.ParcelModel>(actionResult.Value);
             service.Verify(m => m.Parcel.Update(It.IsAny<Entity.Parcel>()), Times.Once());
         }
         #endregion
@@ -333,8 +334,8 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             Assert.Null(actionResult.StatusCode);
-            var actualParcel = Assert.IsType<Model.ParcelModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.ParcelModel>(parcel), actualParcel);
+            var actualResult = Assert.IsType<Model.ParcelModel>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.ParcelModel>(parcel), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Remove(It.IsAny<Entity.Parcel>()), Times.Once());
         }
         #endregion

--- a/backend/test/Controllers/PropertyControllerTest.cs
+++ b/backend/test/Controllers/PropertyControllerTest.cs
@@ -12,6 +12,7 @@ using Pims.Dal.Security;
 using System;
 using System.Linq;
 using Xunit;
+using Pims.Core.Comparers;
 
 namespace Pims.Api.Test.Controllers
 {
@@ -57,9 +58,9 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualProperties = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedProperties = mapper.Map<Model.PropertyModel[]>(parcels).Concat(mapper.Map<Model.PropertyModel[]>(buildings));
-            Assert.Equal(expectedProperties, actualProperties);
+            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
+            var expectedResult = mapper.Map<Model.PropertyModel[]>(parcels).Concat(mapper.Map<Model.PropertyModel[]>(buildings));
+            Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Once());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), Times.Once());
         }
@@ -90,9 +91,9 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualProperties = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedProperties = mapper.Map<Model.PropertyModel[]>(parcels).Concat(mapper.Map<Model.PropertyModel[]>(buildings));
-            Assert.Equal(expectedProperties, actualProperties);
+            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
+            var expectedResult = mapper.Map<Model.PropertyModel[]>(parcels).Concat(mapper.Map<Model.PropertyModel[]>(buildings));
+            Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Once());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), Times.Once());
         }
@@ -121,9 +122,9 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualProperties = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedProperties = mapper.Map<Model.PropertyModel[]>(parcels);
-            Assert.Equal(expectedProperties, actualProperties);
+            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
+            var expectedResult = mapper.Map<Model.PropertyModel[]>(parcels);
+            Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Once());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), Times.Never());
         }
@@ -152,9 +153,9 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualProperties = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedProperties = mapper.Map<Model.PropertyModel[]>(buildings);
-            Assert.Equal(expectedProperties, actualProperties);
+            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
+            var expectedResult = mapper.Map<Model.PropertyModel[]>(buildings);
+            Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Never());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), Times.Once());
         }
@@ -183,9 +184,9 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualProperties = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedProperties = mapper.Map<Model.PropertyModel[]>(parcels);
-            Assert.Equal(expectedProperties, actualProperties);
+            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
+            var expectedResult = mapper.Map<Model.PropertyModel[]>(parcels);
+            Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Once());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), Times.Once());
         }

--- a/backend/test/Helpers/EntityHelper.cs
+++ b/backend/test/Helpers/EntityHelper.cs
@@ -100,5 +100,73 @@ namespace Pims.Api.Test.Helpers
                 RowVersion = new byte[] { 12, 13, 14 }
             };
         }
+
+        /// <summary>
+        /// Create a new instance of an AccessRequest for a default user.
+        /// </summary>
+        /// <returns></returns>
+        public static Entity.AccessRequest CreateAccessRequest()
+        {
+            return CreateAccessRequest(Guid.NewGuid());
+        }
+
+        /// <summary>
+        /// Create a new instance of an AccessRequest for a default user.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public static Entity.AccessRequest CreateAccessRequest(Guid id)
+        {
+            var user = new Entity.User
+            {
+                Id = Guid.NewGuid(),
+                Username = "test",
+                FirstName = "first",
+                LastName = "last",
+                DisplayName = "TEST",
+                Email = "test@test.ca"
+            };
+
+            return CreateAccessRequest(id, user);
+        }
+
+        /// <summary>
+        /// Create a new instance of an AccessRequest for the specified user.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="user"></param>
+        /// <returns></returns>
+        public static Entity.AccessRequest CreateAccessRequest(Guid id, Entity.User user)
+        {
+            var accessRequest = new Entity.AccessRequest()
+            {
+                Id = id,
+                UserId = user.Id,
+                User = user
+            };
+
+            accessRequest.Agencies.Add(new Entity.AccessRequestAgency()
+            {
+                AgencyId = 1,
+                Agency = new Entity.Agency()
+                {
+                    Id = 1
+                },
+                AccessRequestId = id
+            });
+
+            var roleId = Guid.NewGuid();
+            accessRequest.Roles.Add(new Entity.AccessRequestRole()
+            {
+                RoleId = roleId,
+                Role = new Entity.Role()
+                {
+                    Id = roleId
+                },
+                AccessRequestId = id
+            });
+
+            return accessRequest;
+        }
     }
 }

--- a/backend/test/Helpers/PimsAssert.cs
+++ b/backend/test/Helpers/PimsAssert.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Pims.Api.Policies;
+using Pims.Core.Comparers;
 using Pims.Dal.Security;
 using Xunit;
 
@@ -176,6 +177,28 @@ namespace Pims.Api.Test.Helpers
             var attribute = endpoint?.GetCustomAttribute<HasPermissionAttribute>();
             Assert.NotNull(attribute);
             attribute?.HasPermissions(permissions);
+        }
+
+        /// <summary>
+        /// Does a deep compare of the two objects public properties.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="expected"></param>
+        /// <param name="actual"></param>
+        public static void DeepPropertyEqual<T>(T expected, T actual)
+        {
+            Assert.Equal(expected, actual, new DeepPropertyCompare<T>());
+        }
+
+        /// <summary>
+        /// Does a shallow compare of the two objects public properties.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="expected"></param>
+        /// <param name="actual"></param>
+        public static void ShallowPropertyEqual<T>(T expected, T actual)
+        {
+            Assert.Equal(expected, actual, new ShallowPropertyCompare<T>());
         }
     }
 }

--- a/backend/test/Helpers/PrincipalHelper.cs
+++ b/backend/test/Helpers/PrincipalHelper.cs
@@ -15,12 +15,12 @@ namespace Pims.Api.Test.Helpers
         /// </summary>
         /// <param name="role"></param>
         /// <returns></returns>
-        public static ClaimsPrincipal CreateForRole(string role)
+        public static ClaimsPrincipal CreateForRole(string role = null)
         {
             var user = new ClaimsPrincipal(new ClaimsIdentity(new System.Security.Claims.Claim[]
             {
                 new System.Security.Claims.Claim (ClaimTypes.NameIdentifier, Guid.NewGuid ().ToString ()),
-                    new System.Security.Claims.Claim (ClaimTypes.Role, role)
+                    new System.Security.Claims.Claim (ClaimTypes.Role, role ?? "none")
             }, "mock"));
 
             return user;

--- a/backend/test/Pims.Api.Test.csproj
+++ b/backend/test/Pims.Api.Test.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="NExpect" Version="1.0.168" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />


### PR DESCRIPTION
We shouldn't be adding code to models to support unit tests.  I've removed `IEquatable` from every model.  If at some point the application itself requires the ability to compare two models I would suggest creating a custom `IEqualityComparer`, but it won't hurt to use `IEquatable` for those specific occurrences.

Additionally I have created two custom IEqualityComparer's (`ShallowPropertyCompare`, and `DeepPropertyCompare`).  These provided the basic tests that we were using `IEquatable` for, without all the overhead.

Sorry again for the large PR, but it doesn't make sense to do 10 PRs for the same effort.