### PR TITLE
PIMS-1542 SRES Deleting/Editing Properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,15 @@
 * text=auto
 
 # Declare files that will always have LF line endings on checkout.
+text eol=lf
+*.cs text eol=lf
+*.csproj text eol=lf
+*.sln text eol=lf
+*.sql text eol=lf
 *.tsx text eol=lf
 *.ts text eol=lf
 *.js text eol=lf
+*.jsx text eol=lf
 *.sh text eol=lf
 *.md text eol=lf
 *.json text eol=lf

--- a/auth/keycloak/config/realm-export.json
+++ b/auth/keycloak/config/realm-export.json
@@ -1934,11 +1934,18 @@
       "containerId": "pims",
       "attributes": {}
     }, {
+      "id": "223664c7-650c-40ac-8581-f40e10164537",
+      "name": "property-delete",
+      "composite": false,
+      "clientRole": false,
+      "containerId": "pims",
+      "attributes": {}
+    }, {
       "id": "216b6a37-bc1c-4cf3-9a93-25f96277647e",
       "name": "system-administrator",
       "composite": true,
       "composites": {
-        "realm": ["property-view", "property-edit", "sensitive-view", "admin-roles", "admin-users", "property-add"]
+        "realm": ["property-view", "property-edit", "sensitive-view", "admin-roles", "admin-users", "property-add", "property-delete"]
       },
       "clientRole": false,
       "containerId": "pims",
@@ -1966,6 +1973,13 @@
       "containerId": "pims",
       "attributes": {}
     }, {
+      "id": "71e74513-a036-4df3-b724-a8c349b7fc28",
+      "name": "admin-properties",
+      "composite": false,
+      "clientRole": false,
+      "containerId": "pims",
+      "attributes": {}
+    }, {
       "id": "321e245b-ee7d-4d7c-83a8-56b5a9d33c2d",
       "name": "admin-roles",
       "composite": false,
@@ -1977,7 +1991,7 @@
       "name": "agency-administrator",
       "composite": true,
       "composites": {
-        "realm": ["property-view", "property-edit", "sensitive-view", "admin-roles", "admin-users", "property-add"]
+        "realm": ["property-view", "property-edit", "sensitive-view", "admin-roles", "admin-users", "property-add", "property-delete"]
       },
       "clientRole": false,
       "containerId": "pims",
@@ -2310,6 +2324,14 @@
     "realmRoles": ["system-administrator"],
     "clientRoles": {},
     "subGroups": []
+  }, {
+    "id": "08c52eec-6917-4512-ac02-7d7ff89ed7a6",
+    "name": "SRES",
+    "path": "/SRES",
+    "attributes": {},
+    "realmRoles": ["admin-properties", "property-delete"],
+    "clientRoles": {},
+    "subGroups": []
   }],
   "defaultRoles": ["offline_access", "uma_authorization"],
   "requiredCredentials": ["password"],
@@ -2363,7 +2385,7 @@
     }],
     "disableableCredentialTypes": [],
     "requiredActions": [],
-    "realmRoles": ["property-add", "sensitive-view", "property-edit", "offline_access", "admin-users", "property-view", "admin-roles", "uma_authorization"],
+    "realmRoles": ["property-add", "sensitive-view", "property-edit", "offline_access", "admin-users", "property-view", "property-delete", "admin-roles", "uma_authorization"],
     "clientRoles": {
       "account": ["view-profile", "manage-account"]
     },

--- a/backend/api/Areas/Admin/Controllers/ParcelController.cs
+++ b/backend/api/Areas/Admin/Controllers/ParcelController.cs
@@ -311,9 +311,9 @@ namespace Pims.Api.Areas.Admin.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <param name="model">The parcel model.</param>
-        /// <returns>The parcel who was deleted.</returns>
+        /// <returns>The parcel which was deleted.</returns>
         [HttpDelete("{id}")]
-        [HasPermission(Permissions.PropertyAdd)]
+        [HasPermission(Permissions.PropertyDelete)]
         [Produces("application/json")]
         [ProducesResponseType(typeof(Model.ParcelModel), 200)]
         [ProducesResponseType(typeof(BModel.ErrorResponseModel), 400)]

--- a/backend/api/Areas/Admin/Mapping/Role/RoleMap.cs
+++ b/backend/api/Areas/Admin/Mapping/Role/RoleMap.cs
@@ -7,20 +7,20 @@ namespace Pims.Api.Areas.Admin.Mapping.Role
 {
     public class RoleMap : IRegister
     {
-
         public void Register(TypeAdapterConfig config)
         {
             config.NewConfig<Entity.Role, Model.RoleModel>()
                 .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Inherits<Entity.LookupEntity<Guid>, Api.Models.LookupModel<Guid>>();
-
 
             config.NewConfig<Model.RoleModel, Entity.Role>()
                 .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Inherits<Api.Models.LookupModel<Guid>, Entity.LookupEntity<Guid>>();
         }
     }

--- a/backend/api/Areas/Admin/Mapping/User/RoleMap.cs
+++ b/backend/api/Areas/Admin/Mapping/User/RoleMap.cs
@@ -7,18 +7,16 @@ namespace Pims.Api.Areas.Admin.Mapping.User
 {
     public class RoleMap : IRegister
     {
-
         public void Register(TypeAdapterConfig config)
         {
             config.NewConfig<Entity.Role, Model.RoleModel>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Inherits<Entity.LookupEntity<Guid>, Api.Models.LookupModel<Guid>>();
 
-
             config.NewConfig<Model.RoleModel, Entity.Role>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Inherits<Api.Models.LookupModel<Guid>, Entity.LookupEntity<Guid>>();
         }
     }

--- a/backend/api/Areas/Admin/Models/Role/RoleModel.cs
+++ b/backend/api/Areas/Admin/Models/Role/RoleModel.cs
@@ -13,6 +13,12 @@ namespace Pims.Api.Areas.Admin.Models.Role
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
+
+        /// <summary>
+        /// get/set - Whether the role is public.
+        /// One which users can request to join.
+        /// </summary>
+        public bool IsPublic { get; set; }
         #endregion
     }
 }

