### PR TITLE
PIMS-2038, 1838, 1708

### DIFF
--- a/frontend/src/forms/ParcelDetailForm.test.tsx
+++ b/frontend/src/forms/ParcelDetailForm.test.tsx
@@ -176,7 +176,7 @@ describe('ParcelDetailForm', () => {
       });
       const errors = getAllByText('Required');
       const idErrors = getAllByText('PID or PIN Required');
-      expect(errors).toHaveLength(9);
+      expect(errors).toHaveLength(8);
       expect(idErrors).toHaveLength(2);
     });
 

--- a/frontend/src/forms/subforms/BuildingForm.tsx
+++ b/frontend/src/forms/subforms/BuildingForm.tsx
@@ -43,6 +43,8 @@ export const defaultBuildingValues: any = {
   buildingConstructionTypeId: '',
   buildingPredominateUse: undefined,
   buildingPredominateUseId: '',
+  classificationId: '',
+  classification: undefined,
   buildingOccupantType: undefined,
   buildingOccupantTypeId: '',
   transferLeaseOnSale: false,
@@ -78,21 +80,11 @@ const BuildingForm = <T extends any>(props: BuildingProps & FormikProps<T>) => {
     return [props.nameSpace ?? '', `${props.index ?? ''}`, name].filter(x => x).join('.');
   };
 
-  //set the lat/lon of this building, but only if the building lat/lon hasn't been touched and has no value.
-  if (
-    !getIn(props.touched, withNameSpace('latitude')) &&
-    !getIn(props.values, withNameSpace('latitude')) &&
-    props.values.latitude &&
-    props.touched.latitude
-  ) {
+  //set the lat/lon of this building, but only if the building lat/lon has no value.
+  if (!getIn(props.values, withNameSpace('latitude')) && props.values.latitude) {
     props.setFieldValue(withNameSpace('latitude'), props.values.latitude);
   }
-  if (
-    !getIn(props.touched, withNameSpace('longitude')) &&
-    !getIn(props.values, withNameSpace('longitude')) &&
-    props.values.longitude &&
-    props.touched.longitude
-  ) {
+  if (!getIn(props.values, withNameSpace('longitude')) && props.values.longitude) {
     props.setFieldValue(withNameSpace('longitude'), props.values.longitude);
   }
 

--- a/frontend/src/forms/subforms/EvaluationForm.tsx
+++ b/frontend/src/forms/subforms/EvaluationForm.tsx
@@ -98,7 +98,8 @@ export const validateFinancials = (financials: IFinancial[], nameSpace: string) 
     if (
       financial.year === moment().year() &&
       !financial.value &&
-      financial.key !== EvaluationKeys.Appraised
+      financial.key !== EvaluationKeys.Appraised &&
+      financial.key !== FiscalKeys.Estimated
     ) {
       errors = setIn(errors, `${nameSpace}.${index}.value`, 'Required');
     }


### PR DESCRIPTION
There was something strange going on with the classification values being passed when adding a new building (it would default to the property's classification). Causing [this problem.](https://pimsteam.atlassian.net/browse/PIMS-2038?atlOrigin=eyJpIjoiMGJlM2E2MTEzOGQ3NDU5MmE1M2VlZGE3NzllNTdiMjUiLCJwIjoiaiJ9). Now the user is defaulted to no value in the building classification and when selected the values pass through correctly.

There is also another bug that the City appears to be auto filled (when adding a new building) but is not actually sending a value. I will address this after I get my remaining stories done.