### PR TITLE
PIMS-1541 Adding Excel Export Report

### DIFF
--- a/backend/api/Areas/Property/Controllers/SearchController.cs
+++ b/backend/api/Areas/Property/Controllers/SearchController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Pims.Api.Helpers.Exceptions;
 using Pims.Api.Helpers.Extensions;
 using Pims.Api.Models;
-using Pims.Api.Models.Property;
+using Pims.Api.Areas.Property.Models.Search;
 using Pims.Api.Policies;
 using Pims.Dal;
 using Pims.Dal.Entities.Models;
@@ -14,17 +14,18 @@ using Swashbuckle.AspNetCore.Annotations;
 using System;
 using System.Collections.Generic;
 
-namespace Pims.Api.Controllers
+namespace Pims.Api.Areas.Property.Controllers
 {
     /// <summary>
-    /// PropertyController class, provides endpoints for searching properties.
+    /// SearchController class, provides endpoints for searching properties.
     /// </summary>
     [Authorize]
     [ApiController]
     [ApiVersion("1.0")]
-    [Route("v{version:apiVersion}/properties")]
-    [Route("properties")]
-    public class PropertyController : ControllerBase
+    [Area("properties")]
+    [Route("v{version:apiVersion}/[area]/search")]
+    [Route("[area]/search")]
+    public class SearchController : ControllerBase
     {
         #region Variables
         private readonly IPimsService _pimsService;
@@ -33,11 +34,11 @@ namespace Pims.Api.Controllers
 
         #region Constructors
         /// <summary>
-        /// Creates a new instance of a PropertyController class, initializes it with the specified arguments.
+        /// Creates a new instance of a SearchController class, initializes it with the specified arguments.
         /// </summary>
         /// <param name="pimsService"></param>
         /// <param name="mapper"></param>
-        public PropertyController(IPimsService pimsService, IMapper mapper)
+        public SearchController(IPimsService pimsService, IMapper mapper)
         {
             _pimsService = pimsService;
             _mapper = mapper;
@@ -87,7 +88,7 @@ namespace Pims.Api.Controllers
         }
         #endregion
 
-        #region Property List View Endpoints
+        #region Property Paging Endpoints
         /// <summary>
         /// Get all the properties that satisfy the filter parameters.
         /// </summary>

--- a/backend/api/Areas/Property/Mapping/Search/PropertyMap.cs
+++ b/backend/api/Areas/Property/Mapping/Search/PropertyMap.cs
@@ -1,6 +1,7 @@
 using Mapster;
-using Model = Pims.Api.Models.Property;
+using Model = Pims.Api.Areas.Property.Models.Search;
 using Entity = Pims.Dal.Entities;
+using Pims.Dal.Entities;
 
 namespace Pims.Api.Mapping.Property
 {
@@ -9,7 +10,7 @@ namespace Pims.Api.Mapping.Property
         public void Register(TypeAdapterConfig config)
         {
             config.NewConfig<Entity.Parcel, Model.PropertyModel>()
-                .Map(dest => dest.PropertyTypeId, src => 0)
+                .Map(dest => dest.PropertyTypeId, src => PropertyTypes.Land)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.PID, src => src.ParcelIdentity)
                 .Map(dest => dest.PIN, src => src.PIN)
@@ -20,7 +21,7 @@ namespace Pims.Api.Mapping.Property
                 .Map(dest => dest.Longitude, src => src.Longitude);
 
             config.NewConfig<Entity.Building, Model.PropertyModel>()
-                .Map(dest => dest.PropertyTypeId, src => 1)
+                .Map(dest => dest.PropertyTypeId, src => PropertyTypes.Building)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.PID, src => src.Parcel == null ? null : src.Parcel.ParcelIdentity)
                 .Map(dest => dest.PIN, src => src.Parcel == null ? null : src.Parcel.PIN)

--- a/backend/api/Areas/Property/Models/Search/PropertyFilterModel.cs
+++ b/backend/api/Areas/Property/Models/Search/PropertyFilterModel.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Pims.Core.Extensions;
 using Pims.Dal.Entities.Models;
 
-namespace Pims.Api.Models.Property
+namespace Pims.Api.Areas.Property.Models.Search
 {
     /// <summary>
     /// PropertyFilterModel class, provides a model to contain the parcel and building filters.

--- a/backend/api/Areas/Property/Models/Search/PropertyModel.cs
+++ b/backend/api/Areas/Property/Models/Search/PropertyModel.cs
@@ -1,6 +1,5 @@
-namespace Pims.Api.Models.Property
+namespace Pims.Api.Areas.Property.Models.Search
 {
-
     public class PropertyModel
     {
         #region Properties

--- a/backend/api/Areas/Reports/Controllers/PropertyController.cs
+++ b/backend/api/Areas/Reports/Controllers/PropertyController.cs
@@ -1,0 +1,105 @@
+using MapsterMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Pims.Api.Helpers.Exceptions;
+using Pims.Api.Helpers.Extensions;
+using Pims.Api.Helpers.Reporting;
+using Pims.Api.Areas.Reports.Models.Property;
+using Pims.Api.Policies;
+using Pims.Dal;
+using Pims.Dal.Entities.Models;
+using Pims.Dal.Security;
+using Swashbuckle.AspNetCore.Annotations;
+using System;
+using Pims.Api.Helpers.Constants;
+
+namespace Pims.Api.Areas.Reports.Controllers
+{
+    /// <summary>
+    /// ReportController class, provides endpoints for generating reports.
+    /// </summary>
+    [Authorize]
+    [ApiController]
+    [Area("reports")]
+    [ApiVersion("1.0")]
+    [Route("v{version:apiVersion}/[area]/properties")]
+    [Route("[area]/properties")]
+    public class PropertyController : ControllerBase
+    {
+        #region Variables
+        private readonly IPimsService _pimsService;
+        private readonly IMapper _mapper;
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Creates a new instance of a ReportController class, initializes it with the specified arguments.
+        /// </summary>
+        /// <param name="pimsService"></param>
+        /// <param name="mapper"></param>
+        public PropertyController(IPimsService pimsService, IMapper mapper)
+        {
+            _pimsService = pimsService;
+            _mapper = mapper;
+        }
+        #endregion
+
+        #region Endpoints
+        #region Export Properties
+        /// <summary>
+        /// Exports properties as CSV or Excel file.
+        /// Include 'Accept' header to request the appropriate expor -
+        ///     ["text/csv", "application/application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"]
+        /// </summary>
+        /// <param name="all"></param>
+        /// <returns></returns>
+        [HttpGet]
+        [HasPermission(Permissions.PropertyView)]
+        [Produces(ContentTypes.CONTENT_TYPE_CSV, ContentTypes.CONTENT_TYPE_EXCELX)]
+        [ProducesResponseType(200)]
+        [SwaggerOperation(Tags = new[] { "property", "report" })]
+        public IActionResult ExportProperties(bool all = false)
+        {
+            var uri = new Uri(this.Request.GetDisplayUrl());
+            var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+            return ExportProperties(new Property.Models.Search.PropertyFilterModel(query), all);
+        }
+
+        /// <summary>
+        /// Exports properties as CSV or Excel file.
+        /// Include 'Accept' header to request the appropriate expor -
+        ///     ["text/csv", "application/application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"]
+        /// </summary>
+        /// <param name="filter"></param>
+        /// <param name="all"></param>
+        /// <returns></returns>
+        [HttpPost("filter")]
+        [HasPermission(Permissions.PropertyView)]
+        [Produces(ContentTypes.CONTENT_TYPE_CSV, ContentTypes.CONTENT_TYPE_EXCELX)]
+        [ProducesResponseType(200)]
+        [SwaggerOperation(Tags = new[] { "property", "report" })]
+        public IActionResult ExportProperties([FromBody]Property.Models.Search.PropertyFilterModel filter, bool all = false)
+        {
+            filter.ThrowBadRequestIfNull($"The request must include a filter.");
+            if (!filter.IsValid()) throw new BadRequestException("Property filter must contain valid values.");
+            var accept = (string)this.Request.Headers["Accept"] ?? throw new BadRequestException($"HTTP request header 'Accept' is required.");
+
+            if (accept != ContentTypes.CONTENT_TYPE_CSV && accept != ContentTypes.CONTENT_TYPE_EXCEL && accept != ContentTypes.CONTENT_TYPE_EXCELX)
+                throw new BadRequestException($"Invalid HTTP request header 'Accept:{accept}'.");
+
+            filter.Quantity = all ? _pimsService.Property.Count() : filter.Quantity;
+            var page = _pimsService.Property.GetPage((AllPropertyFilter)filter);
+            var report = _mapper.Map<Api.Models.PageModel<PropertyModel>>(page);
+
+            return accept.ToString() switch
+            {
+                ContentTypes.CONTENT_TYPE_CSV => ReportHelper.GenerateCsv(report.Items),
+                _ => ReportHelper.GenerateExcel(report.Items)
+            };
+
+        }
+        #endregion
+        #endregion
+    }
+}

--- a/backend/api/Areas/Reports/Mapping/Property/PropertyMap.cs
+++ b/backend/api/Areas/Reports/Mapping/Property/PropertyMap.cs
@@ -1,0 +1,47 @@
+using Mapster;
+using Entity = Pims.Dal.Entities;
+using Model = Pims.Api.Areas.Reports.Models.Property;
+
+namespace Pims.Api.Areas.Reports.Mapping.Property
+{
+    public class PropertyMap : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<Entity.Views.Property, Model.PropertyModel>()
+                .Map(dest => dest.Type, src => src.PropertyTypeId)
+                .Map(dest => dest.Status, src => src.Status)
+                .Map(dest => dest.Classification, src => src.Classification)
+                .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.Agency, src => src.Agency)
+                .Map(dest => dest.Address, src => src.Address)
+                .Map(dest => dest.City, src => src.City)
+                .Map(dest => dest.Postal, src => src.Postal)
+                .Map(dest => dest.Latitude, src => src.Latitude)
+                .Map(dest => dest.Longitude, src => src.Longitude)
+                .Map(dest => dest.IsSensitive, src => src.IsSensitive)
+
+                .Map(dest => dest.Assessed, src => src.Assessed)
+                .Map(dest => dest.Estimated, src => src.Estimated)
+
+                .Map(dest => dest.PID, src => src.ParcelIdentity)
+                .Map(dest => dest.PIN, src => src.PIN)
+                .Map(dest => dest.LandArea, src => src.LandArea)
+                .Map(dest => dest.LandLegalDescription, src => src.LandLegalDescription)
+                .Map(dest => dest.Municipality, src => src.Municipality)
+                .Map(dest => dest.Zoning, src => src.Zoning)
+                .Map(dest => dest.ZoningPotential, src => src.ZoningPotential)
+
+                .Map(dest => dest.LocalId, src => src.LocalId)
+                .Map(dest => dest.BuildingConstructionType, src => src.BuildingConstructionType)
+                .Map(dest => dest.BuildingPredominateUse, src => src.BuildingPredominateUse)
+                .Map(dest => dest.BuildingOccupantType, src => src.BuildingOccupantType)
+                .Map(dest => dest.BuildingTenancy, src => src.BuildingTenancy)
+                .Map(dest => dest.RentableArea, src => src.RentableArea)
+                .Map(dest => dest.OccupantName, src => src.OccupantName)
+                .Map(dest => dest.LeaseExpiry, src => src.LeaseExpiry)
+                .Map(dest => dest.TransferLeaseOnSale, src => src.TransferLeaseOnSale);
+
+        }
+    }
+}

--- a/backend/api/Areas/Reports/Models/Property/PropertyModel.cs
+++ b/backend/api/Areas/Reports/Models/Property/PropertyModel.cs
@@ -1,0 +1,48 @@
+using Pims.Dal.Entities;
+using System;
+
+namespace Pims.Api.Areas.Reports.Models.Property
+{
+    public class PropertyModel
+    {
+        #region Properties
+        public PropertyTypes Type { get; set; }
+        public string Status { get; set; }
+        public string Classification { get; set; }
+        public string Description { get; set; }
+        public string Agency { get; set; }
+        public string Address { get; set; }
+        public string City { get; set; }
+        public string Postal { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+        public bool IsSensitive { get; set; }
+
+        public decimal Assessed { get; set; }
+        public decimal Estimated { get; set; }
+
+
+        #region Parcel Properties
+        public string PID { get; set; }
+        public int? PIN { get; set; }
+        public float LandArea { get; set; }
+        public string LandLegalDescription { get; set; }
+        public string Municipality { get; set; }
+        public string Zoning { get; set; }
+        public string ZoningPotential { get; set; }
+        #endregion
+
+        #region Building Properties
+        public string LocalId { get; set; }
+        public string BuildingConstructionType { get; set; }
+        public string BuildingPredominateUse { get; set; }
+        public string BuildingOccupantType { get; set; }
+        public string BuildingTenancy { get; set; }
+        public float RentableArea { get; set; }
+        public string OccupantName { get; set; }
+        public DateTime? LeaseExpiry { get; set; }
+        public bool TransferLeaseOnSale { get; set; }
+        #endregion
+        #endregion
+    }
+}

--- a/backend/api/Controllers/LookupController.cs
+++ b/backend/api/Controllers/LookupController.cs
@@ -1,7 +1,6 @@
 using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Model = Pims.Api.Models;
 using Pims.Dal;
 using System.Linq;
@@ -22,7 +21,6 @@ namespace Pims.Api.Controllers
     public class LookupController : ControllerBase
     {
         #region Variables
-        private readonly ILogger<LookupController> _logger;
         private readonly IPimsService _pimsService;
         private readonly IMapper _mapper;
         #endregion
@@ -31,12 +29,10 @@ namespace Pims.Api.Controllers
         /// <summary>
         /// Creates a new instance of a LookupController class.
         /// </summary>
-        /// <param name="logger"></param>
         /// <param name="pimsService"></param>
         /// <param name="mapper"></param>
-        public LookupController(ILogger<LookupController> logger, IPimsService pimsService, IMapper mapper)
+        public LookupController(IPimsService pimsService, IMapper mapper)
         {
-            _logger = logger;
             _pimsService = pimsService;
             _mapper = mapper;
         }

--- a/backend/api/Helpers/Constants/ContentTypes.cs
+++ b/backend/api/Helpers/Constants/ContentTypes.cs
@@ -1,0 +1,14 @@
+namespace Pims.Api.Helpers.Constants
+{
+    /// <summary>
+    /// ContentTypes static class, provides constant values for Content-Type.
+    /// </summary>
+    public static class ContentTypes
+    {
+        #region Properties
+        public const string CONTENT_TYPE_CSV = "text/csv";
+        public const string CONTENT_TYPE_EXCEL = "application/vnd.ms-excel";
+        public const string CONTENT_TYPE_EXCELX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+        #endregion
+    }
+}

--- a/backend/api/Helpers/Reporting/ReportHelper.cs
+++ b/backend/api/Helpers/Reporting/ReportHelper.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Mvc;
+using Pims.Api.Helpers.Constants;
+using Pims.Core.Helpers;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Pims.Api.Helpers.Reporting
+{
+    /// <summary>
+    /// ReportHelper static class, provides helper functions to generate reports.
+    /// </summary>
+    public static class ReportHelper
+    {
+        #region Methods
+        /// <summary>
+        /// Generates a CSV file for the specified 'items'.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items"></param>
+        /// <returns></returns>
+        public static ContentResult GenerateCsv<T>(IEnumerable<T> items)
+        {
+            var csv = items.ConvertToCSV();
+            var result = new ContentResult
+            {
+                Content = csv,
+                ContentType = ContentTypes.CONTENT_TYPE_CSV
+            };
+            return result;
+        }
+
+        /// <summary>
+        /// Generates an Excel document for the specified 'items'.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items"></param>
+        /// <returns></returns>
+        public static FileStreamResult GenerateExcel<T>(IEnumerable<T> items)
+        {
+            var data = items.ConvertToDataTable();
+            var excel = data.ConvertToXLWorkbook("Properties");
+            var stream = new MemoryStream();
+            excel.SaveAs(stream);
+            stream.Position = 0;
+
+            return new FileStreamResult(stream, ContentTypes.CONTENT_TYPE_EXCELX);
+        }
+        #endregion
+    }
+}

--- a/backend/core/Helpers/CsvHelper.cs
+++ b/backend/core/Helpers/CsvHelper.cs
@@ -1,0 +1,66 @@
+using CsvHelper;
+using CsvHelper.Configuration;
+using Pims.Core.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.IO;
+
+namespace Pims.Core.Helpers
+{
+    /// <summary>
+    /// CsvHelper static class, provides helper methods to generate CSV data.
+    /// </summary>
+    public static class CsvHelper
+    {
+        /// <summary>
+        /// Converts the specified 'data' into a CSV string.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="data"></param>
+        /// <param name="delimiter"></param>
+        /// <returns></returns>
+        public static string ConvertToCSV<T>(this IEnumerable<T> data, string delimiter = ",")
+        {
+            using var writer = new StringWriter();
+            var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+            {
+                IgnoreBlankLines = true,
+                Delimiter = delimiter,
+            };
+            using var csvWriter = new CsvWriter(writer, config);
+            csvWriter.WriteRecords(data);
+            return writer.ToString();
+        }
+
+        /// <summary>
+        /// Converts the specified 'data' into a DataTable.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static DataTable ConvertToDataTable<T>(this IEnumerable<T> data)
+        {
+            var csv = data.ConvertToCSV().Replace(",,", ",\"\",");
+            using var stringReader = new StringReader(csv);
+            using var reader = new CsvReader(stringReader, CultureInfo.InvariantCulture);
+            // Configure the CsvReader before creating the CsvDataReader.
+            using var dataReader = new CsvDataReader(reader);
+            var dt = new DataTable();
+
+            var properties = typeof(T).GetCachedProperties();
+            properties.ForEach(p =>
+            {
+                var isNullable = p.PropertyType.IsGenericType && p.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>);
+                var type = isNullable ? Nullable.GetUnderlyingType(p.PropertyType) : p.PropertyType;
+                if (type.IsEnum || isNullable) type = typeof(string); // Need to do this because enums are converted to strings.
+                dt.Columns.Add(new DataColumn(p.Name, type) { AllowDBNull = isNullable });
+            });
+
+            dt.Load(dataReader);
+
+            return dt;
+        }
+    }
+}

--- a/backend/core/Helpers/XmlHelper.cs
+++ b/backend/core/Helpers/XmlHelper.cs
@@ -1,0 +1,25 @@
+using ClosedXML.Excel;
+using System.Data;
+
+namespace Pims.Core.Helpers
+{
+    /// <summary>
+    /// XmlHelper static class, provides helper methods to generate XML data.
+    /// </summary>
+    public static class XmlHelper
+    {
+        /// <summary>
+        /// Creates a new XLWorkbook based on the specified 'data'.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="sheetName"></param>
+        /// <returns></returns>
+        public static XLWorkbook ConvertToXLWorkbook(this DataTable data, string sheetName = "Sheet 1")
+        {
+            var wb = new XLWorkbook();
+            wb.Worksheets.Add(data, sheetName);
+
+            return wb;
+        }
+    }
+}

--- a/backend/core/Pims.Core.csproj
+++ b/backend/core/Pims.Core.csproj
@@ -6,5 +6,9 @@
     <Version>0.1.0.0-alpha</Version>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.95.1" />
+    <PackageReference Include="CsvHelper" Version="15.0.5" />
+  </ItemGroup>
 
 </Project>

--- a/backend/dal/Helpers/Extensions/PropertyExtensions.cs
+++ b/backend/dal/Helpers/Extensions/PropertyExtensions.cs
@@ -89,7 +89,7 @@ namespace Pims.Dal.Helpers.Extensions
             if (filter.MinAssessedValue.HasValue)
                 query = query.Where(p => p.Assessed >= filter.MinAssessedValue);
             if (filter.MaxAssessedValue.HasValue)
-                query = query.Where(p => p.Assessed >= filter.MaxAssessedValue);
+                query = query.Where(p => p.Assessed <= filter.MaxAssessedValue);
 
             if (filter.Sort?.Any() == true)
                 query = query.OrderByProperty(filter.Sort);

--- a/backend/dal/Services/Concrete/PropertyService.cs
+++ b/backend/dal/Services/Concrete/PropertyService.cs
@@ -28,6 +28,15 @@ namespace Pims.Dal.Services
 
         #region Methods
         /// <summary>
+        /// Returns the total number of properties in the database.
+        /// </summary>
+        /// <returns></returns>
+        public int Count()
+        {
+            return this.Context.Properties.Count();
+        }
+
+        /// <summary>
         /// Get an array of parcel properties within the specified filters.
         /// Will not return sensitive properties unless the user has the `sensitive-view` claim and belongs to the owning agency.
         /// </summary>

--- a/backend/dal/Services/IPropertyService.cs
+++ b/backend/dal/Services/IPropertyService.cs
@@ -8,6 +8,7 @@ namespace Pims.Dal.Services
     /// </summary>
     public interface IPropertyService
     {
+        int Count();
         Paged<Property> GetPage(AllPropertyFilter filter);
         Paged<Property> GetPage(ParcelFilter filter);
         Paged<Property> GetPage(BuildingFilter filter);

--- a/backend/entities/PropertyTypes.cs
+++ b/backend/entities/PropertyTypes.cs
@@ -1,0 +1,11 @@
+namespace Pims.Dal.Entities
+{
+    /// <summary>
+    /// PropertyTypes enum, provides the valid property types that can be used.
+    /// </summary>
+    public enum PropertyTypes
+    {
+        Land = 0,
+        Building = 1
+    }
+}

--- a/backend/entities/Views/Property.cs
+++ b/backend/entities/Views/Property.cs
@@ -16,7 +16,7 @@ namespace Pims.Dal.Entities.Views
         /// <summary>
         /// get/set - The property type [0=Parcel, 1=Building].
         /// </summary>
-        public int PropertyTypeId { get; set; }
+        public PropertyTypes PropertyTypeId { get; set; }
 
         /// <summary>
         /// get/set - The RAEG/SPP project number.
@@ -291,7 +291,7 @@ namespace Pims.Dal.Entities.Views
         /// <param name="parcel"></param>
         public Property(Parcel parcel) : this((Entities.Property)parcel)
         {
-            this.PropertyTypeId = 0;
+            this.PropertyTypeId = PropertyTypes.Land;
             this.PID = parcel.PID;
             this.PIN = parcel.PIN;
             this.LandArea = parcel.LandArea;
@@ -307,7 +307,7 @@ namespace Pims.Dal.Entities.Views
         /// <param name="building"></param>
         public Property(Building building) : this((Entities.Property)building)
         {
-            this.PropertyTypeId = 1;
+            this.PropertyTypeId = PropertyTypes.Building;
             this.PID = building.Parcel?.PID ?? 0;
             this.PIN = building.Parcel?.PIN;
             this.LocalId = building.LocalId;

--- a/backend/tests/unit/api/Controllers/Property/SearchControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/Property/SearchControllerTest.cs
@@ -1,22 +1,21 @@
-using MapsterMapper;
-using Entity = Pims.Dal.Entities;
-using Microsoft.AspNetCore.Mvc;
-using Model = Pims.Api.Models.Property;
-using Moq;
-using Pims.Api.Controllers;
-using Pims.Api.Helpers.Exceptions;
-using Pims.Api.Models.Property;
-using Pims.Core.Test;
-using Pims.Dal;
-using Pims.Dal.Security;
+using Xunit;
 using System;
 using System.Linq;
-using Xunit;
-using Pims.Core.Comparers;
-using System.Collections.Generic;
-using Pims.Dal.Entities.Models;
-using Pims.Core.Extensions;
 using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using Pims.Dal;
+using Pims.Dal.Security;
+using Pims.Dal.Entities.Models;
+using Pims.Core.Test;
+using Pims.Core.Extensions;
+using Pims.Core.Comparers;
+using Pims.Api.Helpers.Exceptions;
+using Pims.Api.Areas.Property.Models.Search;
+using Pims.Api.Areas.Property.Controllers;
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using MapsterMapper;
+using Entity = Pims.Dal.Entities;
 
 namespace Pims.Api.Test.Controllers
 {
@@ -24,7 +23,7 @@ namespace Pims.Api.Test.Controllers
     [Trait("category", "api")]
     [Trait("group", "property")]
     [ExcludeFromCodeCoverage]
-    public class PropertyControllerTest
+    public class SearchControllerTest
     {
         #region Variables
         public static IEnumerable<object[]> AllPropertiesFilters = new List<object[]>()
@@ -80,7 +79,7 @@ namespace Pims.Api.Test.Controllers
         #endregion
 
         #region Constructors
-        public PropertyControllerTest()
+        public SearchControllerTest()
         {
         }
         #endregion
@@ -96,7 +95,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView);
 
             var parcel = new Entity.Parcel(1, 51, 25);
             var parcels = new[] { parcel };
@@ -113,8 +112,8 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedResult = mapper.Map<Model.PropertyModel[]>(parcels).Concat(mapper.Map<Model.PropertyModel[]>(buildings));
+            var actualResult = Assert.IsType<PropertyModel[]>(actionResult.Value);
+            var expectedResult = mapper.Map<PropertyModel[]>(parcels).Concat(mapper.Map<PropertyModel[]>(buildings));
             Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Once());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), Times.Once());
@@ -131,7 +130,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView);
 
             var parcel1 = new Entity.Parcel(1, 51, 25) { Id = 1 };
             var parcel2 = new Entity.Parcel(2, 51, 26) { Id = 2 };
@@ -146,8 +145,8 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedResult = mapper.Map<Model.PropertyModel[]>(parcels);
+            var actualResult = Assert.IsType<PropertyModel[]>(actionResult.Value);
+            var expectedResult = mapper.Map<PropertyModel[]>(parcels);
             Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Once());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), Times.Never());
