### PR TITLE
Enabling Project Number

### DIFF
--- a/frontend/src/forms/subforms/BuildingForm.tsx
+++ b/frontend/src/forms/subforms/BuildingForm.tsx
@@ -22,6 +22,7 @@ import { mapLookupCode, formikFieldMemo } from 'utils';
 import * as API from 'constants/API';
 import { IBuilding } from 'actions/parcelsActions';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
+import { Claims } from 'constants/claims';
 
 export interface IFormBuilding extends IBuilding {
   financials: any;
@@ -90,13 +91,7 @@ const BuildingForm = <T extends any>(props: BuildingProps & FormikProps<T>) => {
 
   const keycloak = useKeycloakWrapper();
 
-  const disableProjectNumber = () => {
-    if (keycloak.hasClaim('admin-properties')) {
-      return false;
-    } else {
-      return true;
-    }
-  };
+  const projectNumberDisabled = !keycloak.hasClaim(Claims.ADMIN_PROPERTIES);
 
   return (
     <Fragment>
@@ -192,7 +187,7 @@ const BuildingForm = <T extends any>(props: BuildingProps & FormikProps<T>) => {
               RAEG or SPP
             </Form.Label>
             <Input
-              disabled={disableProjectNumber()}
+              disabled={projectNumberDisabled}
               outerClassName="col-md-10"
               field={withNameSpace('projectNumber')}
             />

--- a/frontend/src/forms/subforms/PidPinForm.tsx
+++ b/frontend/src/forms/subforms/PidPinForm.tsx
@@ -4,6 +4,8 @@ import { Input, Form } from 'components/common/form';
 import { Col } from 'react-bootstrap';
 import TooltipIcon from 'components/common/TooltipIcon';
 import { PidTooltip, PinTooltip } from 'forms/strings';
+import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
+import { Claims } from 'constants/claims';
 
 interface PidPinProps {
   nameSpace?: string;
@@ -33,6 +35,11 @@ const PidPinForm: FunctionComponent<PidPinProps> = (props: PidPinProps) => {
     const { nameSpace } = props;
     return nameSpace ? `${nameSpace}.${fieldName}` : fieldName;
   };
+
+  const keycloak = useKeycloakWrapper();
+
+  const projectNumberDisabled = !keycloak.hasClaim(Claims.ADMIN_PROPERTIES);
+
   return (
     <Fragment>
       <Col className="pidPinForm" md={6}>
@@ -66,7 +73,7 @@ const PidPinForm: FunctionComponent<PidPinProps> = (props: PidPinProps) => {
             RAEG or SPP
           </Form.Label>
           <Input
-            disabled={true}
+            disabled={projectNumberDisabled}
             outerClassName="col-md-10"
             field={withNameSpace('projectNumber')}
           />


### PR DESCRIPTION
Project Number now editable on the Parcel Detail Form when the user has the `admin-properties` claim.

Just wanted to do this while I thought of it. 