--- a/backend/api/Areas/Admin/Models/User/RoleModel.cs
+++ b/backend/api/Areas/Admin/Models/User/RoleModel.cs
@@ -13,6 +13,12 @@ namespace Pims.Api.Areas.Admin.Models.User
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
+
+        /// <summary>
+        /// get/set - Whether the role is public.
+        /// One which users can request to join.
+        /// </summary>
+        public bool IsPublic { get; set; }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Mapping/Role/UpdateRoleMap.cs
+++ b/backend/api/Areas/Keycloak/Mapping/Role/UpdateRoleMap.cs
@@ -7,30 +7,25 @@ namespace Pims.Api.Areas.Admin.Keycloak.Role
 {
     public class UpdateRoleMap : IRegister
     {
-
         public void Register(TypeAdapterConfig config)
         {
             config.NewConfig<Entity.Role, Model.Update.RoleModel>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Inherits<Entity.BaseEntity, Model.Update.BaseModel>();
 
-
             config.NewConfig<Model.Update.RoleModel, Entity.Role>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Inherits<Model.Update.BaseModel, Entity.BaseEntity>();
 
 
             config.NewConfig<Entity.BaseEntity, Model.Update.BaseModel>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.RowVersion, src => src.RowVersion == null ? null : Convert.ToBase64String(src.RowVersion));
 
-
             config.NewConfig<Model.Update.BaseModel, Entity.BaseEntity>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.RowVersion, src => src.RowVersion == null ? null : Convert.FromBase64String(src.RowVersion));
         }
     }

--- a/backend/api/Areas/Keycloak/Mapping/User/RoleMap.cs
+++ b/backend/api/Areas/Keycloak/Mapping/User/RoleMap.cs
@@ -7,18 +7,16 @@ namespace Pims.Api.Areas.Keycloak.Mapping.User
 {
     public class RoleMap : IRegister
     {
-
         public void Register(TypeAdapterConfig config)
         {
             config.NewConfig<Entity.Role, Model.RoleModel>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Inherits<Entity.LookupEntity<Guid>, Api.Models.LookupModel<Guid>>();
 
-
             config.NewConfig<Model.RoleModel, Entity.Role>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Inherits<Api.Models.LookupModel<Guid>, Entity.LookupEntity<Guid>>();
         }
     }

--- a/backend/api/Areas/Keycloak/Models/Role/RoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/Role/RoleModel.cs
@@ -13,6 +13,12 @@ namespace Pims.Api.Areas.Keycloak.Models.Role
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
+
+        /// <summary>
+        /// get/set - Whether the role is public.
+        /// One which users can request to join.
+        /// </summary>
+        public bool IsPublic { get; set; }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/Role/Update/RoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/Role/Update/RoleModel.cs
@@ -17,6 +17,12 @@ namespace Pims.Api.Areas.Keycloak.Models.Role.Update
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
+
+        /// <summary>
+        /// get/set - Whether the role is public.
+        /// One which users can request to join.
+        /// </summary>
+        public bool IsPublic { get; set; }
         #endregion
     }
 }

--- a/backend/api/Areas/Keycloak/Models/User/RoleModel.cs
+++ b/backend/api/Areas/Keycloak/Models/User/RoleModel.cs
@@ -5,7 +5,7 @@ namespace Pims.Api.Areas.Keycloak.Models.User
     /// <summary>
     /// RoleModel class, provides a model that represents a role.
     /// </summary>
-    public class RoleModel : Pims.Api.Models.LookupModel<Guid>
+    public class RoleModel : Api.Models.LookupModel<Guid>
     {
         #region Properties
         /// <summary>
@@ -13,6 +13,12 @@ namespace Pims.Api.Areas.Keycloak.Models.User
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
+
+        /// <summary>
+        /// get/set - Whether the role is public.
+        /// One which users can request to join.
+        /// </summary>
+        public bool IsPublic { get; set; }
         #endregion
     }
 }

--- a/backend/api/Controllers/LookupController.cs
+++ b/backend/api/Controllers/LookupController.cs
@@ -1,7 +1,7 @@
 using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Model = Pims.Api.Models;
+using Model = Pims.Api.Models.Lookup;
 using Pims.Dal;
 using System.Linq;
 using System.Collections.Generic;
@@ -45,11 +45,11 @@ namespace Pims.Api.Controllers
         /// <returns></returns>
         [HttpGet("agencies")]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(IEnumerable<Model.CodeModel<int>>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<Models.CodeModel<int>>), 200)]
         [SwaggerOperation(Tags = new[] { "lookup" })]
         public IActionResult GetAgencies()
         {
-            var agencyCodes = _mapper.Map<Model.CodeModel<int>[]>(_pimsService.Lookup.GetAgencies());
+            var agencyCodes = _mapper.Map<Models.CodeModel<int>[]>(_pimsService.Lookup.GetAgencies());
             return new JsonResult(agencyCodes.ToArray());
         }
 
@@ -59,11 +59,11 @@ namespace Pims.Api.Controllers
         /// <returns></returns>
         [HttpGet("roles")]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(IEnumerable<Model.LookupModel<Guid>>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<Model.RoleModel>), 200)]
         [SwaggerOperation(Tags = new[] { "lookup" })]
         public IActionResult GetRoles()
         {
-            var roleCodes = _mapper.Map<Model.LookupModel<Guid>[]>(_pimsService.Lookup.GetRoles());
+            var roleCodes = _mapper.Map<Model.RoleModel[]>(_pimsService.Lookup.GetRoles());
             return new JsonResult(roleCodes.ToArray());
         }
 
@@ -73,11 +73,11 @@ namespace Pims.Api.Controllers
         /// <returns></returns>
         [HttpGet("property/classifications")]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(IEnumerable<Model.LookupModel<int>>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<Models.LookupModel<int>>), 200)]
         [SwaggerOperation(Tags = new[] { "lookup" })]
         public IActionResult GetPropertyClassifications()
         {
-            var propertyClassificationCodes = _mapper.Map<Model.LookupModel<int>[]>(_pimsService.Lookup.GetPropertyClassifications());
+            var propertyClassificationCodes = _mapper.Map<Models.LookupModel<int>[]>(_pimsService.Lookup.GetPropertyClassifications());
             return new JsonResult(propertyClassificationCodes.ToArray());
         }
 
@@ -87,19 +87,19 @@ namespace Pims.Api.Controllers
         /// <returns></returns>
         [HttpGet("all")]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(IEnumerable<Model.CodeModel<object>>), 200)]
