### PR TITLE
Re-enable API code coverage on CI servers

### DIFF
--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -31,24 +31,33 @@ jobs:
       - name: Test
         run: dotnet test --no-restore --verbosity normal
         working-directory: ${{env.working-directory}}
-      # - name: Generate code coverage
-      #   run: coverlet ./tests/unit/api/bin/Release/netcoreapp3.1/Pims.Api.Test.dll --target "dotnet" --targetargs "test ./ --no-build" -o "./tests/TestResults/api-coverage.json" --exclude "[*.Test]*" --exclude "[*]*Model" --exclude-by-attribute "CompilerGenerated" -f json
-      #   working-directory: ${{env.working-directory}}
-      # - name: Merge code coverage
-      #   run: coverlet ./tests/unit/dal/bin/Release/netcoreapp3.1/Pims.Dal.Test.dll --target "dotnet" --targetargs "test ./ --no-build" -o "./tests/TestResults/coverage.xml" --exclude "[*.Test]*" --exclude "[*]*Model" --exclude-by-attribute "CompilerGenerated" --merge-with "./tests/TestResults/api-coverage.json" -f opencover
-      #   working-directory: ${{env.working-directory}}
-      # - name: Codecov
-      #   uses: codecov/codecov-action@v1.0.7
-      #   with:
-      #     # User defined upload name. Visible in Codecov UI
-      #     name: PIMS
-      #     # Repository upload token - get it from codecov.io. Required only for private repositories
-      #     token: ${{env.codeCov-token}}
-      #     # Path to coverage file to upload
-      #     file: ${{env.working-directory}}/tests/TestResults/coverage.xml
-      #     # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
-      #     flags: unittests
-      #     # Environment variables to tag the upload with (e.g. PYTHON | OS,PYTHON)
-      #     env_vars: C#
-      #     # Specify whether or not CI build should fail if Codecov runs into an error during upload
-      #     fail_ci_if_error: true
+      - name: Generate code coverage
+        working-directory: ${{env.working-directory}}/tests/unit
+        run: |
+          mkdir -p TestResults
+          rm -rf api/TestResults
+          rm -rf dal/TestResults
+          cd api
+          dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore
+          mv TestResults/*/coverage.json ../TestResults/coverage.json
+          cd ..
+          cd dal
+          dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore
+          mv TestResults/*/* ../TestResults/
+          cd ..
+          head TestResults/coverage.opencover.xml
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          # User defined upload name. Visible in Codecov UI
+          name: PIMS
+          # Repository upload token - get it from codecov.io. Required only for private repositories
+          token: ${{env.codeCov-token}}
+          # Path to coverage file to upload
+          file: ${{env.working-directory}}/tests/unit/TestResults/coverage.opencover.xml
+          # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
+          flags: unittests
+          # Environment variables to tag the upload with (e.g. PYTHON | OS,PYTHON)
+          env_vars: C#
+          # Specify whether or not CI build should fail if Codecov runs into an error during upload
+          fail_ci_if_error: true

--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -31,6 +31,30 @@ jobs:
       - name: Test
         run: dotnet test --no-restore --verbosity normal
         working-directory: ${{env.working-directory}}
+
+        # For future reference, if we have N test projects the flow of events would be:
+        #
+        # **Pre-conditions:**
+        # - All projects export their individual coverage percents in JSON and OpenCover format
+        # - There's no way to merge OpenCover xmls together (that I could find)
+        # - Common folder "../TestResults" is  git ignored so nothing gets in source control
+        #
+        # **Steps:**
+        #
+        # - Test-project 1
+        #   - generate coverage files (without merging)
+        #   - copy results to common folder "../TestResults"
+        # - Test-project 2
+        #   - generate coverage files merging with previous `coverage.json`
+        #   - the previous `coverage.opencoverage.xml` is ignored
+        #   - copy results to common folder "../TestResults"
+        # ...
+        # - Test-project N
+        #   - generate coverage files merging with previous `coverage.json`
+        #   - the previous `coverage.opencoverage.xml` is ignored
+        #   - copy results to common folder "../TestResults"
+        #
+        # The final `coverage.opencover.xml` is the one we want
       - name: Generate code coverage
         working-directory: ${{env.working-directory}}/tests/unit
         run: |
@@ -39,7 +63,7 @@ jobs:
           rm -rf dal/TestResults
           cd api
           dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore
