### PR TITLE
Postal code format

### DIFF
--- a/frontend/src/forms/subforms/AddressForm.tsx
+++ b/frontend/src/forms/subforms/AddressForm.tsx
@@ -41,6 +41,20 @@ const AddressForm = <T extends any>(props: AddressProps & FormikProps<T>) => {
     return nameSpace ? `${nameSpace}.${fieldName}` : fieldName;
   };
 
+  const postalCodeFormatter = (postal: string) => {
+    const noSpace = RegExp(/^[a-zA-z][0-9][a-zA-z][0-9][a-zA-z][0-9]$/);
+    const hyphen = RegExp(/^[a-zA-z][0-9][a-zA-z]-[0-9][a-zA-z][0-9]$/);
+    if (noSpace.test(postal)) {
+      postal = postal.substr(0, 3) + ' ' + postal.substr(3, 5);
+      return postal.toUpperCase();
+    } else if (hyphen.test(postal)) {
+      postal = postal.replace('-', ' ');
+      return postal.toUpperCase();
+    } else {
+      return postal.toUpperCase();
+    }
+  };
+
   return (
     <Fragment>
       <Col className="addressForm" md={6}>
@@ -88,7 +102,9 @@ const AddressForm = <T extends any>(props: AddressProps & FormikProps<T>) => {
             formikProps={props}
             disabled={props.disabled}
             outerClassName="col-md-10"
-            onBlurFormatter={(postal: string) => postal.replace(/[\s-]+/, '')}
+            onBlurFormatter={(postal: string) =>
+              postal.replace(postal, postalCodeFormatter(postal))
+            }
             field={withNameSpace('postal')}
           />
         </Form.Row>

--- a/frontend/src/utils/YupSchema.tsx
+++ b/frontend/src/utils/YupSchema.tsx
@@ -50,7 +50,7 @@ export const Address = Yup.object().shape({
     .nullable(),
   provinceId: Yup.string().required('Required'),
   postal: Yup.string().matches(
-    /^[a-zA-z][0-9][a-zA-z]\s*?[0-9][a-zA-z][0-9]$/,
+    /^[a-zA-z][0-9][a-zA-z]\s*-*[0-9][a-zA-z][0-9]$/,
     'Invalid Postal Code',
   ),
 });


### PR DESCRIPTION
Postal code will now automatically format to upper case, remove a hyphen and replace with a space, and if there is no space it will add one.