+        [ProducesResponseType(typeof(IEnumerable<Models.CodeModel<object>>), 200)]
         [SwaggerOperation(Tags = new[] { "lookup" })]
         public IActionResult GetAll()
         {
-            var agencyCodes = _mapper.Map<Model.CodeModel<int>[]>(_pimsService.Lookup.GetAgencies());
-            var propertyStatusCodes = _mapper.Map<Model.LookupModel<int>[]>(_pimsService.Lookup.GetPropertyStatus());
-            var propertyClassificationCodes = _mapper.Map<Model.LookupModel<int>[]>(_pimsService.Lookup.GetPropertyClassifications());
-            var roleCodes = _mapper.Map<Model.LookupModel<Guid>[]>(_pimsService.Lookup.GetRoles());
-            var provinceCodes = _mapper.Map<Model.LookupModel<string>[]>(_pimsService.Lookup.GetProvinces());
-            var cityCodes = _mapper.Map<Model.CodeModel<int>[]>(_pimsService.Lookup.GetCities());
-            var constructionTypeCodes = _mapper.Map<Model.LookupModel<int>[]>(_pimsService.Lookup.GetBuildingConstructionTypes());
-            var predominateUseCodes = _mapper.Map<Model.LookupModel<int>[]>(_pimsService.Lookup.GetBuildingPredominateUses());
-            var occupantTypeCodes = _mapper.Map<Model.LookupModel<int>[]>(_pimsService.Lookup.GetBuildingOccupantTypes());
+            var agencyCodes = _mapper.Map<Models.CodeModel<int>[]>(_pimsService.Lookup.GetAgencies());
+            var propertyStatusCodes = _mapper.Map<Models.LookupModel<int>[]>(_pimsService.Lookup.GetPropertyStatus());
+            var propertyClassificationCodes = _mapper.Map<Models.LookupModel<int>[]>(_pimsService.Lookup.GetPropertyClassifications());
+            var roleCodes = _mapper.Map<Model.RoleModel[]>(_pimsService.Lookup.GetRoles());
+            var provinceCodes = _mapper.Map<Models.LookupModel<string>[]>(_pimsService.Lookup.GetProvinces());
+            var cityCodes = _mapper.Map<Models.CodeModel<int>[]>(_pimsService.Lookup.GetCities());
+            var constructionTypeCodes = _mapper.Map<Models.LookupModel<int>[]>(_pimsService.Lookup.GetBuildingConstructionTypes());
+            var predominateUseCodes = _mapper.Map<Models.LookupModel<int>[]>(_pimsService.Lookup.GetBuildingPredominateUses());
+            var occupantTypeCodes = _mapper.Map<Models.LookupModel<int>[]>(_pimsService.Lookup.GetBuildingOccupantTypes());
 
             var codes = new List<object>();
             codes.AddRange(roleCodes);

--- a/backend/api/Controllers/ParcelController.cs
+++ b/backend/api/Controllers/ParcelController.cs
@@ -152,7 +152,7 @@ namespace Pims.Api.Controllers
         /// <param name="model"></param>
         /// <returns></returns>
         [HttpDelete("{id}")]
-        [HasPermission(Permissions.PropertyAdd)]
+        [HasPermission(Permissions.PropertyDelete)]
         [Produces("application/json")]
         [ProducesResponseType(typeof(Model.ParcelModel), 200)]
         [SwaggerOperation(Tags = new[] { "parcel" })]
@@ -167,7 +167,6 @@ namespace Pims.Api.Controllers
         }
 
         #region Page Endpoints
-
         /// <summary>
         /// Get a page of parcels that satisfy the filter parameters.
         /// </summary>

--- a/backend/api/Mapping/Lookup/RoleMap.cs
+++ b/backend/api/Mapping/Lookup/RoleMap.cs
@@ -1,25 +1,23 @@
 using Mapster;
-using Model = Pims.Api.Areas.Keycloak.Models.Role;
+using Model = Pims.Api.Models.Lookup;
 using Entity = Pims.Dal.Entities;
 using System;
 
-namespace Pims.Api.Areas.Admin.Keycloak.Role
+namespace Pims.Api.Mapping.Lookup
 {
     public class RoleMap : IRegister
     {
         public void Register(TypeAdapterConfig config)
         {
             config.NewConfig<Entity.Role, Model.RoleModel>()
-                .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Description, src => src.Description)
                 .Map(dest => dest.IsPublic, src => src.IsPublic)
-                .Inherits<Entity.LookupEntity<Guid>, Api.Models.LookupModel<Guid>>();
+                .Inherits<Entity.LookupEntity<Guid>, Models.LookupModel<Guid>>();
 
             config.NewConfig<Model.RoleModel, Entity.Role>()
-                .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Description, src => src.Description)
                 .Map(dest => dest.IsPublic, src => src.IsPublic)
-                .Inherits<Api.Models.LookupModel<Guid>, Entity.LookupEntity<Guid>>();
+                .Inherits<Models.LookupModel<Guid>, Entity.LookupEntity<Guid>>();
         }
     }
 }

--- a/backend/api/Mapping/User/RoleMap.cs
+++ b/backend/api/Mapping/User/RoleMap.cs
@@ -11,11 +11,13 @@ namespace Pims.Api.Mapping.User
         {
             config.NewConfig<Entity.Role, Model.RoleModel>()
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Map(dest => dest.Users, src => src.Users)
                 .Inherits<Entity.LookupEntity<Guid>, Models.LookupModel<Guid>>();
 
             config.NewConfig<Model.RoleModel, Entity.Role>()
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.IsPublic, src => src.IsPublic)
                 .Map(dest => dest.Users, src => src.Users)
                 .Inherits<Models.LookupModel<Guid>, Entity.LookupEntity<Guid>>();
         }

--- a/backend/api/Models/Lookup/RoleModel.cs
+++ b/backend/api/Models/Lookup/RoleModel.cs
@@ -1,14 +1,12 @@
 using System;
-using System.Collections.Generic;
 
-namespace Pims.Api.Models.User
+namespace Pims.Api.Models.Lookup
 {
     public class RoleModel : LookupModel<Guid>
     {
         #region Properties
         public string Description { get; set; }
         public bool IsPublic { get; set; }
-        public ICollection<UserModel> Users { get; } = new List<UserModel>();
         #endregion
     }
 }