@@ -162,7 +161,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView);
 
             var building1 = new Entity.Building() { Id = 1 };
             var building2 = new Entity.Building() { Id = 2 };
@@ -177,8 +176,8 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedResult = mapper.Map<Model.PropertyModel[]>(buildings);
+            var actualResult = Assert.IsType<PropertyModel[]>(actionResult.Value);
+            var expectedResult = mapper.Map<PropertyModel[]>(buildings);
             Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), Times.Never());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), Times.Once());
@@ -193,7 +192,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView, uri);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView, uri);
 
             var parcel1 = EntityHelper.CreateParcel(1, 1, 1);
             var parcel2 = EntityHelper.CreateParcel(2, 1, 1);
@@ -213,10 +212,10 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Model.PropertyModel[]>(actionResult.Value);
-            var expectedResult = new List<Model.PropertyModel>();
-            if (includeParcels) expectedResult.AddRange(mapper.Map<Model.PropertyModel[]>(parcels));
-            if (includeBuildings) expectedResult.AddRange(mapper.Map<Model.PropertyModel[]>(buildings));
+            var actualResult = Assert.IsType<PropertyModel[]>(actionResult.Value);
+            var expectedResult = new List<PropertyModel>();
+            if (includeParcels) expectedResult.AddRange(mapper.Map<PropertyModel[]>(parcels));
+            if (includeBuildings) expectedResult.AddRange(mapper.Map<PropertyModel[]>(buildings));
             Assert.Equal(expectedResult, actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Parcel.Get(It.IsAny<Entity.Models.ParcelFilter>()), includeParcels ? Times.Once() : Times.Never());
             service.Verify(m => m.Building.Get(It.IsAny<Entity.Models.BuildingFilter>()), includeBuildings ? Times.Once() : Times.Never());
