### PR TITLE
PIMS-2410, 2411, 2397

### DIFF
--- a/frontend/src/components/maps/BuildingPopupView.test.tsx
+++ b/frontend/src/components/maps/BuildingPopupView.test.tsx
@@ -6,6 +6,7 @@ import { createMemoryHistory } from 'history';
 import { IAddress, IBuilding } from 'actions/parcelsActions';
 import { useKeycloak } from '@react-keycloak/web';
 import { render } from '@testing-library/react';
+import Claims from 'constants/claims';
 
 jest.mock('@react-keycloak/web');
 (useKeycloak as jest.Mock).mockReturnValue({
@@ -75,7 +76,7 @@ it('displays update option when user belongs to buildings agency', () => {
       <BuildingPopupView building={mockBuilding(1)} />
     </Router>,
   );
-  expect(getByText(/Update/i));
+  expect(getByText(/Update/i)).toBeInTheDocument();
 });
 
 it('displays view option', () => {
@@ -84,5 +85,23 @@ it('displays view option', () => {
       <BuildingPopupView building={mockBuilding(2)} />
     </Router>,
   );
-  expect(getByText(/View/i));
+  expect(getByText(/View/i)).toBeInTheDocument();
+});
+
+it('always displays update option for SRES', () => {
+  (useKeycloak as jest.Mock).mockReturnValue({
+    keycloak: {
+      userInfo: {
+        agencies: [1],
+        roles: [Claims.ADMIN_PROPERTIES],
+      },
+      subject: 'test',
+    },
+  });
+  const { getByText } = render(
+    <Router history={history}>
+      <BuildingPopupView building={mockBuilding(2)} />
+    </Router>,
+  );
+  expect(getByText(/Update/i)).toBeInTheDocument();
 });

--- a/frontend/src/components/maps/BuildingPopupView.tsx
+++ b/frontend/src/components/maps/BuildingPopupView.tsx
@@ -8,6 +8,7 @@ import { Label } from 'components/common/Label';
 import { EvaluationKeys } from '../../constants/evaluationKeys';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import { Link } from 'react-router-dom';
+import Claims from 'constants/claims';
 
 export interface IBuildingDetailProps {
   building: IBuilding | null;
@@ -62,7 +63,8 @@ export const BuildingPopupView: React.FC<IBuildingDetailProps> = (props: IBuildi
               )}
             </ListGroup>
             {!props?.disabled &&
-              (!keycloak.hasAgency(buildingDetail?.agencyId as number) ? (
+              (!keycloak.hasAgency(buildingDetail?.agencyId as number) &&
+              !keycloak.hasClaim(Claims.ADMIN_PROPERTIES) ? (
                 <Link to={`/submitProperty/${buildingDetail?.parcelId}?disabled=true`}>View</Link>
               ) : (
                 <Link to={`/submitProperty/${buildingDetail?.parcelId}`}>Update</Link>

--- a/frontend/src/components/maps/ParcelPopupView.test.tsx
+++ b/frontend/src/components/maps/ParcelPopupView.test.tsx
@@ -6,6 +6,7 @@ import { createMemoryHistory } from 'history';
 import { render } from '@testing-library/react';
 import { useKeycloak } from '@react-keycloak/web';
 import { IAddress, IParcel } from 'actions/parcelsActions';
+import { Claims } from 'constants/claims';
 
 const history = createMemoryHistory();
 
@@ -77,7 +78,7 @@ it('displays update option when user belongs to buildings agency', () => {
       <ParcelPopupView parcel={mockParcel(1)} />
     </Router>,
   );
-  expect(getByText(/Update/i));
+  expect(getByText(/Update/i)).toBeInTheDocument();
 });
 
 it('displays view option', () => {
@@ -86,5 +87,23 @@ it('displays view option', () => {
       <ParcelPopupView parcel={mockParcel(2)} />
     </Router>,
   );
-  expect(getByText(/View/i));
+  expect(getByText(/View/i)).toBeInTheDocument();
+});
+
+it('always displays update option for sres', () => {
+  (useKeycloak as jest.Mock).mockReturnValue({
+    keycloak: {
+      userInfo: {
+        agencies: [1],
+        roles: [Claims.ADMIN_PROPERTIES],
+      },
+      subject: 'test',
+    },
+  });
+  const { getByText } = render(
+    <Router history={history}>
+      <ParcelPopupView parcel={mockParcel(2)} />
+    </Router>,
+  );
+  expect(getByText(/Update/i)).toBeInTheDocument();
 });

--- a/frontend/src/components/maps/ParcelPopupView.tsx
+++ b/frontend/src/components/maps/ParcelPopupView.tsx
@@ -7,6 +7,7 @@ import './ParcelPopupView.scss';
 import { Link } from 'react-router-dom';
 import { EvaluationKeys } from '../../constants/evaluationKeys';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
+import Claims from 'constants/claims';
 
 export interface IParcelDetailProps {
   parcel: IParcel | null;
@@ -67,7 +68,8 @@ export const ParcelPopupView = (props: IParcelDetailProps | null) => {
           {parcelDetail?.id && !props?.disabled && (
             <Col>
               <Link to={`/submitProperty/${parcelDetail?.id}?disabled=true`}>View</Link>
-              {keycloak.hasAgency(parcelDetail?.agencyId as number) && (
+              {(keycloak.hasAgency(parcelDetail?.agencyId as number) ||
+                keycloak.hasClaim(Claims.ADMIN_PROPERTIES)) && (
                 <Link style={{ paddingLeft: '5px' }} to={`/submitProperty/${parcelDetail?.id}`}>
                   Update
                 </Link>

--- a/frontend/src/features/projects/dispose/components/columns.tsx
+++ b/frontend/src/features/projects/dispose/components/columns.tsx
@@ -32,12 +32,15 @@ const EditableMoneyCell = (cellInfo: any) => {
 
 const EditableClassificationCell = (cellInfo: any) => {
   const classifications = useCodeLookups().getOptionsByType('PropertyClassification');
+  const filteredClassifications = classifications.filter(
+    (x: any) => x?.label === 'Surplus Active' || x?.label === 'Surplus Encumbered',
+  );
   const context = useFormikContext();
   return (
     <FastSelect
       formikProps={context}
       type="number"
-      options={classifications}
+      options={filteredClassifications}
       field={`properties.${cellInfo.row.id}.classificationId`}
     ></FastSelect>
   );

--- a/frontend/src/pages/SubmitProperty.test.tsx
+++ b/frontend/src/pages/SubmitProperty.test.tsx
@@ -11,6 +11,7 @@ import { useKeycloak } from '@react-keycloak/web';
 import SubmitProperty from './SubmitProperty';
 import { render, fireEvent, act } from '@testing-library/react';
 import { mockDetails } from 'mocks/filterDataMock';
+import { Claims } from 'constants/claims';
 
 jest.mock('./MapView', () => () => <div id="mockMapView"></div>);
 jest.mock('@react-keycloak/web');
@@ -23,10 +24,12 @@ Enzyme.configure({ adapter: new Adapter() });
   keycloak: {
     userInfo: {
       agencies: [mockDetails[0]?.agencyId],
+      roles: [Claims.ADMIN_PROPERTIES],
     },
     subject: 'test',
   },
 });
+
 const mockStore = configureMockStore([thunk]);
 const history = createMemoryHistory();
 const store = mockStore({
@@ -132,4 +135,19 @@ describe('SubmitProperty', () => {
     });
     expect(getByText('Unsaved Draft')).toBeVisible();
   });
+});
+
+it('Edit button available for sres even when they dont belong to agency', () => {
+  let store: any = mockStore({
+    [reducerTypes.LOOKUP_CODE]: { lookupCodes: [] },
+    [reducerTypes.PARCEL]: { parcelDetail: { parcelTypeId: 1, parcelDetail: mockDetails[1] } },
+    [reducerTypes.LEAFLET_CLICK_EVENT]: {},
+    [reducerTypes.NETWORK]: {
+      parcel: {
+        status: 201,
+      },
+    },
+  });
+  const { getByText } = render(getSubmitProperty({ match: { params: { id: 2 } } }, store));
+  expect(getByText('Edit')).toBeInTheDocument();
 });

--- a/frontend/src/pages/SubmitProperty.tsx
+++ b/frontend/src/pages/SubmitProperty.tsx
@@ -65,7 +65,8 @@ const SubmitProperty = (props: any) => {
   if (
     cachedParcelDetail?.agencyId &&
     !formDisabled &&
-    !keycloak.hasAgency(cachedParcelDetail?.agencyId)
+    !keycloak.hasAgency(cachedParcelDetail?.agencyId) &&
+    !keycloak.hasClaim(Claims.ADMIN_PROPERTIES)
   ) {
     setFormDisabled(true); //if the user doesn't belong to this properties agency, display a read only view.
   }
@@ -240,7 +241,8 @@ const EditButton = ({
   formDisabled,
   setFormDisabled,
 }: any) => {
-  return keycloak.hasAgency(cachedParcelDetail?.agencyId) ? (
+  return keycloak.hasAgency(cachedParcelDetail?.agencyId) ||
+    keycloak.hasClaim(Claims.ADMIN_PROPERTIES) ? (
     <Button disabled={!formDisabled || !parcelId} onClick={() => setFormDisabled(false)}>
       Edit
     </Button>


### PR DESCRIPTION
- SRES now able to edit any property
- updating corresponding tests 
- restrict classification options to surplus active and surplus encumbered (still working on unit tests)