--- a/backend/dal/Helpers/Extensions/BuildingExtensions.cs
+++ b/backend/dal/Helpers/Extensions/BuildingExtensions.cs
@@ -43,10 +43,11 @@ namespace Pims.Dal.Helpers.Extensions
             // Check if user has the ability to view sensitive properties.
             var userAgencies = user.GetAgencies();
             var viewSensitive = user.HasPermission(Permissions.SensitiveView);
+            var isAdmin = user.HasPermission(Permissions.AdminProperties);
 
             // Users may only view sensitive properties if they have the `sensitive-view` claim and belong to the owning agency.
             var query = context.Buildings.AsNoTracking().Where(b =>
-                !b.IsSensitive || (viewSensitive && userAgencies.Contains(b.AgencyId)));
+                isAdmin || !b.IsSensitive || (viewSensitive && userAgencies.Contains(b.AgencyId)));
 
             if (filter.NELatitude.HasValue && filter.NELongitude.HasValue && filter.SWLatitude.HasValue && filter.SWLongitude.HasValue)
                 query = query.Where(b =>

--- a/backend/dal/Helpers/Extensions/EntityExtensions.cs
+++ b/backend/dal/Helpers/Extensions/EntityExtensions.cs
@@ -34,7 +34,7 @@ namespace Pims.Dal.Helpers.Extensions
         }
 
         /// <summary>
-        /// Throw exception if the user is not allowed to edit the specified entity.
+        /// Throw exception if the 'user' is not allowed to edit the specified 'entity'.
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="paramName"></param>
@@ -47,6 +47,28 @@ namespace Pims.Dal.Helpers.Extensions
         /// <exception type="NotAuthorizedException">User must have specified 'role'.</exception>
         /// <returns></returns>
         public static T ThrowIfNotAllowedToEdit<T>(this T entity, string paramName, ClaimsPrincipal user, Permissions permission, string message = null) where T : BaseEntity
+        {
+            entity.ThrowIfNull(paramName);
+            entity.ThrowIfRowVersionNull(paramName);
+            user.ThrowIfNotAuthorized(permission, message);
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Throw exception if the 'user' is not allowed to edit the specified 'entity'.
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="paramName"></param>
+        /// <param name="user"></param>
+        /// <param name="permission"></param>
+        /// <param name="message"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <exception type="ArgumentNullException">Entity argument cannot be null.</exception>
+        /// <exception type="RowVersionMissingException">Entity.RowVersion cannot be null.</exception>
+        /// <exception type="NotAuthorizedException">User must have specified 'role'.</exception>
+        /// <returns></returns>
+        public static T ThrowIfNotAllowedToEdit<T>(this T entity, string paramName, ClaimsPrincipal user, Permissions[] permission, string message = null) where T : BaseEntity
         {
             entity.ThrowIfNull(paramName);
             entity.ThrowIfRowVersionNull(paramName);

--- a/backend/dal/Helpers/Extensions/ParcelExtensions.cs
+++ b/backend/dal/Helpers/Extensions/ParcelExtensions.cs
@@ -57,10 +57,11 @@ namespace Pims.Dal.Helpers.Extensions
             // Check if user has the ability to view sensitive properties.
             var userAgencies = user.GetAgencies();
             var viewSensitive = user.HasPermission(Permissions.SensitiveView);
+            var isAdmin = user.HasPermission(Permissions.AdminProperties);
 
             // Users may only view sensitive properties if they have the `sensitive-view` claim and belong to the owning agency.
             var query = context.Parcels.AsNoTracking().Where(p =>
-                !p.IsSensitive || (viewSensitive && userAgencies.Contains(p.AgencyId)));
+                isAdmin || !p.IsSensitive || (viewSensitive && userAgencies.Contains(p.AgencyId)));
 
             if (filter.NELatitude.HasValue && filter.NELongitude.HasValue && filter.SWLatitude.HasValue && filter.SWLongitude.HasValue)
                 query = query.Where(p =>

--- a/backend/dal/Migrations/20200428234104_Initial.Designer.cs
+++ b/backend/dal/Migrations/20200428234104_Initial.Designer.cs
@@ -10,7 +10,7 @@ using Pims.Dal;
 namespace Pims.Dal.Migrations
 {
     [DbContext(typeof(PimsContext))]
-    [Migration("20200424171751_Initial")]
+    [Migration("20200428234104_Initial")]
     partial class Initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -1186,6 +1186,9 @@ namespace Pims.Dal.Migrations
                         .HasMaxLength(500);
 
                     b.Property<bool>("IsDisabled")
+                        .HasColumnType("bit");
+
+                    b.Property<bool>("IsPublic")
                         .HasColumnType("bit");
 
                     b.Property<string>("Name")

--- a/backend/dal/Migrations/20200428234104_Initial.cs
+++ b/backend/dal/Migrations/20200428234104_Initial.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Pims.Dal.Helpers.Migrations;
 
@@ -9,6 +9,7 @@ namespace Pims.Dal.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             PreDeploy(migrationBuilder);
+
             migrationBuilder.CreateTable(
                 name: "Users",
                 columns: table => new
@@ -418,7 +419,8 @@ namespace Pims.Dal.Migrations
                     Name = table.Column<string>(maxLength: 100, nullable: false),
                     IsDisabled = table.Column<bool>(nullable: false),
                     SortOrder = table.Column<int>(nullable: false),
-                    Description = table.Column<string>(maxLength: 500, nullable: true)
+                    Description = table.Column<string>(maxLength: 500, nullable: true),
+                    IsPublic = table.Column<bool>(nullable: false)
                 },
                 constraints: table =>
                 {

--- a/backend/dal/Migrations/Initial/PostDeploy/01-Claims.sql
+++ b/backend/dal/Migrations/Initial/PostDeploy/01-Claims.sql
@@ -15,6 +15,12 @@ VALUES
         0
     ),
     (
+        '71e74513-a036-4df3-b724-a8c349b7fc28',
+        'admin-properties',
+        'Ability to administrate properties.',
+        0
+    ),
+    (
         '9b556b3f-441f-4d11-9f6f-14d455df4e05',
         'admin-agencies',
         'Ability to administrate agencies.',
@@ -36,6 +42,12 @@ VALUES
         '223664c7-650c-40ac-8581-f40e10064537',
         'property-edit',
         'Ability to edit properties.',
+        0
+    ),
+    (
+        '223664c7-650c-40ac-8581-f40e10164537',
+        'property-delete',
+        'Ability to delete properties.',
         0
     ),
     (

--- a/backend/dal/Migrations/Initial/PostDeploy/01-Roles.sql
+++ b/backend/dal/Migrations/Initial/PostDeploy/01-Roles.sql
@@ -4,6 +4,7 @@ INSERT INTO
         [Id],
         [Name],
         [Description],
+        [IsPublic],
         [IsDisabled],
         [SortOrder]
     )
@@ -13,6 +14,7 @@ VALUES
         'System Administrator',
         'System Administrator of the PIMS solution.',
         0,
+        0,
         0
     ),
     (
@@ -20,12 +22,14 @@ VALUES
         'Agency Administrator',
         'Agency Administrator of the users agency.',
         0,
+        0,
         0
     ),
     (
         'aad8c03d-892c-4cc3-b992-5b41c4f2392c',
         'Real Estate Manager',
         'Real Estate Manager can manage properties within their agencies.',
+        1,
         0,
         0
     ),
@@ -33,6 +37,7 @@ VALUES
         '7a7b2549-ae85-4ad6-a8d3-3a5f8d4f9ca5',
         'Real Estate Analyst',
         'Real Estate Analyst can manage properties within their agencies.',
+        1,
         0,
         0
     ),
@@ -40,6 +45,7 @@ VALUES
         'fbe5fc86-f69e-4610-a746-0113d29e04cd',
         'Assistant Deputy Minister',
         'Assistant Deputy Minister can manage properties within their agencies.',
+        1,
         0,
         0
     ),
