### PR TITLE
PIMS-1685 Fixing api coverage and secret

### DIFF
--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       working-directory: ./backend
+      codeCov-token: ${{ secrets.CodeCov }}
 
     steps:
       - uses: actions/checkout@v2
@@ -31,10 +32,10 @@ jobs:
         run: dotnet test --no-restore --verbosity normal
         working-directory: ${{env.working-directory}}
       - name: Generate code coverage
-        run: coverlet ./tests/unit/api/bin/Release/netcoreapp3.1/Pims.Api.Test.dll --target "dotnet" --targetargs "test ./ --no-build" -o "./tests/TestResults/coverage.json" --exclude "[*.Test]*" --exclude "[*]*Model" --exclude-by-attribute "CompilerGenerated" -f json
+        run: coverlet ./tests/unit/api/bin/Release/netcoreapp3.1/Pims.Api.Test.dll --target "dotnet" --targetargs "test ./ --no-build" -o "./tests/TestResults/api-coverage.json" --exclude "[*.Test]*" --exclude "[*]*Model" --exclude-by-attribute "CompilerGenerated" -f json
         working-directory: ${{env.working-directory}}
       - name: Merge code coverage
-        run: coverlet ./tests/unit/dal/bin/Release/netcoreapp3.1/Pims.Dal.Test.dll --target "dotnet" --targetargs "test ./ --no-build" -o "./tests/TestResults/coverage.json" --exclude "[*.Test]*" --exclude "[*]*Model" --exclude-by-attribute "CompilerGenerated" --merge-with "./tests/TestResults/coverage.json" -f json
+        run: coverlet ./tests/unit/dal/bin/Release/netcoreapp3.1/Pims.Dal.Test.dll --target "dotnet" --targetargs "test ./ --no-build" -o "./tests/TestResults/coverage.xml" --exclude "[*.Test]*" --exclude "[*]*Model" --exclude-by-attribute "CompilerGenerated" --merge-with "./tests/TestResults/api-coverage.json" -f cobertura
         working-directory: ${{env.working-directory}}
 
       - name: Codecov
@@ -43,9 +44,9 @@ jobs:
           # User defined upload name. Visible in Codecov UI
           name: PIMS
           # Repository upload token - get it from codecov.io. Required only for private repositories
-          token: c02e6ccf-6e0f-47cd-842e-ab2f488933b8
+          token: ${{env.codeCov-token}}
           # Path to coverage file to upload
-          file: ${{env.working-directory}}/tests/TestResults/coverage.json
+          file: ${{env.working-directory}}/tests/TestResults/coverage.xml
           # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
           flags: unittests
           # Environment variables to tag the upload with (e.g. PYTHON | OS,PYTHON)

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       CI: true
       working-directory: ./frontend
+      codeCov-token: ${{ secrets.CodeCov }}
 
     strategy:
       matrix:
@@ -36,7 +37,7 @@ jobs:
           # User defined upload name. Visible in Codecov UI
           name: PIMS
           # Repository upload token - get it from codecov.io. Required only for private repositories
-          token: c02e6ccf-6e0f-47cd-842e-ab2f488933b8
+          token: ${{env.codeCov-token}}
           # Path to coverage file to upload
           file: ${{env.working-directory}}/coverage/coverage-final.json
           # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   require_ci_to_pass: yes
-  branch: dev
+  branch: master
 
 coverage:
   precision: 2


### PR DESCRIPTION
## Description

For some reason the api code coverage report wasn't working.

Using GitHub secrets to keep the CodeCov token outside of source.