-          mv TestResults/*/coverage.json ../TestResults/coverage.json
+          mv TestResults/*/* ../TestResults/
           cd ..
           cd dal
           dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore

--- a/backend/tests/unit/api/coverlet.runsettings
+++ b/backend/tests/unit/api/coverlet.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>json,opencover</Format>
+          <Exclude>[*.Test]*,[*]*Model,[*]*Migrations*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/backend/tests/unit/dal/coverlet.runsettings
+++ b/backend/tests/unit/dal/coverlet.runsettings
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>json,opencover</Format>
+          <MergeWith>../TestResults/coverage.json</MergeWith>
+          <Exclude>[*.Test]*,[*]*Model,[*]*Migrations*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -294,30 +294,21 @@ pipeline {
                 echo 'Build'
                 sh 'dotnet build --configuration Release --no-restore'
 
-                echo 'Testing the API...'
-                sh 'dotnet test --no-restore'
-
-                echo 'Generate code coverage'
+                echo 'Run API tests and collect code coverage'
                 sh '''
-                coverlet ./tests/unit/api/bin/Release/netcoreapp3.1/Pims.Api.Test.dll \
-                  --target "dotnet" \
-                  --targetargs "test ./ --no-build" \
-                  -o "./tests/TestResults/api-coverage.json" \
-                  --exclude "[*.Test]*" \
-                  --exclude "[*]*Model" \
-                  --exclude-by-attribute "CompilerGenerated" \
-                  -f json
-                '''
-                sh '''
-                coverlet ./tests/unit/dal/bin/Release/netcoreapp3.1/Pims.Dal.Test.dll \
-                  --target "dotnet" \
-                  --targetargs "test ./ --no-build" \
-                  -o "./tests/TestResults/coverage.xml" \
-                  --exclude "[*.Test]*" \
-                  --exclude "[*]*Model" \
-                  --exclude-by-attribute "CompilerGenerated" \
-                  --merge-with "./tests/TestResults/api-coverage.json" \
-                  -f opencover
+                cd tests/unit
+                mkdir -p TestResults
+                rm -rf api/TestResults
+                rm -rf dal/TestResults
+                cd api
+                dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore
+                mv TestResults/*/coverage.json ../TestResults/coverage.json
+                cd ..
+                cd dal
+                dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore
+                mv TestResults/*/* ../TestResults/
+                cd ..
+                head TestResults/coverage.opencover.xml
                 '''
 
                 echo 'API Tests passed'
@@ -331,7 +322,7 @@ pipeline {
       }
       post {
         success {
-          stash name: API_COV_STASH, includes: 'backend/tests/TestResults/**'
+          stash name: API_COV_STASH, includes: 'backend/tests/unit/TestResults/**'
           echo 'All Tests passed'
         }
         failure {

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -294,6 +294,29 @@ pipeline {
                 echo 'Build'
                 sh 'dotnet build --configuration Release --no-restore'
 
+                // For future reference, if we have N test projects the flow of events would be:
+                //
+                // **Pre-conditions:**
+                //  - All projects export their individual coverage percents in JSON and OpenCover format
+                //  - There's no way to merge OpenCover xmls together (that I could find)
+                //  - Common folder "../TestResults" is  git ignored so nothing gets in source control
+                //
+                // **Steps:**
+                //
+                // Test-project 1
+                //   - generate coverage files (without merging)
+                //   - copy results to common folder "../TestResults"
+                // Test-project 2
+                //   - generate coverage files merging with previous `coverage.json`
+                //   - the previous `coverage.opencoverage.xml` is ignored
+                //   - copy results to common folder "../TestResults"
+                //  ...
+                // Test-project N
+                //   - generate coverage files merging with previous `coverage.json`
+                //   - the previous `coverage.opencoverage.xml` is ignored
+                //   - copy results to common folder "../TestResults"
+                //
+                // The final `coverage.opencover.xml` is the one we want
                 echo 'Run API tests and collect code coverage'
                 sh '''
                 cd tests/unit
@@ -302,7 +325,7 @@ pipeline {
                 rm -rf dal/TestResults
                 cd api
                 dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore
-                mv TestResults/*/coverage.json ../TestResults/coverage.json
+                mv TestResults/*/* ../TestResults/
                 cd ..
                 cd dal
                 dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore


### PR DESCRIPTION
- Follow recommended `coverlet` approach on CI servers
- Exclude migrations from code coverage
- Restore GitHub action
- Update Jenkins pipeline