### PR TITLE
PIMS-2175, 2193

### DIFF
--- a/frontend/src/components/common/form/DisplayCurrency.scss
+++ b/frontend/src/components/common/form/DisplayCurrency.scss
@@ -1,0 +1,4 @@
+.displayCurrency {
+  font-size: 16px;
+  width: 100%;
+}

--- a/frontend/src/components/common/form/DisplayCurrency.tsx
+++ b/frontend/src/components/common/form/DisplayCurrency.tsx
@@ -1,0 +1,29 @@
+import './DisplayCurrency.scss';
+
+import React from 'react';
+import MaskedInput from 'react-text-mask';
+import createNumberMask from 'text-mask-addons/dist/createNumberMask';
+import { defaultMaskOptions } from './FastCurrencyInput';
+
+type RequiredAttributes = {
+  /** The value to display */
+  value?: number | '';
+};
+/**
+ * To provide a read only currency format used in tables, commonly for displaying sums.
+ * @param param0
+ */
+export const DisplayCurrency = ({ value }: RequiredAttributes) => {
+  const currencyMask = createNumberMask({
+    ...defaultMaskOptions,
+  });
+  return (
+    <MaskedInput
+      className="displayCurrency"
+      value={value}
+      mask={currencyMask}
+      disabled={true}
+      placeholder="$0"
+    />
+  );
+};

--- a/frontend/src/components/common/form/FastCurrencyInput.tsx
+++ b/frontend/src/components/common/form/FastCurrencyInput.tsx
@@ -6,7 +6,7 @@ import { formikFieldMemo } from 'utils';
 import classNames from 'classnames';
 import Form from 'react-bootstrap/Form';
 
-const defaultMaskOptions = {
+export const defaultMaskOptions = {
   prefix: '$',
   suffix: '',
   includeThousandsSeparator: true,

--- a/frontend/src/components/common/form/index.ts
+++ b/frontend/src/components/common/form/index.ts
@@ -12,3 +12,4 @@ export * from './TextArea';
 export * from './FastCurrencyInput';
 export * from './AutoCompleteText';
 export * from './Check';
+export * from './DisplayCurrency';

--- a/frontend/src/components/maps/ParcelPopupView.test.tsx
+++ b/frontend/src/components/maps/ParcelPopupView.test.tsx
@@ -20,7 +20,7 @@ jest.mock('@react-keycloak/web');
   },
 });
 
