### PR TITLE
PIMS-1339 Including sub-agencies in filter

### DIFF
--- a/backend/dal/Services/Concrete/BuildingService.cs
+++ b/backend/dal/Services/Concrete/BuildingService.cs
@@ -88,7 +88,12 @@ namespace Pims.Dal.Services
                     b.Longitude >= filter.SWLongitude);
 
             if (filter.Agencies?.Any() == true)
-                query = query.Where(b => filter.Agencies.Contains(b.AgencyId));
+            {
+                // Get list of sub-agencies for any agency selected in the filter.
+                var agencies = filter.Agencies.Concat(this.Context.Agencies.AsNoTracking().Where(a => filter.Agencies.Contains(a.Id)).SelectMany(a => a.Children.Select(ac => ac.Id)).ToArray()).Distinct();
+                query = query.Where(p => agencies.Contains(p.AgencyId));
+            }
+
             if (filter.ConstructionTypeId.HasValue)
                 query = query.Where(b => b.BuildingConstructionTypeId == filter.ConstructionTypeId);
             if (filter.PredominateUseId.HasValue)

--- a/backend/dal/Services/Concrete/ParcelService.cs
+++ b/backend/dal/Services/Concrete/ParcelService.cs
@@ -84,7 +84,12 @@ namespace Pims.Dal.Services
                     p.Longitude >= filter.SWLongitude);
 
             if (filter.Agencies?.Any() == true)
-                query = query.Where(p => filter.Agencies.Contains(p.AgencyId));
+            {
+                // Get list of sub-agencies for any agency selected in the filter.
+                var agencies = filter.Agencies.Concat(this.Context.Agencies.AsNoTracking().Where(a => filter.Agencies.Contains(a.Id)).SelectMany(a => a.Children.Select(ac => ac.Id)).ToArray()).Distinct();
+                query = query.Where(p => agencies.Contains(p.AgencyId));
+            }
+
             if (filter.ClassificationId.HasValue)
                 query = query.Where(p => p.ClassificationId == filter.ClassificationId);
             if (filter.StatusId.HasValue)

--- a/backend/test/Controllers/Admin/UserControllerTest.cs
+++ b/backend/test/Controllers/Admin/UserControllerTest.cs
@@ -26,7 +26,7 @@ namespace PimsApi.Test.Admin.Controllers
         #endregion
 
         #region Tests
-        #region AddAccessRequest
+        #region GetAccessRequests
         [Fact]
         public void GetAccessRequests_Success()
         {
@@ -47,6 +47,7 @@ namespace PimsApi.Test.Admin.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
             var actualResult = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
             Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(accessRequests), actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.User.GetAccessRequests(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool?>()), Times.Once());
@@ -72,6 +73,7 @@ namespace PimsApi.Test.Admin.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
             var actualResult = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
             Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(accessRequests), actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.User.GetAccessRequests(1, 1, null, null), Times.Once());
@@ -97,6 +99,7 @@ namespace PimsApi.Test.Admin.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
             var actualResult = Assert.IsType<Entity.Models.Paged<Model.AccessRequestModel>>(actionResult.Value);
             Assert.Equal(mapper.Map<Model.AccessRequestModel[]>(accessRequests), actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.User.GetAccessRequests(2, 20, null, null), Times.Once());
