### PR TITLE
Adding ParentId to Agency endpoint

### DIFF
--- a/backend/api/Mapping/Lookup/CodeMap.cs
+++ b/backend/api/Mapping/Lookup/CodeMap.cs
@@ -8,12 +8,11 @@ namespace Pims.Api.Mapping.Lookup
         public void Register(TypeAdapterConfig config)
         {
             config.NewConfig<Entity.Agency, Models.CodeModel<int>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Code, src => src.Code)
+                .Map(dest => dest.ParentId, src => src.ParentId)
                 .Inherits<Entity.LookupEntity<int>, Models.LookupModel<int>>();
 
             config.NewConfig<Entity.City, Models.CodeModel<int>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Code, src => src.Code)
                 .Inherits<Entity.LookupEntity<int>, Models.LookupModel<int>>();
         }

--- a/backend/api/Mapping/Lookup/LookupMap.cs
+++ b/backend/api/Mapping/Lookup/LookupMap.cs
@@ -9,14 +9,12 @@ namespace Pims.Api.Mapping.Lookup
         public void Register(TypeAdapterConfig config)
         {
             config.NewConfig<Entity.Province, Models.LookupModel<string>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.Type, src => src.GetType().Name)
                 .Inherits<Entity.BaseEntity, Models.BaseModel>();
 
             config.NewConfig<Entity.Role, Models.LookupModel<Guid>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.IsDisabled, src => src.IsDisabled)
@@ -26,7 +24,6 @@ namespace Pims.Api.Mapping.Lookup
 
 
             config.NewConfig<Entity.PropertyType, Models.LookupModel<int>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.IsDisabled, src => src.IsDisabled)
@@ -36,7 +33,6 @@ namespace Pims.Api.Mapping.Lookup
 
 
             config.NewConfig<Entity.PropertyStatus, Models.LookupModel<int>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.IsDisabled, src => src.IsDisabled)
@@ -46,7 +42,6 @@ namespace Pims.Api.Mapping.Lookup
 
 
             config.NewConfig<Entity.PropertyClassification, Models.LookupModel<int>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.IsDisabled, src => src.IsDisabled)
@@ -56,7 +51,6 @@ namespace Pims.Api.Mapping.Lookup
 
 
             config.NewConfig<Entity.BuildingConstructionType, Models.LookupModel<int>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.IsDisabled, src => src.IsDisabled)
@@ -66,7 +60,6 @@ namespace Pims.Api.Mapping.Lookup
 
 
             config.NewConfig<Entity.BuildingOccupantType, Models.LookupModel<int>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.IsDisabled, src => src.IsDisabled)
@@ -76,7 +69,6 @@ namespace Pims.Api.Mapping.Lookup
 
 
             config.NewConfig<Entity.BuildingPredominateUse, Models.LookupModel<int>>()
-                .IgnoreNonMapped(true)
                 .Map(dest => dest.Id, src => src.Id)
                 .Map(dest => dest.Name, src => src.Name)
                 .Map(dest => dest.IsDisabled, src => src.IsDisabled)

--- a/backend/api/Models/CodeModel.cs
+++ b/backend/api/Models/CodeModel.cs
@@ -12,6 +12,11 @@ namespace Pims.Api.Models
         /// </summary>
         /// <value></value>
         public string Code { get; set; }
+
+        /// <summary>
+        /// get/set - The parent id of this item.
+        /// </summary>
+        public int? ParentId { get; set; } // TODO: this isn't ideal as it will only currently be used by agency.
         #endregion
     }
 }


### PR DESCRIPTION
## Description

The Lookup endpoints will now include `ParentId` for agencies.