@@ -47,6 +53,7 @@ VALUES
         'c9fb2167-d675-455f-96ff-fb0c416246aa',
         'Assistant Deputy Minister Assistant',
         'Assistant Deputy Minister Assistant can manage properties within their agencies.',
+        1,
         0,
         0
     ),
@@ -54,6 +61,15 @@ VALUES
         '6cdfeb00-6f67-4457-b46a-85bbbc97066c',
         'Executive Director',
         'Executive Director can manage properties within their agencies.',
+        1,
+        0,
+        0
+    ),
+    (
+        '08c52eec-6917-4512-ac02-7d7ff89ed7a6',
+        'SRES',
+        'SRES group provides a way to add additional claims to users (i.e. property-delete).',
+        0,
         0,
         0
     )

--- a/backend/dal/Migrations/Initial/PostDeploy/02-RoleClaims.sql
+++ b/backend/dal/Migrations/Initial/PostDeploy/02-RoleClaims.sql
@@ -21,6 +21,10 @@ VALUES
 ),
     (
         'bbf27108-a0dc-4782-8025-7af7af711335'
+    , '223664c7-650c-40ac-8581-f40e10164537'   -- property-delete
+),
+    (
+        'bbf27108-a0dc-4782-8025-7af7af711335'
     , '4dc0f39a-32f0-43a4-9d90-62fd94f20567'   -- sensitive-view
 ),
     -- agency-administrator
