### PR TITLE
PIMS-1420 Adding ParcelId to Properties

### DIFF
--- a/backend/api/Areas/Property/Mapping/Search/PropertyMap.cs
+++ b/backend/api/Areas/Property/Mapping/Search/PropertyMap.cs
@@ -101,6 +101,7 @@ namespace Pims.Api.Mapping.Property
                 .Map(dest => dest.AppraisedDate, src => src.Evaluations.OrderByDescending(f => f.Date).FirstOrDefault(f => f.Key == EvaluationKeys.Appraised) == null ? (DateTime?)null : src.Evaluations.OrderByDescending(f => f.Date).FirstOrDefault(f => f.Key == EvaluationKeys.Appraised).Date)
 
                 .Map(dest => dest.LocalId, src => src.LocalId)
+                .Map(dest => dest.ParcelId, src => src.ParcelId)
                 .Map(dest => dest.ConstructionTypeId, src => src.BuildingConstructionTypeId)
                 .Map(dest => dest.ConstructionType, src => src.BuildingConstructionType.Name)
                 .Map(dest => dest.PredominateUseId, src => src.BuildingPredominateUseId)
@@ -159,6 +160,7 @@ namespace Pims.Api.Mapping.Property
                 .Map(dest => dest.ZoningPotential, src => src.ZoningPotential)
 
                 .Map(dest => dest.LocalId, src => src.LocalId)
+                .Map(dest => dest.ParcelId, src => src.ParcelId)
                 .Map(dest => dest.ConstructionTypeId, src => src.BuildingConstructionTypeId)
                 .Map(dest => dest.ConstructionType, src => src.BuildingConstructionType)
                 .Map(dest => dest.PredominateUseId, src => src.BuildingPredominateUseId)

