### PR TITLE
Fix frontend container crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,19 +62,20 @@ services:
     depends_on:
       - database
       - keycloak
-    # volumes:
-    #   - $(AppData)/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
     networks:
       - pims
 
   ####################### Frontend #######################
   frontend:
+    stdin_open: true
+    tty: true
     restart: on-failure
     container_name: frontend-app
     build:
       context: frontend
     volumes:
-      - ./frontend/src/:/usr/app/src/
+      - ./frontend/src:/usr/app/src
+      - ./frontend/public:/usr/app/public
       - frontend-node-cache:/usr/app/node_modules
     ports:
       - "3000:3000"
@@ -83,18 +84,6 @@ services:
     env_file: ./frontend/.env
     networks:
       - pims
-
-  ####################### Local SMTP Server #######################
-  # mailhog:
-  #   container_name: mailhog
-  #   restart: always
-  #   image: mailhog/mailhog:latest
-  #   ports:
-  #     - 25:1025
-  #     - 1025:1025
-  #     - 8025:8025 # visit localhost:8025 to see the list of captured emails
-  #   networks:
-  #     - starter_kit
 
 ####################### Networks Definition #######################
 networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,13 @@
 FROM node:10-slim as node
 
-# Install build toolchain, install node deps and compile native add-ons
-RUN apt-get -yq update && apt-get -yq install make gcc g++ python --no-install-recommends
+# install build toolchain (for node-gyp)
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y dumb-init python build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# set entrypoint to `dumb-init` as it handles being pid 1 and forwarding signals
+# so that you dont need to bake that logic into your node app
+ENTRYPOINT ["dumb-init", "--"]
 
 WORKDIR /usr/app
 
@@ -10,7 +16,8 @@ RUN npm install -g npm@6.9.0
 
 COPY package*.json ./
 
-RUN npm ci --quiet
+RUN npm set progress=false \
+    && npm ci
 
 COPY . .
 


### PR DESCRIPTION
As of version 3.4.1, react-scripts exits after start-up which causes the container to exit.

```
Attaching to frontend-app
frontend-app   |
frontend-app   | > frontend@0.1.0 start /usr/app
frontend-app   | > react-scripts start
frontend-app   |
frontend-app   | [HPM] Proxy created: /  -> http://backend:8080/
frontend-app   | [HPM] Subscribed to http-proxy events: [ 'proxyReq', 'error', 'close' ]
frontend-app   | ℹ ｢wds｣: Project is running at http://172.19.0.6/
frontend-app   | ℹ ｢wds｣: webpack output is served from
frontend-app   | ℹ ｢wds｣: Content not from webpack is served from /usr/app/public
frontend-app   | ℹ ｢wds｣: 404s will fallback to /
frontend-app   | Starting the development server...
frontend-app   |
frontend-app exited with code 0
```

Turning on **interactive mode** resolves this. I also took the time to clean up our `Dockerfiles`.

More details here: facebook/create-react-app#8688