@@ -122,6 +125,59 @@ namespace PimsApi.Test.Admin.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
+            var actualResult = Assert.IsType<Entity.Models.Paged<Model.UserModel>>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.UserModel[]>(users), actualResult.Items, new DeepPropertyCompare());
+            service.Verify(m => m.User.Get(It.IsAny<Entity.Models.UserFilter>()), Times.Once());
+        }
+
+        [Fact]
+        public void GetUsers_Filtered_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<UserController>(Permissions.AdminUsers);
+
+            var mapper = helper.GetService<IMapper>();
+            var service = helper.GetService<Mock<IPimsAdminService>>();
+            var users = new Entity.User[] { EntityHelper.CreateUser("user1"), EntityHelper.CreateUser("user2") };
+            var paged = new Entity.Models.Paged<Entity.User>(users);
+            var filter = new Entity.Models.UserFilter(1, 1, 1, "test", "test", "test", "test", "test", null);
+            service.Setup(m => m.User.Get(It.IsAny<Entity.Models.UserFilter>())).Returns(paged);
+
+            // Act
+            var result = controller.GetUsers(filter);
+
+            // Assert
+            var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
+            var actualResult = Assert.IsType<Entity.Models.Paged<Model.UserModel>>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.UserModel[]>(users), actualResult.Items, new DeepPropertyCompare());
+            service.Verify(m => m.User.Get(It.IsAny<Entity.Models.UserFilter>()), Times.Once());
+        }
+        #endregion
+
+        #region GetMyUsers
+        [Fact]
+        public void GetMyUsers_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<UserController>(Permissions.AdminUsers);
+
+            var mapper = helper.GetService<IMapper>();
+            var service = helper.GetService<Mock<IPimsAdminService>>();
+            var users = new Entity.User[] { EntityHelper.CreateUser("user1"), EntityHelper.CreateUser("user2") };
+            var paged = new Entity.Models.Paged<Entity.User>(users);
+            var filter = new Entity.Models.UserFilter(1, 1, 1, "test", "test", "test", "test", "test", null);
+            service.Setup(m => m.User.Get(It.IsAny<Entity.Models.UserFilter>())).Returns(paged);
+
+            // Act
+            var result = controller.GetMyUsers(filter);
+
+            // Assert
+            var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
             var actualResult = Assert.IsType<Entity.Models.Paged<Model.UserModel>>(actionResult.Value);
             Assert.Equal(mapper.Map<Model.UserModel[]>(users), actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.User.Get(It.IsAny<Entity.Models.UserFilter>()), Times.Once());
@@ -146,9 +202,88 @@ namespace PimsApi.Test.Admin.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
             var actualResult = Assert.IsType<Model.UserModel>(actionResult.Value);
             Assert.Equal(mapper.Map<Model.UserModel>(user), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.User.Get(user.Id), Times.Once());
+        }
+        #endregion
+
+        #region AddUser
+        [Fact]
+        public void AddUser()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<UserController>(Permissions.AdminUsers);
+
+            var mapper = helper.GetService<IMapper>();
+            var service = helper.GetService<Mock<IPimsAdminService>>();
+            var user = EntityHelper.CreateUser("user1");
+            service.Setup(m => m.User.Add(It.IsAny<Entity.User>())).Returns(user);
+            var model = mapper.Map<Model.UserModel>(user);
+
+            // Act
+            var result = controller.AddUser(model);
+
+            // Assert
+            var actionResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(201, actionResult.StatusCode);
+            var actualResult = Assert.IsType<Model.UserModel>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.UserModel>(user), actualResult, new DeepPropertyCompare());
+            service.Verify(m => m.User.Add(It.IsAny<Entity.User>()), Times.Once());
+        }
+        #endregion
+
+        #region UpdateUser
+        [Fact]
+        public void UpdateUser()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<UserController>(Permissions.AdminUsers);
+
+            var mapper = helper.GetService<IMapper>();
+            var service = helper.GetService<Mock<IPimsAdminService>>();
+            var user = EntityHelper.CreateUser("user1");
+            service.Setup(m => m.User.Update(It.IsAny<Entity.User>())).Returns(user);
+            var model = mapper.Map<Model.UserModel>(user);
+
+            // Act
+            var result = controller.UpdateUser(user.Id, model);
+
+            // Assert
+            var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
+            var actualResult = Assert.IsType<Model.UserModel>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.UserModel>(user), actualResult, new DeepPropertyCompare());
+            service.Verify(m => m.User.Update(It.IsAny<Entity.User>()), Times.Once());
+        }
+        #endregion
+
+        #region DeleteUser
+        [Fact]
+        public void DeleteUser()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<UserController>(Permissions.AdminUsers);
+
+            var mapper = helper.GetService<IMapper>();
+            var service = helper.GetService<Mock<IPimsAdminService>>();
+            var user = EntityHelper.CreateUser("user1");
+            service.Setup(m => m.User.Remove(It.IsAny<Entity.User>()));
+            var model = mapper.Map<Model.UserModel>(user);
+
+            // Act
+            var result = controller.DeleteUser(user.Id, model);
+
+            // Assert
+            var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
+            var actualResult = Assert.IsType<Model.UserModel>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.UserModel>(user), actualResult, new DeepPropertyCompare());
+            service.Verify(m => m.User.Remove(It.IsAny<Entity.User>()), Times.Once());
         }
         #endregion
         #endregion