@@ -230,7 +229,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView);
 
             var service = helper.GetService<Mock<IPimsService>>();
 
@@ -249,7 +248,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView);
 
             var service = helper.GetService<Mock<IPimsService>>();
 
@@ -267,13 +266,13 @@ namespace Pims.Api.Test.Controllers
         /// </summary>
         [Theory]
         [MemberData(nameof(AllPropertiesFilters))]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Not Required")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Not Required")]
+        [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Not Required")]
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Not Required")]
         public void GetPropertiesPage_Success(PropertyFilterModel filter, bool includeParcels, bool includeBuildings)
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView);
 
             var parcel = new Entity.Parcel(1, 51, 25);
             var parcels = new[] { parcel };
@@ -291,8 +290,8 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Api.Models.PageModel<Model.PropertyModel>>(actionResult.Value);
-            var expectedResult = mapper.Map<Model.PropertyModel[]>(parcels).JoinAll(mapper.Map<Model.PropertyModel[]>(buildings));
+            var actualResult = Assert.IsType<Api.Models.PageModel<PropertyModel>>(actionResult.Value);
+            var expectedResult = mapper.Map<PropertyModel[]>(parcels).JoinAll(mapper.Map<PropertyModel[]>(buildings));
             Assert.Equal(expectedResult, actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Once());
         }
