### PR TITLE
Fix /auth/activate endpoint

### DIFF
--- a/backend/dal/Helpers/Extensions/IdentityExtensions.cs
+++ b/backend/dal/Helpers/Extensions/IdentityExtensions.cs
@@ -47,6 +47,17 @@ namespace Pims.Dal.Helpers.Extensions
         }
 
         /// <summary>
+        /// Get the user's username.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <returns></returns>
+        public static string GetUsername(this ClaimsPrincipal user)
+        {
+            var value = user?.FindFirstValue("username");
+            return value;
+        }
+
+        /// <summary>
         /// Get the user's display name.
         /// </summary>
         /// <param name="user"></param>

--- a/backend/dal/Services/Concrete/UserService.cs
+++ b/backend/dal/Services/Concrete/UserService.cs
@@ -64,7 +64,7 @@ namespace Pims.Dal.Services
             var entity = this.Context.Users.Find(id);
             if (entity != null) return entity;
 
-            var username = this.User.GetFirstName() ?? _options.ServiceAccount?.Username ??
+            var username = this.User.GetUsername() ?? _options.ServiceAccount?.Username ??
                 throw new ConfigurationException($"Configuration 'Pims:ServiceAccount:Username' is invalid or missing.");
             var givenName = this.User.GetFirstName() ?? _options.ServiceAccount?.FirstName ??
                 throw new ConfigurationException($"Configuration 'Pims:ServiceAccount:FirstName' is invalid or missing.");


### PR DESCRIPTION
Currently when activating users it uses their first name as their username.  This isn't correct and will lead to issues where users have the same first name.

This fix correctly applies their username to their account.