--- a/backend/test/Controllers/Keycloak/UserControllerTest.cs
+++ b/backend/test/Controllers/Keycloak/UserControllerTest.cs
@@ -5,13 +5,13 @@ using Model = Pims.Api.Areas.Keycloak.Models.User;
 using Moq;
 using Pims.Api.Areas.Keycloak.Controllers;
 using Pims.Api.Test.Helpers;
+using Pims.Core.Comparers;
 using Pims.Dal.Keycloak;
 using Pims.Dal.Security;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System;
 using Xunit;
-using Pims.Core.Comparers;
 
 namespace PimsApi.Test.Keycloak.Controllers
 {
@@ -143,6 +143,33 @@ namespace PimsApi.Test.Keycloak.Controllers
             Assert.Equal(expectedResult.Agencies, actualResult.Agencies, new DeepPropertyCompare());
             Assert.Equal(expectedResult.Roles, actualResult.Roles, new DeepPropertyCompare());
             service.Verify(m => m.UpdateUserAsync(It.IsAny<Entity.User>()), Times.Once());
+        }
+        #endregion
+
+        #region UpdateUserAsync
+        [Fact]
+        public async void UpdateAccessRequestAsync_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<UserController>(Permissions.AdminUsers);
+
+            var mapper = helper.GetService<IMapper>();
+            var service = helper.GetService<Mock<IPimsKeycloakService>>();
+            var accessRequest = EntityHelper.CreateAccessRequest();
+            service.Setup(m => m.UpdateAccessRequestAsync(It.IsAny<Entity.AccessRequest>())).Returns(Task.FromResult(accessRequest));
+            var model = mapper.Map<Model.AccessRequestModel>(accessRequest);
+
+            // Act
+            var result = await controller.UpdateAccessRequestAsync(model);
+
+            // Assert
+            var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
+            var actualResult = Assert.IsType<Model.AccessRequestModel>(actionResult.Value);
+            var expectedResult = mapper.Map<Model.AccessRequestModel>(accessRequest);
+            Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
+            service.Verify(m => m.UpdateAccessRequestAsync(It.IsAny<Entity.AccessRequest>()), Times.Once());
         }
         #endregion
         #endregion

--- a/backend/test/Routes/Keycloak/UserControllerTest.cs
+++ b/backend/test/Routes/Keycloak/UserControllerTest.cs
@@ -67,6 +67,18 @@ namespace Pims.Api.Test.Routes.Keycloak
         }
 
         [Fact]
+        public void GetUserAsync_Route()
+        {
+            // Arrange
+            var endpoint = typeof(UserController).FindMethod(nameof(UserController.GetUserAsync), typeof(Guid));
+
+            // Act
+            // Assert
+            Assert.NotNull(endpoint);
+            endpoint.HasGet("{id}");
+        }
+
+        [Fact]
         public void UpdateUserAsync_Route()
         {
             // Arrange


### PR DESCRIPTION
When making a request for properties with a parent agency it makes more sense to also include the sub-agencies.

This isn't technically a bug, but a user-experience issue.