@@ -35,6 +39,10 @@ VALUES
     (
         '6ae8448d-5f0a-4607-803a-df0bc4efdc0f'
     , '223664c7-650c-40ac-8581-f40e10064537'   -- property-edit
+),
+    (
+        '6ae8448d-5f0a-4607-803a-df0bc4efdc0f'
+    , '223664c7-650c-40ac-8581-f40e10164537'   -- property-delete
 ),
     (
         '6ae8448d-5f0a-4607-803a-df0bc4efdc0f'
@@ -119,4 +127,9 @@ VALUES
     (
         '6cdfeb00-6f67-4457-b46a-85bbbc97066c'
     , '4dc0f39a-32f0-43a4-9d90-62fd94f20567'   -- sensitive-view
+),
+    -- SRES
+    (
+        '08c52eec-6917-4512-ac02-7d7ff89ed7a6'
+    , '71e74513-a036-4df3-b724-a8c349b7fc28'   -- admin-properties
 )

--- a/backend/dal/Migrations/PimsContextModelSnapshot.cs
+++ b/backend/dal/Migrations/PimsContextModelSnapshot.cs
@@ -1186,6 +1186,9 @@ namespace Pims.Dal.Migrations
                     b.Property<bool>("IsDisabled")
                         .HasColumnType("bit");
 
+                    b.Property<bool>("IsPublic")
+                        .HasColumnType("bit");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("nvarchar(100)")

--- a/backend/dal/Security/Permissions.cs
+++ b/backend/dal/Security/Permissions.cs
@@ -24,6 +24,9 @@ namespace Pims.Dal.Security
         [Display(GroupName = "admin", Name = "admin-roles", Description = "Can administer application roles.")]
         AdminRoles,
 
+        [Display(GroupName = "admin", Name = "admin-properties", Description = "Can administer properties.")]
+        AdminProperties,
+
         [Display(GroupName = "property", Name = "property-view", Description = "Can view properties from inventory.")]
         PropertyView,
 
@@ -32,6 +35,9 @@ namespace Pims.Dal.Security
 
         [Display(GroupName = "property", Name = "property-edit", Description = "Can edit properties in inventory.")]
         PropertyEdit,
+
+        [Display(GroupName = "property", Name = "property-delete", Description = "Can delete properties in inventory.")]
+        PropertyDelete,
 
         [Display(GroupName = "property", Name = "sensitive-view", Description = "Can view sensitive properties in inventory.")]
         SensitiveView,

--- a/backend/dal/Services/Admin/Concrete/BuildingService.cs
+++ b/backend/dal/Services/Admin/Concrete/BuildingService.cs
@@ -38,8 +38,7 @@ namespace Pims.Dal.Services.Admin
         /// <returns></returns>
         public Paged<Building> Get(int page, int quantity, string sort)
         {
-            // TODO: Check for system-administrator role.
-            if (this.User == null) throw new NotAuthorizedException();
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             var entities = this.Context.Buildings.AsNoTracking();
 
@@ -54,8 +53,7 @@ namespace Pims.Dal.Services.Admin
         /// <returns></returns>
         public Building Get(int id)
         {
-            // TODO: Check for system-administrator role.
-            if (this.User == null) throw new NotAuthorizedException();
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             return this.Context.Buildings
                 .Include(p => p.BuildingConstructionType)
@@ -76,8 +74,7 @@ namespace Pims.Dal.Services.Admin
         /// <returns></returns>
         public Building GetByLocalId(string localId)
         {
-            // TODO: Check for system-administrator role.
-            if (this.User == null) throw new NotAuthorizedException();
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             return this.Context.Buildings
                 .Include(p => p.BuildingConstructionType)
@@ -99,8 +96,7 @@ namespace Pims.Dal.Services.Admin
         /// <returns></returns>
         public Building GetByPidAndLocalId(int pid, string localId)
         {
-            // TODO: Check for system-administrator role.
-            if (this.User == null) throw new NotAuthorizedException();
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             return this.Context.Buildings
                 .Include(p => p.BuildingConstructionType)
@@ -123,6 +119,7 @@ namespace Pims.Dal.Services.Admin
         public override Building Add(Building entity)
         {
             entity.ThrowIfNull(nameof(entity));
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             if (entity.Agency != null)
                 this.Context.Entry(entity.Agency).State = EntityState.Unchanged;
@@ -187,6 +184,7 @@ namespace Pims.Dal.Services.Admin
         public override Building Update(Building entity)
         {
             entity.ThrowIfNull(nameof(entity));
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             var building = this.Context.Buildings.Find(entity.Id);
             if (building == null) throw new KeyNotFoundException();
@@ -202,6 +200,7 @@ namespace Pims.Dal.Services.Admin
         public override void Remove(Building entity)
         {
             entity.ThrowIfNull(nameof(entity));
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             var building = this.Context.Buildings.Find(entity.Id);
             if (building == null) throw new KeyNotFoundException();

--- a/backend/dal/Services/Admin/Concrete/ParcelService.cs
+++ b/backend/dal/Services/Admin/Concrete/ParcelService.cs
@@ -327,6 +327,7 @@ namespace Pims.Dal.Services.Admin
         public override Parcel Update(Parcel entity)
         {
             entity.ThrowIfNull(nameof(entity));
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             var parcel = this.Context.Parcels.Find(entity.Id) ?? throw new KeyNotFoundException();
 
@@ -346,6 +347,7 @@ namespace Pims.Dal.Services.Admin
         public override void Remove(Parcel entity)
         {
             entity.ThrowIfNull(nameof(entity));
+            this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             var parcel = this.Context.Parcels.Find(entity.Id) ?? throw new KeyNotFoundException();
 

--- a/backend/entities/Role.cs
+++ b/backend/entities/Role.cs
@@ -16,6 +16,12 @@ namespace Pims.Dal.Entities
         public string Description { get; set; }
 
         /// <summary>
+        /// get/set - Whether the role is a public role.
+        /// One which new users can request to join.
+        /// </summary>
+        public bool IsPublic { get; set; } = false;
+
+        /// <summary>
         /// get - A collection of users that have this role.
         /// </summary>
         /// <typeparam name="UserRole"></typeparam>

--- a/backend/tests/core/DatabaseHelper.cs
+++ b/backend/tests/core/DatabaseHelper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Moq;
 using Pims.Core.Helpers;
 using Pims.Dal;
@@ -50,6 +51,7 @@ namespace Pims.Core.Test
             helper.AddSingleton(user);
             var options = new DbContextOptionsBuilder<PimsContext>()
                 .UseInMemoryDatabase(databaseName: dbName)
+                .ConfigureWarnings(m => m.Ignore(InMemoryEventId.TransactionIgnoredWarning))
                 .Options;
 
             var contextAccessor = new Mock<IHttpContextAccessor>();

--- a/backend/tests/unit/api/Controllers/Admin/ParcelControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/Admin/ParcelControllerTest.cs
@@ -370,32 +370,6 @@ namespace Pims.Api.Test.Controllers.Admin
         }
         #endregion
 
-        #region DeleteParcel
-        [Fact]
-        public void DeleteParcel_Success()
-        {
-            // Arrange
-            var helper = new TestHelper();
-            var controller = helper.CreateController<ParcelController>(Permissions.PropertyAdd);
-
-            var service = helper.GetService<Mock<IPimsAdminService>>();
-            var mapper = helper.GetService<IMapper>();
-            var existingParcel = EntityHelper.CreateParcel(1);
-            service.Setup(m => m.Parcel.Remove(It.IsAny<Entity.Parcel>()));
-            var modelToDelete = mapper.Map<Model.ParcelModel>(existingParcel);
-
-            // Act
-            var result = controller.DeleteParcel(existingParcel.Id, modelToDelete);
-
-            // Assert
-            var actionResult = Assert.IsType<JsonResult>(result);
-            Assert.Null(actionResult.StatusCode);
-            var actualResult = Assert.IsType<Model.ParcelModel>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.ParcelModel>(existingParcel), actualResult, new DeepPropertyCompare());
-            service.Verify(m => m.Parcel.Remove(It.IsAny<Entity.Parcel>()), Times.Once());
-        }
-        #endregion
-
         #region AddParcel
         [Fact]
         public void AddParcel_Success()
@@ -796,6 +770,32 @@ namespace Pims.Api.Test.Controllers.Admin
             Assert.Equal(model.Buildings.First().Fiscals.Count(), actualParcel.Buildings.First().Fiscals.Count());
             Assert.Equal(model.Buildings.First().Fiscals.First().Value, actualParcel.Buildings.First().Fiscals.First().Value);
             service.Verify(m => m.Parcel.Update(It.IsAny<Entity.Parcel>()), Times.Once());
+        }
+        #endregion
+
+        #region DeleteParcel
+        [Fact]
+        public void DeleteParcel_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<ParcelController>(Permissions.PropertyDelete);
+
+            var service = helper.GetService<Mock<IPimsAdminService>>();
+            var mapper = helper.GetService<IMapper>();
+            var existingParcel = EntityHelper.CreateParcel(1);
+            service.Setup(m => m.Parcel.Remove(It.IsAny<Entity.Parcel>()));
+            var modelToDelete = mapper.Map<Model.ParcelModel>(existingParcel);
+
+            // Act
+            var result = controller.DeleteParcel(existingParcel.Id, modelToDelete);
+
+            // Assert
+            var actionResult = Assert.IsType<JsonResult>(result);
+            Assert.Null(actionResult.StatusCode);
+            var actualResult = Assert.IsType<Model.ParcelModel>(actionResult.Value);
+            Assert.Equal(mapper.Map<Model.ParcelModel>(existingParcel), actualResult, new DeepPropertyCompare());
+            service.Verify(m => m.Parcel.Remove(It.IsAny<Entity.Parcel>()), Times.Once());
         }
         #endregion
         #endregion

--- a/backend/tests/unit/api/Controllers/LookupControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/LookupControllerTest.cs
@@ -1,19 +1,18 @@
 using Xunit;
 using System;
-using Pims.Dal;
-using Pims.Api.Controllers;
-using Newtonsoft.Json;
-using Moq;
-using Model = Pims.Api.Models;
-using Microsoft.AspNetCore.Mvc;
-using Entity = Pims.Dal.Entities;
-using MapsterMapper;
-using Pims.Core.Test;
-using Pims.Core.Comparers;
-using System.Collections.Generic;
 using System.Linq;
-using Pims.Core.Extensions;
 using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using Pims.Dal;
+using Pims.Core.Test;
+using Pims.Core.Extensions;
+using Pims.Core.Comparers;
+using Pims.Api.Controllers;
+using Moq;
+using Model = Pims.Api.Models.Lookup;
+using Microsoft.AspNetCore.Mvc;
+using MapsterMapper;
+using Entity = Pims.Dal.Entities;
 
 namespace Pims.Api.Test.Controllers
 {
@@ -56,8 +55,8 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Model.CodeModel<int>[]>(actionResult.Value);
-            Assert.Equal(new[] { mapper.Map<Model.CodeModel<int>>(agency) }, actualResult, new DeepPropertyCompare());
+            var actualResult = Assert.IsType<Models.CodeModel<int>[]>(actionResult.Value);
+            Assert.Equal(new[] { mapper.Map<Models.CodeModel<int>>(agency) }, actualResult, new DeepPropertyCompare());
             pimsService.Verify(m => m.Lookup.GetAgencies(), Times.Once());
         }
 
@@ -82,8 +81,8 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Model.LookupModel<int>[]>(actionResult.Value);
-            Assert.Equal(new[] { mapper.Map<Model.LookupModel<int>>(propertyClassification) }, actualResult, new DeepPropertyCompare());
+            var actualResult = Assert.IsType<Models.LookupModel<int>[]>(actionResult.Value);
+            Assert.Equal(new[] { mapper.Map<Models.LookupModel<int>>(propertyClassification) }, actualResult, new DeepPropertyCompare());
             pimsService.Verify(m => m.Lookup.GetPropertyClassifications(), Times.Once());
         }
 
@@ -110,8 +109,8 @@ namespace Pims.Api.Test.Controllers
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
-            var actualResult = Assert.IsType<Model.LookupModel<Guid>[]>(actionResult.Value);
-            Assert.Equal(new[] { mapper.Map<Model.LookupModel<Guid>>(role) }, actualResult, new DeepPropertyCompare());
+            var actualResult = Assert.IsType<Model.RoleModel[]>(actionResult.Value);
+            Assert.Equal(new[] { mapper.Map<Model.RoleModel>(role) }, actualResult, new DeepPropertyCompare());
             pimsService.Verify(m => m.Lookup.GetRoles(), Times.Once());
         }
 
@@ -158,15 +157,15 @@ namespace Pims.Api.Test.Controllers
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             var actualResult = Assert.IsAssignableFrom<IEnumerable<object>>(actionResult.Value);
-            Assert.Equal(mapper.Map<Model.LookupModel<Guid>>(role), actualResult.First(), new ShallowPropertyCompare());
-            Assert.Equal(mapper.Map<Model.CodeModel<int>>(agency), actualResult.Next(1), new ShallowPropertyCompare());
-            Assert.Equal(mapper.Map<Model.LookupModel<int>>(propertyStatus), actualResult.Next(2), new ShallowPropertyCompare());
-            Assert.Equal(mapper.Map<Model.LookupModel<int>>(propertyClassification), actualResult.Next(3), new ShallowPropertyCompare());
-            Assert.Equal(mapper.Map<Model.LookupModel<string>>(province), actualResult.Next(4), new ShallowPropertyCompare());
-            Assert.Equal(mapper.Map<Model.CodeModel<int>>(city), actualResult.Next(5), new ShallowPropertyCompare());
-            Assert.Equal(mapper.Map<Model.LookupModel<int>>(buildingConstructionType), actualResult.Next(6), new ShallowPropertyCompare());
-            Assert.Equal(mapper.Map<Model.LookupModel<int>>(buildingPredominateUse), actualResult.Next(7), new ShallowPropertyCompare());
-            Assert.Equal(mapper.Map<Model.LookupModel<int>>(buildingOccupantType), actualResult.Next(8), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Model.RoleModel>(role), actualResult.First(), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Models.CodeModel<int>>(agency), actualResult.Next(1), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Models.LookupModel<int>>(propertyStatus), actualResult.Next(2), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Models.LookupModel<int>>(propertyClassification), actualResult.Next(3), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Models.LookupModel<string>>(province), actualResult.Next(4), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Models.CodeModel<int>>(city), actualResult.Next(5), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Models.LookupModel<int>>(buildingConstructionType), actualResult.Next(6), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Models.LookupModel<int>>(buildingPredominateUse), actualResult.Next(7), new ShallowPropertyCompare());
+            Assert.Equal(mapper.Map<Models.LookupModel<int>>(buildingOccupantType), actualResult.Next(8), new ShallowPropertyCompare());
         }
         #endregion
     }

--- a/backend/tests/unit/api/Controllers/ParcelControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/ParcelControllerTest.cs
@@ -307,7 +307,7 @@ namespace Pims.Api.Test.Controllers
         {
             // Arrange
             var helper = new TestHelper();
-            var controller = helper.CreateController<ParcelController>(Permissions.PropertyAdd);
+            var controller = helper.CreateController<ParcelController>(Permissions.PropertyDelete);
 
             var service = helper.GetService<Mock<IPimsService>>();
             var mapper = helper.GetService<IMapper>();

--- a/backend/tests/unit/api/Routes/Admin/ParcelControllerTest.cs
+++ b/backend/tests/unit/api/Routes/Admin/ParcelControllerTest.cs
@@ -145,7 +145,7 @@ namespace Pims.Api.Test.Routes.Admin
             // Assert
             Assert.NotNull(endpoint);
             endpoint.HasDelete("{id}");
-            endpoint.HasPermissions(Permissions.PropertyAdd);
+            endpoint.HasPermissions(Permissions.PropertyDelete);
         }
         #endregion
     }

--- a/backend/tests/unit/api/Routes/ParcelControllerTest.cs
+++ b/backend/tests/unit/api/Routes/ParcelControllerTest.cs
@@ -116,7 +116,7 @@ namespace Pims.Api.Test.Routes
             // Assert
             Assert.NotNull(endpoint);
             endpoint.HasDelete("{id}");
-            endpoint.HasPermissions(Permissions.PropertyAdd);
+            endpoint.HasPermissions(Permissions.PropertyDelete);
         }
 
         [Fact]