@@ -302,13 +301,13 @@ namespace Pims.Api.Test.Controllers
         /// </summary>
         [Theory]
         [MemberData(nameof(PropertyQueryFilters))]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Not Required")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Not Required")]
+        [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Not Required")]
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Not Required")]
         public void GetPropertiesPage_Query_Success(Uri uri, bool includeParcels, bool includeBuildings)
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView, uri);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView, uri);
 
             var parcel1 = new Entity.Parcel(1, 51, 25) { Id = 1 };
             var parcel2 = new Entity.Parcel(2, 51, 26) { Id = 2 };
@@ -325,8 +324,8 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Api.Models.PageModel<Model.PropertyModel>>(actionResult.Value);
-            var expectedResult = mapper.Map<Model.PropertyModel[]>(parcels);
+            var actualResult = Assert.IsType<Api.Models.PageModel<PropertyModel>>(actionResult.Value);
+            var expectedResult = mapper.Map<PropertyModel[]>(parcels);
             Assert.Equal(expectedResult, actualResult.Items, new DeepPropertyCompare());
             service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Once());
         }
@@ -339,7 +338,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView);
 
             var service = helper.GetService<Mock<IPimsService>>();
 
@@ -357,7 +356,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var controller = helper.CreateController<SearchController>(Permissions.PropertyView);
 
             var service = helper.GetService<Mock<IPimsService>>();
 

