### PR TITLE
Documentation updates to maintenance and backup readmes.

### DIFF
--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -34,7 +34,7 @@ For the sake of simplicity all examples will use jcxjin-test.
 
    ```
    oc patch route pims-app-test -n jcxjin-test -p \
-       '{ "spec": { "to": { "name": "proxy-caddy", "port": { "targetPort": "2015-tcp" }}}'
+       '{ "spec": { "to": { "name": "proxy-caddy" }, "port": { "targetPort": "2015-tcp" }}}'
    oc patch route proxy-caddy -n jcxjin-test -p \
        '{ "spec": { "to": { "name": "pims-app-test" }, "port": { "targetPort": "8080-tcp" }}}'
    ```

--- a/openshift/templates/backup/BACKUP.md
+++ b/openshift/templates/backup/BACKUP.md
@@ -27,20 +27,24 @@ For the sake of simplicity all examples will use jcxjin-dev.
 ## Backup Config Map
 
 1. Add any desired cron configuration and mssql database connections to backup.conf (that file contains examples).
-2. Run `./backup-deploy.overrides.sh` which will generate a new deployment config.
+2. Either run `backup-deploy.overrides.sh` from https://github.com/BCDevOps/backup-container/tree/master/openshift which will generate a new deployment config, or manually edit backup-conf-configmap_DeploymentConfig.json
 3. Run `oc create -f backup-conf-configmap_DeploymentConfig.json` to create the deployment config within Openshift.
 
 ## Backup Deployment Config
 
 1. View the parameters `oc process --parameters -f openshift/templates/backup/backup-deploy.yaml`
 2. Most of the defaults should be correct, so either create a **`backup-deploy.params`** file that contains the values for the parameters within the template, or provide any desired paremeter changes with -p (see below for example).
-3. Create the pipeline objects. Note that DATABASE_DEPLOYMENT_NAME should be set to whatever secret holds the pims database credentials.
+3. Create the pipeline objects. Note that DATABASE_DEPLOYMENT_NAME should be set to whatever secret holds the pims database credentials. note that the BACKUP_VOLUME_SIZE MUST match the size of your provisioned volume.
 
 ```
-oc process -f openshift/templates/backup/backup-deploy.yaml -n jcxjin-dev \
--p BACKUP_VOLUME_NAME=bk-jcxjin-dev-r9c53stkggh6 \
--p TAG_NAME=dev \
--p DATABASE_DEPLOYMENT_NAME=pims-db-dev-secret | oc create -f -
+oc process -f deploy.yaml -n jcxjin-dev \
+-p BACKUP_VOLUME_NAME=bk-jcxjin-dev-fakefakefake \
+-p IMAGE_TAG=dev \
+-p BACKUP_VOLUME_SIZE=3Gi \
+-p ENV_NAME=dev \
+-p DATABASE_DEPLOYMENT_NAME=pims-db-dev-secret | oc apply -f -
 ```
 
 4. Note that whilst the deployment config contains all resources required to run, it does require that pims-db-\${namespace}-secret has already been created in the environment. This should be a safe assumption given that the database container should already be created in the target environment.
+
+5. Ensure that the deployment config for pims-db-\${environment} contains a volume mapping for the backup volume. This will need to be added after the backup volume has been created for the first time in the target environment. There is a commented out section in mssql-deploy with this configuration, or you can complete this task in the GUI by mapping the backup volume to path /backups.

--- a/openshift/templates/backup/deploy.yaml
+++ b/openshift/templates/backup/deploy.yaml
@@ -146,6 +146,11 @@ objects:
                     secretKeyRef:
                       name: "${DATABASE_DEPLOYMENT_NAME}"
                       key: "${DATABASE_PASSWORD_KEY_NAME}"
+                - name: MSSQL_SA_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: "${DATABASE_DEPLOYMENT_NAME}"
+                      key: "${DATABASE_PASSWORD_KEY_NAME}"
                 - name: FTP_URL
                   valueFrom:
                     secretKeyRef:
@@ -462,9 +467,9 @@ parameters:
     displayName: Resources Memory Request
     description: The resources Memory request (in Mi, Gi, etc) for this build.
     required: true
-    value: 256MiB
+    value: 256Mi
   - name: MEMORY_LIMIT
     displayName: Resources Memory Limit
     description: The resources Memory limit (in Mi, Gi, etc) for this build.
     required: true
-    value: 1GiB
+    value: 1Gi


### PR DESCRIPTION
Fix syntax for memory requests in backup dc config.
Fix typo in maintenance readme.
Add missing step to backup documentation.
Add all flags to backup documentation that are likely to change per-environment.
Add a tip related to BACKUP_VOLUME_SIZE