-const mockParcel = (agencyId: number) => {
+const mockParcel = (agencyId: number, projectNumber?: string) => {
   var parcel: IParcel = {
     id: 1,
     pid: '1',
@@ -30,7 +30,7 @@ const mockParcel = (agencyId: number) => {
     statusId: 1,
     propertyStatus: 'Test Property Status',
     municipality: 'Test Municipality',
-    projectNumber: 'Test-Project-Number',
+    projectNumber: projectNumber,
     classification: 'Test Classification',
     description: 'Test Description',
     landArea: 100,
@@ -85,13 +85,14 @@ describe('Parcel popup view', () => {
     expect(getByText(/Update/i)).toBeInTheDocument();
   });
 
-  it('displays view option', () => {
-    const { getByText } = render(
+  it('displays only view option when user not in properties agency', () => {
+    const { getByText, queryByText } = render(
       <Router history={history}>
         <ParcelPopupView parcel={mockParcel(2)} />
       </Router>,
     );
     expect(getByText(/View/i)).toBeInTheDocument();
+    expect(queryByText(/Update/i)).toBeNull();
   });
 
   it('always displays update option for sres', () => {
@@ -110,5 +111,25 @@ describe('Parcel popup view', () => {
       </Router>,
     );
     expect(getByText(/Update/i)).toBeInTheDocument();
+  });
+
+  it('displays clickable project number when the property belongs to a project', () => {
+    const { getByText } = render(
+      <Router history={history}>
+        <ParcelPopupView parcel={mockParcel(1, 'Test-Project-Number')} />
+      </Router>,
+    );
+    const projectNum = getByText(/Test-Project-Number/);
+    expect(getByText(/Project Number/)).toBeInTheDocument();
+    expect(projectNum).toBeInTheDocument();
+  });
+
+  it('does not display project number field when none present', () => {
+    const { queryByText } = render(
+      <Router history={history}>
+        <ParcelPopupView parcel={mockParcel(1)} />
+      </Router>,
+    );
+    expect(queryByText(/Project Number/)).toBeNull();
   });
 });

--- a/frontend/src/components/maps/ParcelPopupView.tsx
+++ b/frontend/src/components/maps/ParcelPopupView.tsx
@@ -47,11 +47,18 @@ export const ParcelPopupView = (props: IParcelDetailProps | null) => {
               <ListGroup.Item>
                 <Label>PID: </Label> {parcelDetail?.pid}
               </ListGroup.Item>
-              {parcelDetail?.projectNumber && (
-                <ListGroup.Item>
-                  <Label>RAEG or SPP:</Label> {parcelDetail?.projectNumber}
-                </ListGroup.Item>
-              )}
+              {parcelDetail?.projectNumber &&
+                (keycloak.hasAgency(parcelDetail?.agencyId as number) ||
+                  keycloak.hasClaim(Claims.ADMIN_PROJECTS)) && (
+                  <ListGroup.Item>
+                    <Label>Project Number: </Label>
+                    <Link
+                      to={`/dispose/projects/assess/properties?projectNumber=${parcelDetail?.projectNumber}`}
+                    >
+                      {parcelDetail?.projectNumber}
+                    </Link>
+                  </ListGroup.Item>
+                )}
             </ListGroup>
             <ListGroup>
               <ListGroup.Item>

--- a/frontend/src/components/maps/__snapshots__/ParcelPopupView.test.tsx.snap
+++ b/frontend/src/components/maps/__snapshots__/ParcelPopupView.test.tsx.snap
@@ -64,20 +64,6 @@ exports[`Parcel popup view renders correctly 1`] = `
            
           1
         </div>
-        <div
-          className="list-group-item"
-          data-rb-event-key={null}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <p
-            className="label"
-          >
-            RAEG or SPP:
-          </p>
-           
-          Test-Project-Number
-        </div>
       </div>
       <div
         className="list-group"

--- a/frontend/src/forms/ParcelDetailForm.test.tsx
+++ b/frontend/src/forms/ParcelDetailForm.test.tsx
@@ -171,6 +171,14 @@ describe('ParcelDetailForm', () => {
       });
     });
 
+    it('properly renders EvalutationForm', () => {
+      const { getByText, getAllByText } = render(parcelDetailForm());
+      expect(getByText('Land')).toBeInTheDocument();
+      expect(getByText('Improvements')).toBeInTheDocument();
+      expect(getByText('Total')).toBeInTheDocument();
+      expect(getAllByText('Value')).toHaveLength(2);
+    });
+
     it('validates all required fields correctly', async () => {
       const { getByText, getAllByText } = render(parcelDetailForm());
       const submit = getByText('Submit');

--- a/frontend/src/forms/ParcelDetailForm.tsx
+++ b/frontend/src/forms/ParcelDetailForm.tsx
@@ -230,6 +230,7 @@ const ParcelDetailForm = (props: ParcelPropertyProps) => {
                   <h4>Valuation Information</h4>
                   <EvaluationForm
                     {...formikProps}
+                    isParcel={true}
                     showAppraisal={false}
                     disabled={props.disabled}
                     nameSpace="financials"

--- a/frontend/src/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
+++ b/frontend/src/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
@@ -675,7 +675,7 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
               className="row no-gutters"
             >
               <div
-                className="col-md-3"
+                className="col-5"
               >
                 <h6>
                   Assessed
@@ -685,12 +685,18 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
                 >
                   <thead>
                     <tr>
-                      <td>
+                      <th>
                         Year
-                      </td>
-                      <td>
-                        Value
-                      </td>
+                      </th>
+                      <th>
+                        Land
+                      </th>
+                      <th>
+                        Improvements
+                      </th>
+                      <th>
+                        Total
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -719,6 +725,22 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
                           />
                         </div>
                       </td>
+                      <td>
+                        <input
+                          className="displayCurrency"
+                          disabled={true}
+                          placeholder="$0"
+                          value={0}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          className="displayCurrency"
+                          disabled={true}
+                          placeholder="$0"
+                          value={10000}
+                        />
+                      </td>
                     </tr>
                     <tr>
                       <td>
@@ -745,12 +767,28 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
                           />
                         </div>
                       </td>
+                      <td>
+                        <input
+                          className="displayCurrency"
+                          disabled={true}
+                          placeholder="$0"
+                          value={0}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          className="displayCurrency"
+                          disabled={true}
+                          placeholder="$0"
+                          value={0}
+                        />
+                      </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
               <div
-                className="col-md-3"
+                className="col-3"
               >
                 <h6>
                   NetBook
@@ -760,12 +798,12 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
                 >
                   <thead>
                     <tr>
-                      <td>
+                      <th>
                         Fiscal Year
-                      </td>
-                      <td>
+                      </th>
+                      <th>
                         Value
-                      </td>
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -825,7 +863,7 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
                 </table>
               </div>
               <div
-                className="col-md-3"
+                className="col-3"
               >
                 <h6>
                   Estimated
@@ -835,12 +873,12 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
                 >
                   <thead>
                     <tr>
-                      <td>
+                      <th>
                         Fiscal Year
-                      </td>
-                      <td>
+                      </th>
+                      <th>
                         Value
-                      </td>
+                      </th>
                     </tr>
                   </thead>
                   <tbody>

--- a/frontend/src/forms/subforms/BuildingForm.test.tsx
+++ b/frontend/src/forms/subforms/BuildingForm.test.tsx
@@ -119,6 +119,11 @@ describe('sub-form BuildingForm functionality', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders EvaluationForm as expected', () => {
+    const { getAllByText } = render(getBuildingForm(defaultBuildingValues, () => {}));
+    expect(getAllByText('Value')).toHaveLength(3);
+  });
+
   it('validates all required fields', async () => {
     const { getByText, getAllByText } = render(getBuildingForm(defaultBuildingValues, () => {}));
     const submit = getByText('Submit');

--- a/frontend/src/forms/subforms/EvaluationForm.tsx
+++ b/frontend/src/forms/subforms/EvaluationForm.tsx
@@ -12,6 +12,7 @@ import WrappedPaginate from 'components/common/WrappedPaginate';
 import { IPaginate } from 'utils/CommonFunctions';
 import { formikFieldMemo } from 'utils';
 import PaginatedFormErrors from './PaginatedFormErrors';
+import SumFinancialsForm from './SumFinancialsForm';
 
 interface EvaluationProps {
   /** the formik tracked namespace of this component */
@@ -20,6 +21,8 @@ interface EvaluationProps {
   disabled?: boolean;
   /** whether to show the appraisal value on the form or not*/
   showAppraisal?: boolean;
+  /** whether the form is being used on parcel or building */
+  isParcel?: boolean;
 }
 
 /**
@@ -172,18 +175,26 @@ const EvaluationForm = <T extends any>(props: EvaluationProps & FormikProps<T>) 
               return null;
             } else {
               return (
-                <Col md={3} key={type}>
+                <Col xs={EvaluationKeys.Assessed === type && props.isParcel ? 5 : 3} key={type}>
                   <h6>{type}</h6>
                   <Table bordered>
                     <thead>
                       <tr>
-                        <td>
+                        <th>
                           {EvaluationKeys.Appraised === type && 'Date'}
                           {EvaluationKeys.Assessed === type && 'Year'}
                           {(FiscalKeys.Estimated === type || FiscalKeys.NetBook === type) &&
                             'Fiscal Year'}
-                        </td>
-                        <td>Value</td>
+                        </th>
+                        <th>
+                          {EvaluationKeys.Assessed === type && props.isParcel ? 'Land' : 'Value'}
+                        </th>
+                        {EvaluationKeys.Assessed === type && props.isParcel && (
+                          <>
+                            <th>Improvements</th>
+                            <th>Total</th>
+                          </>
+                        )}
                       </tr>
                     </thead>
                     <tbody>
@@ -228,6 +239,15 @@ const EvaluationForm = <T extends any>(props: EvaluationProps & FormikProps<T>) 
                                 field={withNameSpace('value', type, year)}
                               />
                             </td>
+                            {EvaluationKeys.Assessed === type && props.isParcel && (
+                              <>
+                                <SumFinancialsForm
+                                  formikProps={props}
+                                  onlyAssesedSums={true}
+                                  year={year}
+                                />
+                              </>
+                            )}
                           </tr>
                         );
                       })}

--- a/frontend/src/forms/subforms/EvaluationForm.tsx
+++ b/frontend/src/forms/subforms/EvaluationForm.tsx
@@ -18,7 +18,7 @@ interface EvaluationProps {
   nameSpace: string;
   /** whether this form is enabled for editing */
   disabled?: boolean;
-  /** only want to show appraisal when the property belongs to a project */
+  /** whether to show the appraisal value on the form or not*/
   showAppraisal?: boolean;
 }
 

--- a/frontend/src/forms/subforms/SumFinancialsForm.tsx
+++ b/frontend/src/forms/subforms/SumFinancialsForm.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Col } from 'react-bootstrap';
 import { FormikProps } from 'formik';
 import _ from 'lodash';
-import { Form, FastCurrencyInput } from 'components/common/form';
+import { Form, FastCurrencyInput, DisplayCurrency } from 'components/common/form';
 import { FiscalKeys } from 'constants/fiscalKeys';
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { IFinancial } from './EvaluationForm';
@@ -13,10 +13,12 @@ import { IFinancial } from './EvaluationForm';
  * create an object where all sums are keyed by evaluation/fiscal type.
  * @param financials an unordered list of financials to sum.
  */
-const sumFinancials = (financials: IFinancial[]) => {
+const sumFinancials = (financials: IFinancial[], year?: number) => {
   const summedFinancials: any = {};
   Object.keys({ ...EvaluationKeys, ...FiscalKeys }).forEach(type => {
-    const typedFinancials = _.filter(financials, financial => financial.key === type);
+    const typedFinancials = year
+      ? _.filter(financials, financial => financial.key === type && financial.year === year)
+      : _.filter(financials, financial => financial.key === type);
     const recentFinancialsForType = getMostRecentFinancials(typedFinancials);
     summedFinancials[type] = _.reduce(
       recentFinancialsForType,
@@ -50,6 +52,8 @@ const getMostRecentFinancials = (financials: IFinancial[]) => {
 
 type SumProps = {
   showAppraisal?: boolean;
+  onlyAssesedSums?: boolean;
+  year?: number;
   formikProps: FormikProps<any>;
 };
 
@@ -62,6 +66,8 @@ const SumFinancialsForm: React.FC<SumProps> = (props: SumProps) => {
     ...(props.formikProps.values?.financials ?? []),
     ..._.flatten(_.map(props.formikProps.values?.buildings ?? [], 'financials')),
   ];
+
+  const buildings = [..._.flatten(_.map(props.formikProps.values?.buildings ?? [], 'financials'))];
 
   const withAppraised = () => {
     if (props.showAppraisal) {
@@ -83,53 +89,68 @@ const SumFinancialsForm: React.FC<SumProps> = (props: SumProps) => {
       return null;
     }
   };
-
-  const summedFinancials: any = sumFinancials(allFinancials) ?? {};
-  return (
-    <Fragment>
-      <Col md={6}>
-        <Form.Row>
-          <Form.Label column md={2}>
-            Assessed Sum
-          </Form.Label>
-          <FastCurrencyInput
-            formikProps={props.formikProps}
-            disabled={true}
-            outerClassName="col-md-10"
-            value={summedFinancials[EvaluationKeys.Assessed]}
-            field={EvaluationKeys.Assessed}
-          />
-        </Form.Row>
-        {withAppraised()}
-      </Col>
-      <Col md={6}>
-        <Form.Row>
-          <Form.Label column md={2}>
-            NetBook Sum
-          </Form.Label>
-          <FastCurrencyInput
-            formikProps={props.formikProps}
-            disabled={true}
-            outerClassName="col-md-10"
-            value={summedFinancials[FiscalKeys.NetBook]}
-            field={FiscalKeys.NetBook}
-          />
-        </Form.Row>
-        <Form.Row>
-          <Form.Label column md={2}>
-            Estimated Sum
-          </Form.Label>
-          <FastCurrencyInput
-            formikProps={props.formikProps}
-            disabled={true}
-            outerClassName="col-md-10"
-            value={summedFinancials[FiscalKeys.Estimated]}
-            field={FiscalKeys.Estimated}
-          />
-        </Form.Row>
-      </Col>
-    </Fragment>
-  );
+  const summedFinancials: any = props.onlyAssesedSums
+    ? sumFinancials(allFinancials, props.year)
+    : sumFinancials(allFinancials) ?? {};
+  const summedBuildingFinacnials: any = sumFinancials(buildings, props.year);
+  if (props.onlyAssesedSums) {
+    return (
+      <>
+        <td>
+          <DisplayCurrency value={summedBuildingFinacnials.Assessed} />
+        </td>
+        <td>
+          <DisplayCurrency value={summedFinancials.Assessed} />
+        </td>
+      </>
+    );
+  } else {
+    return (
+      <Fragment>
+        <Col md={6}>
+          <Form.Row>
+            <Form.Label column md={2}>
+              Assessed Sum
+            </Form.Label>
+            <FastCurrencyInput
+              formikProps={props.formikProps}
+              disabled={true}
+              outerClassName="col-md-10"
+              value={summedFinancials[EvaluationKeys.Assessed]}
+              field={EvaluationKeys.Assessed}
+            />
+          </Form.Row>
+          {withAppraised()}
+        </Col>
+        <Col md={6}>
+          <Form.Row>
+            <Form.Label column md={2}>
+              NetBook Sum
+            </Form.Label>
+            <FastCurrencyInput
+              formikProps={props.formikProps}
+              disabled={true}
+              outerClassName="col-md-10"
+              value={summedFinancials[FiscalKeys.NetBook]}
+              field={FiscalKeys.NetBook}
+            />
+          </Form.Row>
+          <Form.Row>
+            <Form.Label column md={2}>
+              Estimated Sum
+            </Form.Label>
+            <FastCurrencyInput
+              formikProps={props.formikProps}
+              disabled={true}
+              outerClassName="col-md-10"
+              value={summedFinancials[FiscalKeys.Estimated]}
+              field={FiscalKeys.Estimated}
+            />
+          </Form.Row>
+        </Col>
+      </Fragment>
+    );
+  }
 };
 
 /**

--- a/frontend/src/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
+++ b/frontend/src/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
@@ -583,7 +583,7 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
           className="row no-gutters"
         >
           <div
-            className="col-md-3"
+            className="col-3"
           >
             <h6>
               Assessed
@@ -593,12 +593,12 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
             >
               <thead>
                 <tr>
-                  <td>
+                  <th>
                     Year
-                  </td>
-                  <td>
+                  </th>
+                  <th>
                     Value
-                  </td>
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -658,7 +658,7 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
             </table>
           </div>
           <div
-            className="col-md-3"
+            className="col-3"
           >
             <h6>
               NetBook
@@ -668,12 +668,12 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
             >
               <thead>
                 <tr>
-                  <td>
+                  <th>
                     Fiscal Year
-                  </td>
-                  <td>
+                  </th>
+                  <th>
                     Value
-                  </td>
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -733,7 +733,7 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
             </table>
           </div>
           <div
-            className="col-md-3"
+            className="col-3"
           >
             <h6>
               Estimated
@@ -743,12 +743,12 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
             >
               <thead>
                 <tr>
-                  <td>
+                  <th>
                     Fiscal Year
-                  </td>
-                  <td>
+                  </th>
+                  <th>
                     Value
-                  </td>
+                  </th>
                 </tr>
               </thead>
               <tbody>

--- a/frontend/src/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
+++ b/frontend/src/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
@@ -647,7 +647,7 @@ exports[`PagedBuildingForms functionality displays any pre-existing buildings 1`
               className="row no-gutters"
             >
               <div
-                className="col-md-3"
+                className="col-3"
               >
                 <h6>
                   Assessed
@@ -657,12 +657,12 @@ exports[`PagedBuildingForms functionality displays any pre-existing buildings 1`
                 >
                   <thead>
                     <tr>
-                      <td>
+                      <th>
                         Year
-                      </td>
-                      <td>
+                      </th>
+                      <th>
                         Value
-                      </td>
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -722,7 +722,7 @@ exports[`PagedBuildingForms functionality displays any pre-existing buildings 1`
                 </table>
               </div>
               <div
-                className="col-md-3"
+                className="col-3"
               >
                 <h6>
                   NetBook
@@ -732,12 +732,12 @@ exports[`PagedBuildingForms functionality displays any pre-existing buildings 1`
                 >
                   <thead>
                     <tr>
-                      <td>
+                      <th>
                         Fiscal Year
-                      </td>
-                      <td>
+                      </th>
+                      <th>
                         Value
-                      </td>
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -797,7 +797,7 @@ exports[`PagedBuildingForms functionality displays any pre-existing buildings 1`
                 </table>
               </div>
               <div
-                className="col-md-3"
+                className="col-3"
               >
                 <h6>
                   Estimated
@@ -807,12 +807,12 @@ exports[`PagedBuildingForms functionality displays any pre-existing buildings 1`
                 >
                   <thead>
                     <tr>
-                      <td>
+                      <th>
                         Fiscal Year
-                      </td>
-                      <td>
+                      </th>
+                      <th>
                         Value
-                      </td>
+                      </th>
                     </tr>
                   </thead>
                   <tbody>


### PR DESCRIPTION
Display clickable Project Number on property pins that belong to a project. Only visible to owning agency and SRES

Update Assessed Value tables. `ParcelDetailForm` now has `Land`, `Improvements`, and `Total` columns. Building  Assessed Value table remains the same; however, the value entered there is reflected under `Improvments` on the `ParcelDetailForm`