--- a/backend/tests/unit/api/Controllers/Reports/PropertyControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/Reports/PropertyControllerTest.cs
@@ -1,0 +1,372 @@
+using Xunit;
+using System;
+using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using Pims.Dal;
+using Pims.Dal.Security;
+using Pims.Dal.Entities.Models;
+using Pims.Core.Test;
+using Pims.Api.Helpers.Exceptions;
+using Pims.Api.Helpers.Constants;
+using Pims.Api.Areas.Reports.Controllers;
+using Pims.Api.Areas.Property.Models.Search;
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using MapsterMapper;
+using Entity = Pims.Dal.Entities;
+
+namespace Pims.Api.Test.Controllers.Reports
+{
+    [Trait("category", "unit")]
+    [Trait("category", "api")]
+    [Trait("group", "report")]
+    [Trait("group", "property")]
+    [ExcludeFromCodeCoverage]
+    public class PropertyControllerTest
+    {
+        #region Variables
+        public static IEnumerable<object[]> AllPropertiesFilters = new List<object[]>()
+        {
+            new object [] { new PropertyFilterModel(100, 0, 0, 0) },
+            new object [] { new PropertyFilterModel(0, 100, 0, 0) },
+            new object [] { new PropertyFilterModel(0, 0, 10, 0) },
+            new object [] { new PropertyFilterModel(0, 0, 0, 10) },
+            new object [] { new PropertyFilterModel(0, 0, 0, 10) { Address = "Address" } },
+            new object [] { new PropertyFilterModel(0, 0, 0, 10) { Agencies = new [] { 1 } } },
+            new object [] { new PropertyFilterModel(0, 0, 0, 10) { StatusId = 1 } },
+            new object [] { new PropertyFilterModel(0, 0, 0, 10) { ClassificationId = 1 } },
+            new object [] { new PropertyFilterModel(0, 0, 0, 10) { ProjectNumber = "ProjectNumber" } },
+            new object [] { new PropertyFilterModel(0, 0, 0, 10) { Municipality = "Municipality" } }
+        };
+
+        public static IEnumerable<object[]> ParcelOnlyFilters = new List<object[]>()
+        {
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { MinLotArea = 1 } },
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { MaxLotArea = 1 } },
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { MinLandArea = 1 } },
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { MaxLandArea = 1 } }
+        };
+
+        public static IEnumerable<object[]> BuildingOnlyFilters = new List<object[]>()
+        {
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { ConstructionTypeId = 1 } },
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { PredominateUseId = 1 } },
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { FloorCount = 1 } },
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { Tenancy = "Tenancy" } },
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { MinRentableArea = 1 } },
+            new [] { new PropertyFilterModel(100, 100, 0, 0) { MaxRentableArea = 1 } }
+        };
+
+        public static IEnumerable<object[]> PropertyQueryFilters = new List<object[]>()
+        {
+            new object [] { new Uri("http://host/api/properties?Agencies=1,2") },
+            new object [] { new Uri("http://host/api/properties?StatusId=2") },
+            new object [] { new Uri("http://host/api/properties?ClassificationId=1") },
+            new object [] { new Uri("http://host/api/properties?Address=Address") },
+            new object [] { new Uri("http://host/api/properties?ProjectNumber=ProjectNumber") },
+            new object [] { new Uri("http://host/api/properties?MinLotArea=1") },
+            new object [] { new Uri("http://host/api/properties?MaxLotArea=1") },
+            new object [] { new Uri("http://host/api/properties?MinLandArea=1") },
+            new object [] { new Uri("http://host/api/properties?MaxLandArea=1") },
+            new object [] { new Uri("http://host/api/properties?ConstructionTypeId=1") },
+            new object [] { new Uri("http://host/api/properties?PredominateUseId=1") },
+            new object [] { new Uri("http://host/api/properties?FloorCount=1") },
+            new object [] { new Uri("http://host/api/properties?Tenancy=Tenancy") },
+            new object [] { new Uri("http://host/api/properties?MinRentableArea=1") },
+            new object [] { new Uri("http://host/api/properties?MaxRentableArea=1") }
+        };
+        #endregion
+
+        #region Constructors
+        public PropertyControllerTest()
+        {
+        }
+        #endregion
+
+        #region Tests
+        #region ExportProperties
+        /// <summary>
+        /// Make a successful request that includes the latitude.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(AllPropertiesFilters))]
+        public void ExportProperties_Csv_Success(PropertyFilterModel filter)
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var headers = helper.GetService<Mock<Microsoft.AspNetCore.Http.IHeaderDictionary>>();
+            headers.Setup(m => m["Accept"]).Returns(ContentTypes.CONTENT_TYPE_CSV);
+
+            var parcel = new Entity.Parcel(1, 51, 25);
+            var parcels = new[] { parcel };
+            var building = new Entity.Building(parcel, 51, 25);
+            var buildings = new[] { building };
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+            var items = parcels.Select(p => new Entity.Views.Property(p)).Concat(buildings.Select(b => new Entity.Views.Property(b)));
+            var page = new Paged<Entity.Views.Property>(items, filter.Page, filter.Quantity);
+            service.Setup(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>())).Returns(page);
+
+            // Act
+            var result = controller.ExportProperties(filter);
+
+            // Assert
+            var actionResult = Assert.IsType<ContentResult>(result);
+            var actualResult = Assert.IsType<string>(actionResult.Content);
+            Assert.Equal(ContentTypes.CONTENT_TYPE_CSV, actionResult.ContentType);
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Make a successful request that passes the filter in the query string.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(PropertyQueryFilters))]
+        public void ExportProperties_Csv_Query_Success(Uri uri)
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView, uri);
+            var headers = helper.GetService<Mock<Microsoft.AspNetCore.Http.IHeaderDictionary>>();
+            headers.Setup(m => m["Accept"]).Returns(ContentTypes.CONTENT_TYPE_CSV);
+
+            var parcel1 = new Entity.Parcel(1, 51, 25) { Id = 1 };
+            var parcel2 = new Entity.Parcel(2, 51, 26) { Id = 2 };
+            var parcels = new[] { parcel1, parcel2 };
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+            var items = parcels.Select(p => new Entity.Views.Property(p));
+            var page = new Paged<Entity.Views.Property>(items);
+            service.Setup(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>())).Returns(page);
+
+            // Act
+            var result = controller.ExportProperties();
+
+            // Assert
+            var actionResult = Assert.IsType<ContentResult>(result);
+            var actualResult = Assert.IsType<string>(actionResult.Content);
+            Assert.Equal(ContentTypes.CONTENT_TYPE_CSV, actionResult.ContentType);
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Make a successful request that includes the latitude.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(AllPropertiesFilters))]
+        public void ExportProperties_Excel_Success(PropertyFilterModel filter)
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var headers = helper.GetService<Mock<Microsoft.AspNetCore.Http.IHeaderDictionary>>();
+            headers.Setup(m => m["Accept"]).Returns(ContentTypes.CONTENT_TYPE_EXCEL);
+
+            var parcel = new Entity.Parcel(1, 51, 25);
+            var parcels = new[] { parcel };
+            var building = new Entity.Building(parcel, 51, 25);
+            var buildings = new[] { building };
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+            var items = parcels.Select(p => new Entity.Views.Property(p)).Concat(buildings.Select(b => new Entity.Views.Property(b)));
+            var page = new Paged<Entity.Views.Property>(items, filter.Page, filter.Quantity);
+            service.Setup(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>())).Returns(page);
+
+            // Act
+            var result = controller.ExportProperties(filter);
+
+            // Assert
+            var actionResult = Assert.IsType<FileStreamResult>(result);
+            Assert.Equal(ContentTypes.CONTENT_TYPE_EXCELX, actionResult.ContentType);
+            Assert.NotNull(actionResult.FileDownloadName);
+            Assert.True(actionResult.FileStream.Length > 0);
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Make a successful request that passes the filter in the query string.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(PropertyQueryFilters))]
+        public void ExportProperties_Excel_Query_Success(Uri uri)
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView, uri);
+            var headers = helper.GetService<Mock<Microsoft.AspNetCore.Http.IHeaderDictionary>>();
+            headers.Setup(m => m["Accept"]).Returns(ContentTypes.CONTENT_TYPE_EXCEL);
+
+            var parcel1 = new Entity.Parcel(1, 51, 25) { Id = 1 };
+            var parcel2 = new Entity.Parcel(2, 51, 26) { Id = 2 };
+            var parcels = new[] { parcel1, parcel2 };
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+            var items = parcels.Select(p => new Entity.Views.Property(p));
+            var page = new Paged<Entity.Views.Property>(items);
+            service.Setup(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>())).Returns(page);
+
+            // Act
+            var result = controller.ExportProperties();
+
+            // Assert
+            var actionResult = Assert.IsType<FileStreamResult>(result);
+            Assert.Equal(ContentTypes.CONTENT_TYPE_EXCELX, actionResult.ContentType);
+            Assert.NotNull(actionResult.FileDownloadName);
+            Assert.True(actionResult.FileStream.Length > 0);
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Make a successful request that includes the latitude.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(AllPropertiesFilters))]
+        public void ExportProperties_ExcelX_Success(PropertyFilterModel filter)
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+            var headers = helper.GetService<Mock<Microsoft.AspNetCore.Http.IHeaderDictionary>>();
+            headers.Setup(m => m["Accept"]).Returns(ContentTypes.CONTENT_TYPE_EXCELX);
+
+            var parcel = new Entity.Parcel(1, 51, 25);
+            var parcels = new[] { parcel };
+            var building = new Entity.Building(parcel, 51, 25);
+            var buildings = new[] { building };
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+            var items = parcels.Select(p => new Entity.Views.Property(p)).Concat(buildings.Select(b => new Entity.Views.Property(b)));
+            var page = new Paged<Entity.Views.Property>(items, filter.Page, filter.Quantity);
+            service.Setup(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>())).Returns(page);
+
+            // Act
+            var result = controller.ExportProperties(filter);
+
+            // Assert
+            var actionResult = Assert.IsType<FileStreamResult>(result);
+            Assert.Equal(ContentTypes.CONTENT_TYPE_EXCELX, actionResult.ContentType);
+            Assert.NotNull(actionResult.FileDownloadName);
+            Assert.True(actionResult.FileStream.Length > 0);
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Make a successful request that passes the filter in the query string.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(PropertyQueryFilters))]
+        public void ExportProperties_ExcelX_Query_Success(Uri uri)
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView, uri);
+            var headers = helper.GetService<Mock<Microsoft.AspNetCore.Http.IHeaderDictionary>>();
+            headers.Setup(m => m["Accept"]).Returns(ContentTypes.CONTENT_TYPE_EXCELX);
+
+            var parcel1 = new Entity.Parcel(1, 51, 25) { Id = 1 };
+            var parcel2 = new Entity.Parcel(2, 51, 26) { Id = 2 };
+            var parcels = new[] { parcel1, parcel2 };
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+            var items = parcels.Select(p => new Entity.Views.Property(p));
+            var page = new Paged<Entity.Views.Property>(items);
+            service.Setup(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>())).Returns(page);
+
+            // Act
+            var result = controller.ExportProperties();
+
+            // Assert
+            var actionResult = Assert.IsType<FileStreamResult>(result);
+            Assert.Equal(ContentTypes.CONTENT_TYPE_EXCELX, actionResult.ContentType);
+            Assert.NotNull(actionResult.FileDownloadName);
+            Assert.True(actionResult.FileStream.Length > 0);
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Make a failed request because the query doesn't contain filter values.
+        /// </summary>
+        [Fact]
+        public void ExportProperties_Query_NoFilter_BadRequest()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+
+            var service = helper.GetService<Mock<IPimsService>>();
+
+            // Act
+            // Assert
+            Assert.Throws<BadRequestException>(() => controller.ExportProperties());
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Make a failed request because the body doesn't contain a filter object.
+        /// </summary>
+        [Fact]
+        public void ExportProperties_NoFilter_BadRequest()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+
+            var service = helper.GetService<Mock<IPimsService>>();
+
+            // Act
+            // Assert
+            Assert.Throws<BadRequestException>(() => controller.ExportProperties(null));
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Make a failed request because the body doesn't contain a valid accept header.
+        /// </summary>
+        [Fact]
+        public void ExportProperties_NoAcceptHeader_BadRequest()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var filter = new PropertyFilterModel(100, 0, 0, 0) { StatusId = 1 };
+
+            // Act
+            // Assert
+            Assert.Throws<BadRequestException>(() => controller.ExportProperties(filter));
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Make a failed request because the body doesn't contain a valid accept header.
+        /// </summary>
+        [Fact]
+        public void ExportProperties_InvalidAcceptHeader_BadRequest()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<PropertyController>(Permissions.PropertyView);
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var headers = helper.GetService<Mock<Microsoft.AspNetCore.Http.IHeaderDictionary>>();
+            headers.Setup(m => m["Accept"]).Returns("invalid");
+            var filter = new PropertyFilterModel(100, 0, 0, 0) { StatusId = 1 };
+
+            // Act
+            // Assert
+            Assert.Throws<BadRequestException>(() => controller.ExportProperties(filter));
+            service.Verify(m => m.Property.GetPage(It.IsAny<Entity.Models.AllPropertyFilter>()), Times.Never());
+        }
+        #endregion
+        #endregion
+    }
+}