--- a/backend/api/Areas/Property/Models/Search/PropertyModel.cs
+++ b/backend/api/Areas/Property/Models/Search/PropertyModel.cs
@@ -2,108 +2,263 @@ using System;
 
 namespace Pims.Api.Areas.Property.Models.Search
 {
+    /// <summary>
+    /// PropertyModel class, provides a model to represent the property whether Land or Building.
+    /// </summary>
     public class PropertyModel
     {
         #region Properties
+        /// <summary>
+        /// get/set - The primary key to identify the property.
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// get/set - The foreign key to the property type [Land, Building].
+        /// </summary>
         public int PropertyTypeId { get; set; }
 
+        /// <summary>
+        /// get/set - A unique identifier for the titled parcel.
+        /// </summary>
         public string PID { get; set; }
 
+        /// <summary>
+        /// get/set - A unique identifier for an untitled parcel.
+        /// </summary>
         public string PIN { get; set; }
 
+        /// <summary>
+        /// get/set - The foreign key to the property status.
+        /// </summary>
         public int StatusId { get; set; }
 
+        /// <summary>
+        /// get/set - The status of the property.
+        /// </summary>
         public string Status { get; set; }
 
+        /// <summary>
+        /// get/set - The foreign key to the property classification.
+        /// </summary>
         public int ClassificationId { get; set; }
 
+        /// <summary>
+        /// get/set - The classification of the property.
+        /// </summary>
         public string Classification { get; set; }
 
+        /// <summary>
+        /// get/set - The GIS latitude location of the property.
+        /// </summary>
         public double Latitude { get; set; }
 
+        /// <summary>
+        /// get/set - The GIS latitude location of the property.
+        /// </summary>
         public double Longitude { get; set; }
 
+        /// <summary>
+        /// get/set - The property description.
+        /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
+        /// get/set - The property project number.
+        /// </summary>
         public string ProjectNumber { get; set; }
 
+        /// <summary>
+        /// get/set - Whether the property is sensitive data.
+        /// </summary>
         public bool IsSensitive { get; set; }
 
+        /// <summary>
+        /// get/set - The foreign key to the owning agency.
+        /// </summary>
         public int AgencyId { get; set; }
 
+        /// <summary>
+        /// get/set - The owning agency name.
+        /// </summary>
         public string Agency { get; set; }
 
+        /// <summary>
+        /// get/set - The owning agency code.
+        /// </summary>
         public string AgencyCode { get; set; }
 
+        /// <summary>
+        /// get/set - The owning subagency name.
+        /// </summary>
         public string SubAgency { get; set; }
 
+        /// <summary>
+        /// get/set - The owning subagency code.
+        /// </summary>
         public string SubAgencyCode { get; set; }
 
+        /// <summary>
+        /// get/set - The foreign key to the address.
+        /// </summary>
         public int AddressId { get; set; }
 
+        /// <summary>
+        /// get/set - The address of the property.
+        /// </summary>
         public string Address { get; set; }
 
+        /// <summary>
+        /// get/set - The name of the city.
+        /// </summary>
         public string City { get; set; }
 
+        /// <summary>
+        /// get/set - The name of the province.
+        /// </summary>
         public string Province { get; set; }
 
+        /// <summary>
+        /// get/set - The postal code.
+        /// </summary>
         public string Postal { get; set; }
 
+        /// <summary>
+        /// get/set - The property estimated value.
+        /// </summary>
         public decimal Estimated { get; set; }
 
+        /// <summary>
+        /// get/set - The fiscal year of the estimated value.
+        /// </summary>
         public int? EstimatedFiscalYear { get; set; }
 
+        /// <summary>
+        /// get/set - The property netbook value.
+        /// </summary>
         public decimal NetBook { get; set; }
 
+        /// <summary>
+        /// get/set - The fiscal year of the netbook value.
+        /// </summary>
         public int? NetBookFiscalYear { get; set; }
 
+        /// <summary>
+        /// get/set - The property assessed value.
+        /// </summary>
         public decimal Assessed { get; set; }
 
+        /// <summary>
+        /// get/set - The date when the assessment occured.
+        /// </summary>
         public DateTime? AssessedDate { get; set; }
 
+        /// <summary>
+        /// get/set - The property appraised value.
+        /// </summary>
         public decimal Appraised { get; set; }
 
+        /// <summary>
+        /// get/set - the date when the appraisal occured.
+        /// </summary>
         public DateTime? AppraisedDate { get; set; }
 
         #region Parcel Properties
+        /// <summary>
+        /// get/set - The land area of the parcel.
+        /// </summary>
         public float LandArea { get; set; }
 
+        /// <summary>
+        /// get/set - The land legal description of the parcel.
+        /// </summary>
         public string LandLegalDescription { get; set; }
 
+        /// <summary>
+        /// get/set - The property municipality name.
+        /// </summary>
         public string Municipality { get; set; }
 
+        /// <summary>
+        /// get/set - The property zoning name.
+        /// </summary>
         public string Zoning { get; set; }
 
+        /// <summary>
+        /// get/set - The property zoning potential.
+        /// </summary>
         public string ZoningPotential { get; set; }
         #endregion
 
         #region Building Properties
+        /// <summary>
+        /// get/set - Local building unique identifier.
+        /// </summary>
         public string LocalId { get; set; }
 
+        /// <summary>
+        /// get/set - The parent parcel Id.
+        /// </summary>
+        public int? ParcelId { get; set; }
+
+        /// <summary>
+        /// get/set - Foreign key to the construction type.
+        /// </summary>
         public int? ConstructionTypeId { get; set; }
 
+        /// <summary>
+        /// get/set - The construction type name.
+        /// </summary>
         public string ConstructionType { get; set; }
 
+        /// <summary>
+        /// get/set - The foreign key to the predominate use.
+        /// </summary>
         public int? PredominateUseId { get; set; }
 
+        /// <summary>
+        /// get/set - The predominate use name.
+        /// </summary>
         public string PredominateUse { get; set; }
 
+        /// <summary>
+        /// get/set - The foreign key to the occupant type.
+        /// </summary>
         public int? OccupantTypeId { get; set; }
 
+        /// <summary>
+        /// get/set - The occupant type name.
+        /// </summary>
         public string OccupantType { get; set; }
 
+        /// <summary>
+        /// get/set - The number of floors in the building.
+        /// </summary>
         public int? FloorCount { get; set; }
 
+        /// <summary>
+        /// get/set - A description of the building tenancy.
+        /// </summary>
         public string Tenancy { get; set; }
 
+        /// <summary>
+        /// get/set - The name of the occupant.
+        /// </summary>
         public string OccupantName { get; set; }
 
+        /// <summary>
+        /// get/set - The date the lease expires.
+        /// </summary>
         public DateTime? LeaseExpiry { get; set; }
 
+        /// <summary>
+        /// get/set - Whether the lease will transfer with the sale.
+        /// </summary>
         public bool? TransferLeaseOnSale { get; set; }
 
+        /// <summary>
+        /// get/set - The square feet of rentable area in the building.
+        /// </summary>
         public float? RentableArea { get; set; }
         #endregion
         #endregion

--- a/backend/dal/Migrations/Initial/PostDeploy/01-ViewProperties.sql
+++ b/backend/dal/Migrations/Initial/PostDeploy/01-ViewProperties.sql
@@ -43,6 +43,7 @@ SELECT
 
     -- Building Properties
     , [LocalId] = null
+    , [ParcelId] = null
     , [BuildingConstructionTypeId] = 0
     , BuildingConstructionType = null
     , [BuildingFloorCount] = 0
@@ -151,6 +152,7 @@ SELECT
 
     -- Building Properties
     , [LocalId] = b.[LocalId]
+    , [ParcelId] = b.[ParcelId]
     , [BuildingConstructionTypeId] = b.[BuildingConstructionTypeId]
     , BuildingConstructionType = bct.[Name]
     , [BuildingFloorCount] = b.[BuildingFloorCount]

--- a/backend/entities/Views/Property.cs
+++ b/backend/entities/Views/Property.cs
@@ -205,6 +205,11 @@ namespace Pims.Dal.Entities.Views
         public string LocalId { get; set; }
 
         /// <summary>
+        /// get/set - The parent parcel Id.
+        /// </summary>
+        public int? ParcelId { get; set; }
+
+        /// <summary>
         /// get/set - The foreign key to the property building construction type.
         /// </summary>
         public int BuildingConstructionTypeId { get; set; }
@@ -331,6 +336,7 @@ namespace Pims.Dal.Entities.Views
             this.PID = building.Parcel?.PID ?? 0;
             this.PIN = building.Parcel?.PIN;
             this.LocalId = building.LocalId;
+            this.ParcelId = building.ParcelId;
             this.BuildingConstructionTypeId = building.BuildingConstructionTypeId;
             this.BuildingConstructionType = building.BuildingConstructionType?.Name;
             this.BuildingFloorCount = building.BuildingFloorCount;


### PR DESCRIPTION
## Description

Adds the `ParcelId` to the results so that buildings can include a link to their parent parcel.

Note - This will require either refreshing your DB or manually running the SQL script.