### PR TITLE
DB Migration - System Accounts

### DIFF
--- a/backend/dal/Migrations/20200514194159_Initial.Designer.cs
+++ b/backend/dal/Migrations/20200514194159_Initial.Designer.cs
@@ -10,7 +10,7 @@ using Pims.Dal;
 namespace Pims.Dal.Migrations
 {
     [DbContext(typeof(PimsContext))]
-    [Migration("20200429135731_Initial")]
+    [Migration("20200514194159_Initial")]
     partial class Initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -1305,6 +1305,9 @@ namespace Pims.Dal.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
+
+                    b.Property<bool>("IsSystem")
+                        .HasColumnType("bit");
 
                     b.Property<string>("LastName")
                         .IsRequired()

--- a/backend/dal/Migrations/20200514194159_Initial.cs
+++ b/backend/dal/Migrations/20200514194159_Initial.cs
@@ -29,7 +29,8 @@ namespace Pims.Dal.Migrations
                     Position = table.Column<string>(maxLength: 100, nullable: true),
                     IsDisabled = table.Column<bool>(nullable: false, defaultValue: false),
                     EmailVerified = table.Column<bool>(nullable: false, defaultValue: false),
-                    Note = table.Column<string>(maxLength: 1000, nullable: true)
+                    Note = table.Column<string>(maxLength: 1000, nullable: true),
+                    IsSystem = table.Column<bool>(nullable: false)
                 },
                 constraints: table =>
                 {

--- a/backend/dal/Migrations/Initial/PostDeploy/01-Users.sql
+++ b/backend/dal/Migrations/Initial/PostDeploy/01-Users.sql
@@ -8,6 +8,7 @@ INSERT INTO dbo.[Users] (
     , [LastName]
     , [Email]
     , [IsDisabled]
+    , [IsSystem]
 ) VALUES (
     '00000000-0000-0000-0000-000000000000'
     , 'system'
@@ -15,5 +16,6 @@ INSERT INTO dbo.[Users] (
     , 'system'
     , 'system'
     , 'pims@Pims.gov.bc.ca'
+    , 1
     , 1
 )

--- a/backend/dal/Migrations/PimsContextModelSnapshot.cs
+++ b/backend/dal/Migrations/PimsContextModelSnapshot.cs
@@ -1304,6 +1304,9 @@ namespace Pims.Dal.Migrations
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
+                    b.Property<bool>("IsSystem")
+                        .HasColumnType("bit");
+
                     b.Property<string>("LastName")
                         .IsRequired()
                         .HasColumnType("nvarchar(100)")

--- a/backend/dal/Services/Admin/Concrete/UserService.cs
+++ b/backend/dal/Services/Admin/Concrete/UserService.cs
@@ -9,7 +9,6 @@ using Pims.Core.Extensions;
 using Pims.Dal.Entities;
 using Pims.Dal.Entities.Comparers;
 using Pims.Dal.Entities.Models;
-using Pims.Dal.Exceptions;
 using Pims.Dal.Helpers.Extensions;
 using Pims.Dal.Security;
 
@@ -61,7 +60,8 @@ namespace Pims.Dal.Services.Admin
                 .ThenInclude(a => a.Agency)
                 .Include(r => r.Roles)
                 .ThenInclude(r => r.Role)
-                .AsNoTracking();
+                .AsNoTracking()
+                .Where(u => !u.IsSystem);
 
             var userAgencies = this.User.GetAgencies();
             if (userAgencies != null && User.HasPermission(Permissions.AgencyAdmin) && !User.HasPermission(Permissions.SystemAdmin))

--- a/backend/entities/User.cs
+++ b/backend/entities/User.cs
@@ -76,6 +76,12 @@ namespace Pims.Dal.Entities
         public string Note { get; set; }
 
         /// <summary>
+        /// get/set - Whether this user account is a system account.
+        /// A system account will not be visible through user management.
+        /// </summary>
+        public bool IsSystem { get; set; }
+
+        /// <summary>
         /// get - A collection of agencies this user belongs to.
         /// </summary>
         /// <typeparam name="UserAgency"></typeparam>


### PR DESCRIPTION
## Description

We have system user accounts that exists for backend relationships that shouldn't be returned as users that can be managed.  This update will hide them from the UI.

This only solves one of the two problems, but it's a start.

Regrettably it requires a DB refresh.