--- a/backend/tests/unit/api/Routes/Property/SearchControllerTest.cs
+++ b/backend/tests/unit/api/Routes/Property/SearchControllerTest.cs
@@ -1,5 +1,5 @@
-using Pims.Api.Controllers;
-using Pims.Api.Models.Property;
+using Pims.Api.Areas.Property.Controllers;
+using Pims.Api.Areas.Property.Models.Search;
 using Pims.Core.Test;
 using Pims.Core.Extensions;
 using Pims.Dal.Security;
@@ -9,20 +9,20 @@ using System.Diagnostics.CodeAnalysis;
 namespace Pims.Api.Test.Routes
 {
     /// <summary>
-    /// PropertyControllerTest class, provides a way to test endpoint routes.
+    /// SearchControllerTest class, provides a way to test endpoint routes.
     /// </summary>
     [Trait("category", "unit")]
     [Trait("category", "api")]
     [Trait("group", "property")]
     [Trait("group", "route")]
     [ExcludeFromCodeCoverage]
-    public class PropertyControllerTest
+    public class SearchControllerTest
     {
         #region Variables
         #endregion
 
         #region Constructors
-        public PropertyControllerTest()
+        public SearchControllerTest()
         {
         }
         #endregion
@@ -34,17 +34,18 @@ namespace Pims.Api.Test.Routes
             // Arrange
             // Act
             // Assert
-            var type = typeof(PropertyController);
+            var type = typeof(SearchController);
             type.HasAuthorize();
-            type.HasRoute("properties");
-            type.HasRoute("v{version:apiVersion}/properties");
+            type.HasArea("properties");
+            type.HasRoute("[area]/search");
+            type.HasRoute("v{version:apiVersion}/[area]/search");
         }
 
         [Fact]
         public void GetProperties_Query_Route()
         {
             // Arrange
-            var endpoint = typeof(PropertyController).FindMethod(nameof(PropertyController.GetProperties));
+            var endpoint = typeof(SearchController).FindMethod(nameof(SearchController.GetProperties));
 
             // Act
             // Assert
@@ -57,7 +58,7 @@ namespace Pims.Api.Test.Routes
         public void GetProperties_Filter_Route()
         {
             // Arrange
-            var endpoint = typeof(PropertyController).FindMethod(nameof(PropertyController.GetProperties), typeof(PropertyFilterModel));
+            var endpoint = typeof(SearchController).FindMethod(nameof(SearchController.GetProperties), typeof(PropertyFilterModel));
 
             // Act
             // Assert
@@ -70,7 +71,7 @@ namespace Pims.Api.Test.Routes
         public void GetPropertiesPage_Query_Route()
         {
             // Arrange
-            var endpoint = typeof(PropertyController).FindMethod(nameof(PropertyController.GetPropertiesPage));
+            var endpoint = typeof(SearchController).FindMethod(nameof(SearchController.GetPropertiesPage));
 
             // Act
             // Assert
@@ -83,7 +84,7 @@ namespace Pims.Api.Test.Routes
         public void GetPropertiesPage_Filter_Route()
         {
             // Arrange
-            var endpoint = typeof(PropertyController).FindMethod(nameof(PropertyController.GetPropertiesPage), typeof(PropertyFilterModel));
+            var endpoint = typeof(SearchController).FindMethod(nameof(SearchController.GetPropertiesPage), typeof(PropertyFilterModel));
 
             // Act
             // Assert

--- a/backend/tests/unit/api/Routes/Reports/PropertyControllerTest.cs
+++ b/backend/tests/unit/api/Routes/Reports/PropertyControllerTest.cs
@@ -1,0 +1,72 @@
+using Pims.Api.Areas.Reports.Controllers;
+using Pims.Api.Areas.Property.Models.Search;
+using Pims.Core.Test;
+using Pims.Core.Extensions;
+using Pims.Dal.Security;
+using Xunit;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Pims.Api.Test.Routes.Reports
+{
+    /// <summary>
+    /// ReportControllerTest class, provides a way to test endpoint routes.
+    /// </summary>
+    [Trait("category", "unit")]
+    [Trait("category", "api")]
+    [Trait("group", "report")]
+    [Trait("group", "property")]
+    [Trait("group", "route")]
+    [ExcludeFromCodeCoverage]
+    public class PropertyControllerTest
+    {
+        #region Variables
+        #endregion
+
+        #region Constructors
+        public PropertyControllerTest()
+        {
+        }
+        #endregion
+
+        #region Tests
+        [Fact]
+        public void Property_Route()
+        {
+            // Arrange
+            // Act
+            // Assert
+            var type = typeof(PropertyController);
+            type.HasAuthorize();
+            type.HasArea("reports");
+            type.HasRoute("[area]/properties");
+            type.HasRoute("v{version:apiVersion}/[area]/properties");
+        }
+
+        [Fact]
+        public void ExportProperties_Query_Route()
+        {
+            // Arrange
+            var endpoint = typeof(PropertyController).FindMethod(nameof(PropertyController.ExportProperties), typeof(bool));
+
+            // Act
+            // Assert
+            Assert.NotNull(endpoint);
+            endpoint.HasGet();
+            endpoint.HasPermissions(Permissions.PropertyView);
+        }
+
+        [Fact]
+        public void ExportProperties_Filter_Route()
+        {
+            // Arrange
+            var endpoint = typeof(PropertyController).FindMethod(nameof(PropertyController.ExportProperties), typeof(PropertyFilterModel), typeof(bool));
+
+            // Act
+            // Assert
+            Assert.NotNull(endpoint);
+            endpoint.HasPost("filter");
+            endpoint.HasPermissions(Permissions.PropertyView);
+        }
+        #endregion
+    }
+}

--- a/backend/tests/unit/dal/Services/PropertyServiceTest.cs
+++ b/backend/tests/unit/dal/Services/PropertyServiceTest.cs
@@ -24,48 +24,48 @@ namespace Pims.Dal.Test.Services
         public static IEnumerable<object[]> ParcelFilters =>
             new List<object[]>
             {
-                new object[] { new ParcelFilter(50, 25, 50, 20), 1 },
-                new object[] { new ParcelFilter(50, 24, 50, 26), 0 },
-                new object[] { new ParcelFilter() { Agencies = new int[] { 3 } }, 1 },
-                new object[] { new ParcelFilter() { ClassificationId = 2 }, 1 },
-                new object[] { new ParcelFilter() { Description = "Description" }, 1 },
-                new object[] { new ParcelFilter() { Municipality = "Municipality" }, 1 },
-                new object[] { new ParcelFilter() { Zoning = "Zoning" }, 1 },
-                new object[] { new ParcelFilter() { ZoningPotential = "ZoningPotential" }, 1 }
+                new object[] { new ParcelFilter(50, 25, 50, 20), 1, 1 },
+                new object[] { new ParcelFilter(50, 24, 50, 26), 0, 0 },
+                new object[] { new ParcelFilter() { Agencies = new int[] { 3 } }, 1, 1 },
+                new object[] { new ParcelFilter() { ClassificationId = 2 }, 1, 1 },
+                new object[] { new ParcelFilter() { Description = "Description" }, 1, 1 },
+                new object[] { new ParcelFilter() { Municipality = "Municipality" }, 1, 1 },
+                new object[] { new ParcelFilter() { Zoning = "Zoning" }, 1, 1 },
+                new object[] { new ParcelFilter() { ZoningPotential = "ZoningPotential" }, 1, 1 }
             };
 
         public static IEnumerable<object[]> BuildingFilters =>
             new List<object[]>
             {
-                new object[] { new BuildingFilter(50, 25, 50, 20), 1 },
-                new object[] { new BuildingFilter(50, 24, 50, 26), 0 },
-                new object[] { new BuildingFilter() { Agencies = new int[] { 3 } }, 1 },
-                new object[] { new BuildingFilter() { ClassificationId = 2 }, 1 },
-                new object[] { new BuildingFilter() { Description = "Description" }, 1 },
-                new object[] { new BuildingFilter() { Municipality = "Municipality" }, 5 },
-                new object[] { new BuildingFilter() { Tenancy = "BuildingTenancy" }, 1 },
-                new object[] { new BuildingFilter() { ConstructionTypeId = 2 }, 1 },
-                new object[] { new BuildingFilter() { PredominateUseId = 2 }, 1 },
-                new object[] { new BuildingFilter() { MinRentableArea = 100 }, 1 },
-                new object[] { new BuildingFilter() { MinRentableArea = 50, MaxRentableArea = 50 }, 1 }
+                new object[] { new BuildingFilter(50, 25, 50, 20), 1, 1 },
+                new object[] { new BuildingFilter(50, 24, 50, 26), 0, 0 },
+                new object[] { new BuildingFilter() { Agencies = new int[] { 3 } }, 1, 1 },
+                new object[] { new BuildingFilter() { ClassificationId = 2 }, 1, 1 },
+                new object[] { new BuildingFilter() { Description = "Description" }, 1, 1 },
+                new object[] { new BuildingFilter() { Municipality = "Municipality" }, 5, 5 },
+                new object[] { new BuildingFilter() { Tenancy = "BuildingTenancy" }, 1, 1 },
+                new object[] { new BuildingFilter() { ConstructionTypeId = 2 }, 1, 1 },
+                new object[] { new BuildingFilter() { PredominateUseId = 2 }, 1, 1 },
+                new object[] { new BuildingFilter() { MinRentableArea = 100 }, 1, 1 },
+                new object[] { new BuildingFilter() { MinRentableArea = 50, MaxRentableArea = 50 }, 1, 1 }
             };
 
         public static IEnumerable<object[]> AllPropertyFilters =>
             new List<object[]>
             {
-                new object[] { new AllPropertyFilter(50, 25, 50, 20), 2 },
-                new object[] { new AllPropertyFilter(50, 24, 50, 26), 0 },
-                new object[] { new AllPropertyFilter() { Agencies = new int[] { 3 } }, 7 },
-                new object[] { new AllPropertyFilter() { ClassificationId = 2 }, 2 },
-                new object[] { new AllPropertyFilter() { Description = "Description" }, 20 },
-                new object[] { new AllPropertyFilter() { Municipality = "Municipality" }, 11 },
-                new object[] { new AllPropertyFilter() { Tenancy = "BuildingTenancy" }, 1 },
-                new object[] { new AllPropertyFilter() { Zoning = "Zoning" }, 20 },
-                new object[] { new AllPropertyFilter() { ZoningPotential = "ZoningPotential" }, 20 },
-                new object[] { new AllPropertyFilter() { ConstructionTypeId = 2 }, 1 },
-                new object[] { new AllPropertyFilter() { PredominateUseId = 2 }, 1 },
-                new object[] { new AllPropertyFilter() { MinRentableArea = 100 }, 1 },
-                new object[] { new AllPropertyFilter() { MinRentableArea = 50, MaxRentableArea = 50 }, 1 },
+                new object[] { new AllPropertyFilter(50, 25, 50, 20), 2, 2 },
+                new object[] { new AllPropertyFilter(50, 24, 50, 26), 0, 0 },
+                new object[] { new AllPropertyFilter() { Agencies = new int[] { 3 } }, 7, 7 },
+                new object[] { new AllPropertyFilter() { ClassificationId = 2 }, 2, 2 },
+                new object[] { new AllPropertyFilter() { Page = 1, Quantity = 10, Description = "Description" }, 20, 10 },
+                new object[] { new AllPropertyFilter() { Municipality = "Municipality" }, 11, 10 },
+                new object[] { new AllPropertyFilter() { Tenancy = "BuildingTenancy" }, 1, 1 },
+                new object[] { new AllPropertyFilter() { Zoning = "Zoning" }, 20, 10 },
+                new object[] { new AllPropertyFilter() { ZoningPotential = "ZoningPotential" }, 20, 10 },
+                new object[] { new AllPropertyFilter() { ConstructionTypeId = 2 }, 1, 1 },
+                new object[] { new AllPropertyFilter() { PredominateUseId = 2 }, 1, 1 },
+                new object[] { new AllPropertyFilter() { MinRentableArea = 100 }, 1, 1 },
+                new object[] { new AllPropertyFilter() { MinRentableArea = 50, MaxRentableArea = 50 }, 1, 1 },
             };
         #endregion
 
@@ -79,7 +79,7 @@ namespace Pims.Dal.Test.Services
         /// User does not have 'property-view' claim.
         /// </summary>
         [Fact]
-        public void Get_Properties_ArgumentNullException()
+        public void GetPage_Properties_ArgumentNullException()
         {
             // Arrange
             var helper = new TestHelper();
@@ -96,7 +96,7 @@ namespace Pims.Dal.Test.Services
         /// User does not have 'property-view' claim.
         /// </summary>
         [Fact]
-        public void Get_Parcels_ArgumentNullException()
+        public void GetPage_Parcels_ArgumentNullException()
         {
             // Arrange
             var helper = new TestHelper();
@@ -113,7 +113,7 @@ namespace Pims.Dal.Test.Services
         /// User does not have 'property-view' claim.
         /// </summary>
         [Fact]
-        public void Get_Buildings_ArgumentNullException()
+        public void GetPage_Buildings_ArgumentNullException()
         {
             // Arrange
             var helper = new TestHelper();
@@ -130,7 +130,7 @@ namespace Pims.Dal.Test.Services
         /// User does not have 'property-view' claim.
         /// </summary>
         [Fact]
-        public void Get_Properties_NotAuthorized()
+        public void GetPage_Properties_NotAuthorized()
         {
             // Arrange
             var helper = new TestHelper();
@@ -149,7 +149,7 @@ namespace Pims.Dal.Test.Services
         /// User does not have 'property-view' claim.
         /// </summary>
         [Fact]
-        public void Get_Parcels_NotAuthorized()
+        public void GetPage_Parcels_NotAuthorized()
         {
             // Arrange
             var helper = new TestHelper();
@@ -168,7 +168,7 @@ namespace Pims.Dal.Test.Services
         /// User does not have 'property-view' claim.
         /// </summary>
         [Fact]
-        public void Get_Buildings_NotAuthorized()
+        public void GetPage_Buildings_NotAuthorized()
         {
             // Arrange
             var helper = new TestHelper();
@@ -185,7 +185,7 @@ namespace Pims.Dal.Test.Services
 
         [Theory]
         [MemberData(nameof(ParcelFilters))]
-        public void Get_Parcels(ParcelFilter filter, int expectedCount)
+        public void GetPage_Parcels(ParcelFilter filter, int expectedTotal, int expectedCount)
         {
             // Arrange
             var helper = new TestHelper();
@@ -213,12 +213,13 @@ namespace Pims.Dal.Test.Services
             // Assert
             Assert.NotNull(result);
             Assert.IsAssignableFrom<IEnumerable<Entity.Views.Property>>(result);
-            Assert.Equal(expectedCount, result.Total);
+            Assert.Equal(expectedTotal, result.Total);
+            Assert.Equal(expectedCount, result.Count());
         }
 
         [Theory]
         [MemberData(nameof(BuildingFilters))]
-        public void Get_Buildings(BuildingFilter filter, int expectedCount)
+        public void GetPage_Buildings(BuildingFilter filter, int expectedTotal, int expectedCount)
         {
             // Arrange
             var helper = new TestHelper();
@@ -252,12 +253,13 @@ namespace Pims.Dal.Test.Services
             // Assert
             Assert.NotNull(result);
             Assert.IsAssignableFrom<IEnumerable<Entity.Views.Property>>(result);
-            Assert.Equal(expectedCount, result.Total);
+            Assert.Equal(expectedTotal, result.Total);
+            Assert.Equal(expectedCount, result.Count());
         }
 
         [Theory]
         [MemberData(nameof(AllPropertyFilters))]
-        public void Get_Properties(AllPropertyFilter filter, int expectedCount)
+        public void GetPage_Properties(AllPropertyFilter filter, int expectedTotal, int expectedCount)
         {
             // Arrange
             var helper = new TestHelper();
@@ -304,7 +306,8 @@ namespace Pims.Dal.Test.Services
             // Assert
             Assert.NotNull(result);
             Assert.IsAssignableFrom<IEnumerable<Entity.Views.Property>>(result);
-            Assert.Equal(expectedCount, result.Total);
+            Assert.Equal(expectedTotal, result.Total);
+            Assert.Equal(expectedCount, result.Count());
         }
         #endregion
         #endregion

--- a/frontend/src/constants/API.tsx
+++ b/frontend/src/constants/API.tsx
@@ -31,7 +31,7 @@ export interface IParcelListParams {
   maxLandArea: number | null;
 }
 export const PARCELS = (params: IParcelListParams | null) =>
-  params ? `/properties?${queryString.stringify(params)}` : '/properties'; // get filtered properties or all if not specified.
+  `/properties/search?${params ? queryString.stringify(params) : ''}`; // get filtered properties or all if not specified.
 export interface IParcelDetailParams {
   id: number;
 }

--- a/frontend/src/pages/Test.tsx
+++ b/frontend/src/pages/Test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Button, ButtonGroup, Container } from 'react-bootstrap';
+import { ENVIRONMENT } from 'constants/environment';
+import download from './../utils/download';
+import { useDispatch } from 'react-redux';
+
+/**
+ * Test provides a testing page for various things.
+ */
+const Test = () => {
+  const dispatch = useDispatch();
+
+  const fetch = (accept: 'csv' | 'excel') =>
+    dispatch(
+      download({
+        url: ENVIRONMENT.apiUrl + '/reports/properties?statusId=1',
+        fileName: `properties.${accept === 'csv' ? 'csv' : 'xlsx'}`,
+        actionType: 'properties-report',
+        headers: {
+          Accept: accept === 'csv' ? 'text/csv' : 'application/vnd.ms-excel',
+        },
+      }),
+    );
+
+  return (
+    <Container>
+      <h3>Property Reports</h3>
+      <hr />
+      <ButtonGroup>
+        <Button onClick={() => fetch('csv')}>Download CSV</Button>
+        <Button onClick={() => fetch('excel')}>Download Excel</Button>
+      </ButtonGroup>
+    </Container>
+  );
+};
+
+export default Test;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -12,6 +12,7 @@ import { Claims } from 'constants/claims';
 import AppRoute from 'utils/AppRoute';
 import PublicLayout from 'layouts/PublicLayout';
 import AuthLayout from 'layouts/AuthLayout';
+import Test from 'pages/Test';
 
 const AppRouter: React.FC = () => {
   return (
@@ -19,6 +20,7 @@ const AppRouter: React.FC = () => {
       <Redirect exact from="/" to="/login" />
       <AppRoute path="/login" component={Login} layout={PublicLayout}></AppRoute>
       <AppRoute path="/forbidden" component={AccessDenied} layout={PublicLayout}></AppRoute>
+      <AppRoute path="/test" component={Test} layout={PublicLayout}></AppRoute>
       <AppRoute
         protected
         path="/admin/users"

--- a/frontend/src/utils/download.tsx
+++ b/frontend/src/utils/download.tsx
@@ -1,0 +1,53 @@
+import CustomAxios from 'customAxios';
+import { AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios';
+import { createRequestHeader } from 'utils/RequestHeaders';
+import { showLoading, hideLoading } from 'react-redux-loading-bar';
+import { request, success, error } from 'actions/genericActions';
+
+/**
+ * Download configuration options interface.
+ */
+export interface IDownloadConfig extends AxiosRequestConfig {
+  fileName: string;
+  actionType: string;
+}
+
+/**
+ * Make an AJAX request to download content from the specified endpoint.
+ * @param config - Configuration options to make an AJAX request to download content.
+ * @param config.url - The url to the endpoint.
+ * @param config.actionType - The action type name to identify the request in the redux store.
+ * @param config.method - The HTTP method to use.
+ * @param config.headers - The HTTP request headers to include.  By default it will include the JWT bearer token.
+ * @param config.fileName - The file name you want to save the download as.  By default it will use the current date.
+ */
+const download = (config: IDownloadConfig) => (dispatch: Function) => {
+  const headers = createRequestHeader().headers;
+  const options = { ...config, headers: { ...headers, ...config.headers } };
+  dispatch(request(options.actionType));
+  dispatch(showLoading());
+  return CustomAxios()
+    .request({
+      url: options.url,
+      headers: options.headers,
+      method: options.method ?? 'get',
+      responseType: options.responseType ?? 'blob',
+      data: options.data,
+    })
+    .then((response: AxiosResponse) => {
+      dispatch(success(options.actionType));
+
+      const uri = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement('a');
+      link.href = uri;
+      link.setAttribute('download', options.fileName ?? new Date().toDateString());
+      document.body.appendChild(link);
+      link.click();
+    })
+    .catch((axiosError: AxiosError) =>
+      dispatch(error(options.actionType, axiosError?.response?.status, axiosError)),
+    )
+    .finally(() => dispatch(hideLoading()));
+};
+
+export default download;


### PR DESCRIPTION
The API now supports the ability to export properties in both CSV and Excel format!

**Endpionts**

- GET /api/reports/properties
- POST /api/reports/properties/filter

**HTTP Request Header**

The endpoints require you to include the HTTP Request Header 'Accept' as one of the following;

- text/csv
- application/vnd.ms-excel
- application/vnd.openxmlformats-officedocument.spreadsheetml.sheet

**HTTP Request Query Parameters**

> All of the existing filters apply

**Testing**

I have created a test page as a temporary example when this is deployed.  This test page can be removed later, or used for other purposes.

- [DEV](pims-dev.pathfinder.gov.bc.ca/test)

**Notes**

I have moved the root `PropertyController` into its own area `/Areas/Property/SearchController`.  This is to improve organization.