--- a/backend/tests/unit/dal/Services/Admin/ParcelServiceTest.cs
+++ b/backend/tests/unit/dal/Services/Admin/ParcelServiceTest.cs
@@ -214,6 +214,146 @@ namespace Pims.Dal.Test.Services.Admin
             Assert.True(result.IsSensitive);
         }
         #endregion
+
+        #region Delete Parcel
+        /// <summary>
+        /// Argument cannot be null.
+        /// </summary>
+        [Fact]
+        public void Remove_ArgumentNull()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission();
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var dbName = StringHelper.Generate(10);
+            helper.CreatePimsContext(dbName, user, true).AddOne(parcel);
+
+            var service = helper.CreateService<ParcelService>(dbName, user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            // Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                service.Remove(null));
+        }
+
+        /// <summary>
+        /// User does not have 'property-delete' claim.
+        /// </summary>
+        [Fact]
+        public void Remove_NotAuthorized()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission();
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var dbName = StringHelper.Generate(10);
+            helper.CreatePimsContext(dbName, user, true).AddOne(parcel);
+
+            var service = helper.CreateService<ParcelService>(dbName, user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            // Assert
+            Assert.Throws<NotAuthorizedException>(() =>
+                service.Remove(parcel));
+        }
+
+        /// <summary>
+        /// Parcel does not exist.
+        /// </summary>
+        [Fact]
+        public void Remove_KeyNotFound()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var find = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var parcel = EntityHelper.CreateParcel(2, 1, 1, 1);
+            var dbName = StringHelper.Generate(10);
+            helper.CreatePimsContext(dbName, user, true).AddOne(parcel);
+
+            var service = helper.CreateService<ParcelService>(dbName, user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            // Assert
+            Assert.Throws<KeyNotFoundException>(() =>
+                service.Remove(find));
+        }
+
+        /// <summary>
+        /// Parcel found.
+        /// </summary>
+        [Fact]
+        public void Remove_SystemAdmin()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin).AddAgency(1);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var dbName = StringHelper.Generate(10);
+            helper.CreatePimsContext(dbName, user, true).AddOne(parcel);
+
+            var service = helper.CreateService<ParcelService>(dbName, user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            service.Remove(parcel);
+
+            // Assert
+            Assert.Equal(EntityState.Detached, context.Entry(parcel).State);
+        }
+
+        /// <summary>
+        /// Parcel found.
+        /// </summary>
+        [Fact]
+        public void Remove_AgencyAdmin()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.AgencyAdmin).AddAgency(1);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var dbName = StringHelper.Generate(10);
+            helper.CreatePimsContext(dbName, user, true).AddOne(parcel);
+
+            var service = helper.CreateService<ParcelService>(dbName, user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            service.Remove(parcel);
+
+            // Assert
+            Assert.Equal(EntityState.Detached, context.Entry(parcel).State);
+        }
+
+        /// <summary>
+        /// Sensitive parcel found.
+        /// </summary>
+        [Fact]
+        public void Remove_Sensitive()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin, Permissions.SensitiveView).AddAgency(1);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            parcel.IsSensitive = true;
+            var dbName = StringHelper.Generate(10);
+            helper.CreatePimsContext(dbName, user, true).AddOne(parcel);
+
+            var service = helper.CreateService<ParcelService>(dbName, user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            service.Remove(parcel);
+
+            // Assert
+            Assert.Equal(EntityState.Detached, context.Entry(parcel).State);
+            Assert.True(parcel.IsSensitive);
+        }
+        #endregion
         #endregion
     }
 }

