### PR TITLE
Removing HealthCheckUI from API.

### DIFF
--- a/backend/api/Startup.cs
+++ b/backend/api/Startup.cs
@@ -167,7 +167,7 @@ namespace Pims.Api
                 .AddSqlServer(builder.ConnectionString, tags: new[] { "services" });
 
             //TODO: Add a health check for keycloak connectivity.
-            services.AddHealthChecksUI();
+            // services.AddHealthChecksUI();
 
             services.AddMvcCore()
                 .AddJsonOptions(options =>
@@ -275,18 +275,18 @@ namespace Pims.Api
             app.UseEndpoints(config =>
             {
                 config.MapControllers();
-                config.MapHealthChecksUI(
-                    setup =>
-                    {
-                        setup.UIPath = this.Configuration.GetValue<string>("HealthChecksUI:UIPath"); // this is ui path in your browser
-                        setup.ApiPath = this.Configuration.GetValue<string>("HealthChecksUI:ApiPath");
-                        setup.ResourcesPath = this.Configuration.GetValue<string>("HealthChecksUI:ResourcesPath");
-                        setup.WebhookPath = this.Configuration.GetValue<string>("HealthChecksUI:WebhookPath");
-                        setup.UseRelativeResourcesPath = this.Configuration.GetValue<bool>("HealthChecksUI:UseRelativeResourcesPath");
-                        setup.UseRelativeApiPath = this.Configuration.GetValue<bool>("HealthChecksUI:UseRelativeApiPath");
-                        setup.UseRelativeWebhookPath = this.Configuration.GetValue<bool>("HealthChecksUI:UseRelativeWebhookPath");
-                    }
-                );
+                // config.MapHealthChecksUI(
+                //     setup =>
+                //     {
+                //         setup.UIPath = this.Configuration.GetValue<string>("HealthChecksUI:UIPath"); // this is ui path in your browser
+                //         setup.ApiPath = this.Configuration.GetValue<string>("HealthChecksUI:ApiPath");
+                //         setup.ResourcesPath = this.Configuration.GetValue<string>("HealthChecksUI:ResourcesPath");
+                //         setup.WebhookPath = this.Configuration.GetValue<string>("HealthChecksUI:WebhookPath");
+                //         setup.UseRelativeResourcesPath = this.Configuration.GetValue<bool>("HealthChecksUI:UseRelativeResourcesPath");
+                //         setup.UseRelativeApiPath = this.Configuration.GetValue<bool>("HealthChecksUI:UseRelativeApiPath");
+                //         setup.UseRelativeWebhookPath = this.Configuration.GetValue<bool>("HealthChecksUI:UseRelativeWebhookPath");
+                //     }
+                // );
             });
         }
         #endregion

--- a/scripts/gen-env-files.sh
+++ b/scripts/gen-env-files.sh
@@ -66,7 +66,7 @@ echo \
 ASPNETCORE_URLS=http://*:8080
 DB_PASSWORD=$passvar
 Keycloak__Secret=
-Keycloak__ServiceAccount__Secret=" >> ./backend/.env
+Keycloak__ServiceAccount__Secret=" >> ./backend/api/.env
 fi
 
 if test -f "./frontend/.env"; then


### PR DESCRIPTION
HealthCheckUI is causing the API to fail.  As it is not a required dependency I am temporarily removing it.  A feature that is supposed to assist in the health of the API shouldn't be bringing down the API (regardless of why).  It should fail and let the API continue, but it doesn't.  It needs to be extracted and run on its own container.

I've also fixed our setup script that generates our `.env` files.