--- a/frontend/src/actions/lookupActions.tsx
+++ b/frontend/src/actions/lookupActions.tsx
@@ -7,6 +7,7 @@ export interface ILookupCode {
   name: string;
   id: string;
   isDisabled: boolean;
+  isPublic?: boolean;
   type: string;
 }
 

--- a/frontend/src/pages/AccessRequestPage.tsx
+++ b/frontend/src/pages/AccessRequestPage.tsx
@@ -59,7 +59,7 @@ const AccessRequestPage = () => {
     return lookupCode.type === API.AGENCY_CODE_SET_NAME;
   });
   const roles = _.filter(lookupCodes, (lookupCode: ILookupCode) => {
-    return lookupCode.type === API.ROLE_CODE_SET_NAME;
+    return lookupCode.type === API.ROLE_CODE_SET_NAME && !!lookupCode.isPublic;
   });
 
   const accessRequest = data?.accessRequest;


### PR DESCRIPTION
# Description

We now have a way to identify Roles as *private* or *public*.  Public Roles will be displayed in the **Access Request Page** so that users can select them.

There is a new SRES Role, which includes the `property-delete` and `admin-properties` Claims.  This allows us for now to add the SRES Role manually through Keycloak to any users who require it.

The new Claim `property-delete` is required to delete properties of which belong to an agency the user belongs to.

The new Claim `admin-properties` allows a user to do the following;

- Edit properties in other agencies
- Delete properties in other agencies
- View sensitive properties in other agencies

# Development

- EF Migration Refresh required
- Keycloak import script update (refresh keycloak-db)