### PR TITLE
PIMS-2188 Develop production Deployment Configuration process

### DIFF
--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -22,12 +22,6 @@ pipeline {
   environment {
     CI = "true"
 
-    // To enable pipeline verbose debug output set to "true"
-    DEBUG_OUTPUT = "false"
-
-    // To force asking for a release version before running the pipeline, set to "true"
-    REQUIRE_VERSION = "false"
-
     // The name of your application
     APP_NAME = "pims"
 
@@ -50,6 +44,17 @@ pipeline {
 
     // The URI to the application being deployed.
     // VANITY_URL="https://pims-dev.pathfinder.gov.bc.ca/"
+
+    // To force asking for a release version before running the pipeline, set to "true"
+    // REQUIRE_VERSION = "false"
+
+    REQUIRE_VERSION = sh(script: 'echo ${REQUIRE_VERSION:-false}', returnStdout: true).trim()
+    JOB_NAME = sh(script: 'echo ${JOB_NAME:-dev}', returnStdout: true).trim()
+    DESTINATION = sh(script: 'echo ${DESTINATION:-dev}', returnStdout: true).trim()
+    VANITY_URL = sh(script: 'echo "${VANITY_URL:-https://pims-dev.pathfinder.gov.bc.ca/}"', returnStdout: true).trim()
+
+    // To enable pipeline verbose debug output set to "true"
+    DEBUG_OUTPUT = sh(script: 'echo ${DEBUG_OUTPUT:-false}', returnStdout: true).trim()
   }
   stages {
     stage("Initialize") {

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -262,7 +262,9 @@ pipeline {
   post {
     success {
       script {
-        notify.success(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
+        if (env.SKIP_BUILD == "false") {
+          notify.success(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
+        }
       }
     }
     failure {

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -46,15 +46,15 @@ pipeline {
     // VANITY_URL="https://pims-dev.pathfinder.gov.bc.ca/"
 
     // To force asking for a release version before running the pipeline, set to "true"
-    // REQUIRE_VERSION = "false"
+    // ENABLE_VERSION_PROMPT = "false"
 
-    REQUIRE_VERSION = sh(script: 'echo ${REQUIRE_VERSION:-false}', returnStdout: true).trim()
-    JOB_NAME = sh(script: 'echo ${JOB_NAME:-dev}', returnStdout: true).trim()
-    DESTINATION = sh(script: 'echo ${DESTINATION:-dev}', returnStdout: true).trim()
+    ENABLE_VERSION_PROMPT = sh(script: 'echo "${ENABLE_VERSION_PROMPT:-false}"', returnStdout: true).trim()
+    JOB_NAME = sh(script: 'echo "${JOB_NAME:-dev}"', returnStdout: true).trim()
+    DESTINATION = sh(script: 'echo "${DESTINATION:-dev}"', returnStdout: true).trim()
     VANITY_URL = sh(script: 'echo "${VANITY_URL:-https://pims-dev.pathfinder.gov.bc.ca/}"', returnStdout: true).trim()
 
     // To enable pipeline verbose debug output set to "true"
-    DEBUG_OUTPUT = sh(script: 'echo ${DEBUG_OUTPUT:-false}', returnStdout: true).trim()
+    DEBUG_OUTPUT = sh(script: 'echo "${DEBUG_OUTPUT:-false}"', returnStdout: true).trim()
   }
   stages {
     stage("Initialize") {
@@ -88,7 +88,7 @@ pipeline {
             env.SKIP_BUILD = "false"
           }
 
-          if (DEBUG_OUTPUT.equalsIgnoreCase("true")) {
+          if (new Boolean(DEBUG_OUTPUT)) {
             // Force OpenShift Plugin directives to be verbose
             openshift.logLevel(1)
 
@@ -104,7 +104,7 @@ pipeline {
       when {
         anyOf {
           expression { env.GIT_BRANCH == "origin/master" }
-          expression { env.REQUIRE_VERSION == "true" }
+          expression { new Boolean(env.ENABLE_VERSION_PROMPT) }
         }
       }
       steps {
@@ -125,7 +125,7 @@ pipeline {
 
     stage("Force Build?") {
       when {
-        expression { env.SKIP_BUILD == "true" }
+        expression { new Boolean(env.SKIP_BUILD) == true }
       }
       steps {
         script {
@@ -144,7 +144,7 @@ pipeline {
 
     stage('Tests') {
       when {
-        expression { env.SKIP_BUILD == "false" }
+        expression { new Boolean(env.SKIP_BUILD) == false }
       }
       options { timeout(time: 10, unit: "MINUTES") }
       failFast true
@@ -188,7 +188,7 @@ pipeline {
 
     stage('Build') {
       when {
-        expression { env.SKIP_BUILD == "false" }
+        expression { new Boolean(env.SKIP_BUILD) == false }
       }
       options { timeout(time: 25, unit: "MINUTES") }
       failFast true
@@ -215,7 +215,7 @@ pipeline {
 
     stage("Quality Gate") {
       when {
-        expression { env.SKIP_BUILD == "false" }
+        expression { new Boolean(env.SKIP_BUILD) == false }
       }
       options {
         timeout(time: 1, unit: "MINUTES")
@@ -238,7 +238,7 @@ pipeline {
 
     stage("Deploy") {
       when {
-        expression { env.SKIP_BUILD == "false" }
+        expression { new Boolean(env.SKIP_BUILD) == false }
       }
       options { timeout(time: 15, unit: "MINUTES") }
       steps {
@@ -267,7 +267,7 @@ pipeline {
   post {
     success {
       script {
-        if (env.SKIP_BUILD == "false") {
+        if (new Boolean(env.SKIP_BUILD) == false) {
           notify.success(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
         }
       }

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -26,7 +26,7 @@ pipeline {
     DEBUG_OUTPUT = "false"
 
     // To force asking for a release version before running the pipeline, set to "true"
-    REQUIRE_VERSION = "true"
+    REQUIRE_VERSION = "false"
 
     // The name of your application
     APP_NAME = "pims"

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -3,11 +3,12 @@
 // ------------------
 // Pipeline Variables
 // ------------------
-def cli
+def commonPipeline
 def notify
 
 def FE_COV_STASH = 'fe-test-coverage'
 def API_COV_STASH = 'api-test-coverage'
+def RELEASE_VERSION = ""
 
 // --------------------
 // Declarative Pipeline
@@ -19,30 +20,32 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: "5")) // keep 5 builds only
   }
   environment {
+    CI = "true"
+
     // To enable pipeline verbose debug output set to "true"
     DEBUG_OUTPUT = "false"
 
-    // Wait timeout in minutes
-    WAIT_TIMEOUT = 15
-
-    CI = "true"
+    // To force asking for a release version before running the pipeline, set to "true"
+    REQUIRE_VERSION = "true"
 
     // The name of your application
     APP_NAME = "pims"
 
-    // This should match your monorepo folder structure
-    API_CONTEXT_DIRECTORY = "backend"
-    FRONTEND_CONTEXT_DIRECTORY = "frontend"
-
     // The name of the project namespace(s).
     NAME_SPACE = "jcxjin"
 
+    // This should match your monorepo folder structure
+    API_DIRECTORY = "backend"
+    FRONTEND_DIRECTORY = "frontend"
+    MAINTENANCE_DIRECTORY = "maintenance"
+    DEVOPS_DIRECTORY = "openshift"
+
     // Environment Variables that should be set in OpenShift
     // -----------------------------------------------------
-    // The tag used to identify the image.
-    // IMAGE_TAG = "dev"
+    // The job identifier (i.e 'pr-5' OR 'dev' OR 'master')
+    // JOB_NAME = "dev"
 
-    // Which environment to deploy to.
+    // Which environment to deploy to ('dev' OR 'test' OR 'prod').
     // DESTINATION = "dev"
 
     // The URI to the application being deployed.
@@ -53,30 +56,32 @@ pipeline {
       steps {
         script {
           // load supporting functions from external script files
-          cli = load "openshift/pipelines/scripts/common.groovy"
+          commonPipeline = load "openshift/pipelines/scripts/common.groovy"
           notify = load "openshift/pipelines/scripts/notify.groovy"
+
+          // Cancel any running builds in progress
+          timeout(time: 10, unit: 'MINUTES') {
+            echo "Cancelling previous builds in progress..."
+            commonPipeline.abortAllPreviousBuildsInProgress(currentBuild)
+          }
 
           // ensure required secrets and credentials are available in the CI environment
           // [add more secrets here if needed...]
           sh "oc extract secret/rocket-chat-secrets --to=${env.WORKSPACE} --confirm"
+          env.ROCKET_DEPLOY_WEBHOOK = readFile("rocket-deploy-webhook").trim()
 
           // initialize CI environment values
-          env.ROCKET_DEPLOY_WEBHOOK = readFile("rocket-deploy-webhook").trim()
-          env.CHANGELOG = cli.getChangeLog()
+          env.CHANGELOG = commonPipeline.getChangeLog()
 
-          // back-end CI flags
-          def api_changes = cli.hasDirectoryChanged(API_CONTEXT_DIRECTORY)
-          env.API_HAS_CHANGES = api_changes.toString()
-          env.API_FORCE_BUILD = "false"
-          env.API_BUILT = "false"
-          env.API_DEPLOYED = "false"
+          // whether Build and Deploy stage should be skipped
+          def api_changes = commonPipeline.hasDirectoryChanged('backend').toString()
+          def fe_changes = commonPipeline.hasDirectoryChanged('frontend').toString()
 
-          // front-end CI flags
-          def fe_changes = cli.hasDirectoryChanged(FRONTEND_CONTEXT_DIRECTORY)
-          env.FRONTEND_HAS_CHANGES = fe_changes.toString()
-          env.FRONTEND_FORCE_BUILD = "false"
-          env.FRONTEND_BUILT = "false"
-          env.FRONTEND_DEPLOYED = "false"
+          if (api_changes.equalsIgnoreCase("false") && fe_changes.equalsIgnoreCase("false")) {
+            env.SKIP_BUILD = "true"
+          } else {
+            env.SKIP_BUILD = "false"
+          }
 
           if (DEBUG_OUTPUT.equalsIgnoreCase("true")) {
             // Force OpenShift Plugin directives to be verbose
@@ -89,271 +94,124 @@ pipeline {
         }
       }
     }
-    stage("Force API Build?") {
-      when { environment name: "API_HAS_CHANGES", value: "false" }
+
+    stage("Version Prompt") {
+      when {
+        anyOf {
+          expression { env.GIT_BRANCH == "origin/master" }
+          expression { env.REQUIRE_VERSION == "true" }
+        }
+      }
+      steps {
+        script {
+          timeout(time: 5, unit: "MINUTES") {
+            def version = input(message: "Enter the version tag for this release", parameters: [
+              string(name: "RELEASE VERSION", defaultValue: "", description: "")
+            ])
+            if (version != "") {
+              RELEASE_VERSION = version
+            } else {
+              error "***  No release version specified. Aborting pipeline.  ***"
+            }
+          }
+        }
+      }
+    }
+
+    stage("Force Build?") {
+      when {
+        expression { env.SKIP_BUILD == "true" }
+      }
       steps {
         script {
           try {
-            timeout(time: 1, unit: "MINUTES") {
-              input(message: "Should we force the API Build?", ok: "Yes, we should")
+            timeout(time: 2, unit: "MINUTES") {
+              input(message: "No code changes detected. Should we force the Build?", ok: "Yes, we should")
             }
-            echo "[ci/cd]  The API build was forced..."
-            env.API_FORCE_BUILD = "true"
+            env.SKIP_BUILD = "false"
           } catch (err) {
-            echo "[ci/cd]  No API code changes. Skipping the API build..."
-            env.API_FORCE_BUILD = "false"
+            echo "[ci/cd]  No code changes. Skipping the Build stage..."
+            env.SKIP_BUILD = "true"
           }
         }
       }
     }
-    stage("Build API and run tests") {
-      environment {
-        COMP_NAME = "api"
-      }
+
+    stage('Tests') {
       when {
-        anyOf {
-          environment name: "API_HAS_CHANGES", value: "true"
-          environment name: "API_FORCE_BUILD", value: "true"
-        }
+        expression { env.SKIP_BUILD == "false" }
       }
-      steps {
-        echo "[ci/cd]  Building API artifacts..."
-        script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              def build_config = "${APP_NAME}-${COMP_NAME}-${IMAGE_TAG}"
-              def apiSelector = openshift.selector("bc", build_config)
-              if (!apiSelector.exists()) {
-                throw new Exception("Could not find API build with name: '${build_config}'")
-              } else {
-                timeout(WAIT_TIMEOUT) {
-                  apiSelector.startBuild("-w")
-                }
-              }
+      options { timeout(time: 10, unit: "MINUTES") }
+      failFast true
+      parallel {
+        stage("Frontend") {
+          agent { label 'jenkins-slave-npm' }
+          steps {
+            script {
+              commonPipeline.runFrontendTests()
+            }
+          }
+          post {
+            success {
+              echo 'Frontend lint checks and tests passed'
+              stash name: FE_COV_STASH, includes: 'frontend/coverage/**'
+            }
+            failure {
+              error '*** Frontend lint checks and tests failed ***'
+            }
+          }
+        }
+        stage("Backend") {
+          agent { label 'jenkins-slave-dotnet' }
+          steps {
+            script {
+              commonPipeline.runBackendTests()
+            }
+          }
+          post {
+            success {
+              echo 'Backend tests passed'
+              stash name: API_COV_STASH, includes: 'backend/tests/unit/TestResults/**'
+            }
+            failure {
+              error '*** Backend tests failed ***'
             }
           }
         }
       }
-      post {
-        success {
-          script {
-            env.API_BUILT = "true"
-          }
-        }
-      }
     }
-    stage("Force FRONTEND Build?") {
-      when { environment name: "FRONTEND_HAS_CHANGES", value: "false" }
-      steps {
-        script {
-          try {
-            timeout(time: 1, unit: "MINUTES") {
-              input(message: "Should we force the FRONTEND Build?", ok: "Yes, we should")
-            }
-            echo "[ci/cd]  The FRONTEND build was forced..."
-            env.FRONTEND_FORCE_BUILD = "true"
-          } catch (err) {
-            echo "[ci/cd]  No FRONTEND code changes. Skipping the FRONTEND build..."
-            env.FRONTEND_FORCE_BUILD = "false"
-          }
-        }
-      }
-    }
-    stage("Build FRONTEND") {
-      environment {
-        COMP_NAME = "app"
-        WAIT_TIMEOUT = 20 // increase the timeout for this stage as it takes longer to build
-      }
+
+    stage('Build') {
       when {
-        anyOf {
-          environment name: "FRONTEND_HAS_CHANGES", value: "true"
-          environment name: "FRONTEND_FORCE_BUILD", value: "true"
-        }
+        expression { env.SKIP_BUILD == "false" }
       }
-      steps {
-        echo "[ci/cd]  Building FRONTEND artifacts..."
-        script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              // Build the base image. This image leverages Node to create a production build of the React frontend.
-              def build_config = "${APP_NAME}-${COMP_NAME}-base-${IMAGE_TAG}"
-              def feBase = openshift.selector("bc", build_config)
-              if (!feBase.exists()) {
-                throw new Exception("Could not find FRONTEND-base build with name: '${build_config}'")
-              } else {
-                timeout(WAIT_TIMEOUT) {
-                  feBase.startBuild("-w")
-                }
-              }
-
-              // Build the runtime image. This image serves the compiled React artifacts via an NGINX web-server.
-              def runtime_build_config = "${APP_NAME}-${COMP_NAME}-${IMAGE_TAG}"
-              def feRuntime = openshift.selector("bc", runtime_build_config)
-              if (!feRuntime.exists()) {
-                throw new Exception("Could not find FRONTEND-runtime build with name: '${runtime_build_config}'")
-              } else {
-                timeout(WAIT_TIMEOUT) {
-                  feRuntime.startBuild("-w")
-                }
+      options { timeout(time: 25, unit: "MINUTES") }
+      failFast true
+      parallel {
+        stage("Frontend") {
+          steps {
+            script {
+              dir(DEVOPS_DIRECTORY) {
+                sh "JOB_NAME=${JOB_NAME} ./player.sh build app-base apply"
+                sh "JOB_NAME=${JOB_NAME} ./player.sh build app apply"
               }
             }
           }
         }
-      }
-      post {
-        success {
-          script {
-            env.FRONTEND_BUILT = "true"
-          }
-        }
-      }
-    }
-    stage("FRONTEND Tests") {
-      agent {
-        label 'jenkins-slave-npm'
-      }
-      environment {
-        COMP_NAME = "app"
-        CI = "true"
-      }
-      when {
-        anyOf {
-          environment name: "FRONTEND_BUILT", value: "true"
-        }
-      }
-      steps {
-        echo "[ci/cd]  Run FRONTEND Test Cases"
-        script {
-          // pull code
-          checkout scm
-
-          dir(FRONTEND_CONTEXT_DIRECTORY) {
-            try {
-              timeout(20) {
-                sh 'node --version'
-                sh 'npm --version'
-
-                echo 'Installing NPM Dependencies...'
-                sh 'npm ci'
-
-                echo 'Reporting Outdated and Vulnerable Dependencies...'
-                sh 'npm audit || true'
-                sh 'npm outdated || true'
-
-                echo "Linting and Testing Frontend..."
-                sh 'npm run lint'
-                sh 'npm run coverage'
-
-                echo 'Frontend Lint Checks and Tests passed'
-              }
-            } catch (e) {
-              echo 'Lint Checks and Tests failed'
-              throw e
+        stage("Backend") {
+          steps {
+            dir(DEVOPS_DIRECTORY) {
+              sh "JOB_NAME=${JOB_NAME} ./player.sh build api apply"
             }
           }
         }
       }
-      post {
-        success {
-          stash name: FE_COV_STASH, includes: 'frontend/coverage/**'
-          echo 'All Tests passed'
-        }
-        failure {
-          echo 'Tests failed'
-        }
-      }
     }
-    stage("API Tests") {
-      agent {
-        label 'jenkins-slave-dotnet'
-      }
-      environment {
-        COMP_NAME = "api"
-        CI = "true"
-      }
-      when {
-        anyOf {
-          environment name: "API_BUILT", value: "true"
-        }
-      }
-      steps {
-        echo "[ci/cd]  Run API Test Cases"
-        script {
-          // pull code
-          checkout scm
 
-          dir(API_CONTEXT_DIRECTORY) {
-            try {
-              timeout(20) {
-                sh 'dotnet --version'
-                sh 'node --version'
-
-                echo 'Install dependencies...'
-                sh 'dotnet restore'
-
-                echo 'Build'
-                sh 'dotnet build --configuration Release --no-restore'
-
-                // For future reference, if we have N test projects the flow of events would be:
-                //
-                // **Pre-conditions:**
-                //  - All projects export their individual coverage percents in JSON and OpenCover format
-                //  - There's no way to merge OpenCover xmls together (that I could find)
-                //  - Common folder "../TestResults" is  git ignored so nothing gets in source control
-                //
-                // **Steps:**
-                //
-                // Test-project 1
-                //   - generate coverage files (without merging)
-                //   - copy results to common folder "../TestResults"
-                // Test-project 2
-                //   - generate coverage files merging with previous `coverage.json`
-                //   - the previous `coverage.opencoverage.xml` is ignored
-                //   - copy results to common folder "../TestResults"
-                //  ...
-                // Test-project N
-                //   - generate coverage files merging with previous `coverage.json`
-                //   - the previous `coverage.opencoverage.xml` is ignored
-                //   - copy results to common folder "../TestResults"
-                //
-                // The final `coverage.opencover.xml` is the one we want
-                echo 'Run API tests and collect code coverage'
-                sh '''
-                cd tests/unit
-                mkdir -p TestResults
-                rm -rf api/TestResults
-                rm -rf dal/TestResults
-                cd api
-                dotnet test -m:1 --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore
-                mv TestResults/*/* ../TestResults/
-                cd ..
-                cd dal
-                dotnet test -m:1 --collect:"XPlat Code Coverage" --settings coverlet.runsettings --no-restore
-                mv TestResults/*/* ../TestResults/
-                cd ..
-                head TestResults/coverage.opencover.xml
-                '''
-
-                echo 'API Tests passed'
-              }
-            } catch (e) {
-              echo 'Lint Checks and Tests failed'
-              throw e
-            }
-          }
-        }
-      }
-      post {
-        success {
-          stash name: API_COV_STASH, includes: 'backend/tests/unit/TestResults/**'
-          echo 'All Tests passed'
-        }
-        failure {
-          echo 'Tests failed'
-        }
-      }
-    }
     stage("Quality Gate") {
+      when {
+        expression { env.SKIP_BUILD == "false" }
+      }
       options {
         timeout(time: 1, unit: "MINUTES")
       }
@@ -372,190 +230,45 @@ pipeline {
         // """
       }
     }
-    stage("Tag API") {
-      environment {
-        COMP_NAME = "api"
-      }
-      steps {
-        script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              try {
-                timeout(time: 1, unit: "MINUTES") {
-                  def api_tag = input(message: "Enter the desired API tag", parameters: [
-                    string(name: 'API_TAG', defaultValue: '', description: 'Tag to apply to the API image.')
-                  ])
-                  if (api_tag != '') {
-                    def image_name = "${APP_NAME}-${COMP_NAME}"
-                    def hash = cli.getImageTagHash("${image_name}")
-                    echo "[ci/cd]  Create permanent tag ${api_tag} for image ${image_name}@${hash}"
-                    openshift.tag("${image_name}@${hash}", "${image_name}:${api_tag}")
-                  }
-                }
-              } catch (err) {
-                echo "${err}"
-                echo "[ci/cd]  No api tag specified"
-              }
-            }
-          }
-        }
-      }
-    }
-    stage("Tag App") {
-      environment {
-        COMP_NAME = "app"
-      }
-      steps {
-        script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              try {
-                timeout(time: 1, unit: "MINUTES") {
-                  def app_tag = input(message: "Enter the desired App tag", parameters: [
-                    string(name: 'APP_TAG', defaultValue: '', description: 'Tag to apply to the App image.')
-                  ])
-                  if (app_tag != '') {
-                    def image_name = "${APP_NAME}-${COMP_NAME}"
-                    def hash = cli.getImageTagHash("${image_name}")
-                    echo "[ci/cd]  Create permanent tag ${app_tag} for image ${image_name}@${hash}"
-                    openshift.tag("${image_name}@${hash}", "${image_name}:${app_tag}")
-                  }
-                }
-              } catch (err) {
-                echo "${err}"
-                echo "[ci/cd]  No app tag specified"
-              }
-            }
-          }
-        }
-      }
-    }
-    stage("Deploy API -> DEV") {
-      options {
-        timeout(time: 5, unit: "MINUTES")
-      }
-      environment {
-        COMP_NAME = "api"
-      }
-      when { environment name: "API_BUILT", value: "true" }
-      steps {
-        script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              def image_name = "${APP_NAME}-${COMP_NAME}"
-              // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
-              // Tag the images for deployment based on the image's hash
-              def hash = cli.getImageTagHash("${image_name}")
-              echo "[ci/cd]  Tagging ${image_name}@${hash} for deployment to ${DESTINATION.toUpperCase()} ..."
-              openshift.tag("${image_name}@${hash}", "${image_name}:${DESTINATION}")
-            }
 
-            openshift.withProject("${NAME_SPACE}-${DESTINATION}") {
-                def dc = openshift.selector("dc", [ app: APP_NAME, component: COMP_NAME ])
-                echo "[ci/cd]  Found ${dc.count()} DeploymentConfigs: ${dc.names()}"
-                // Wait for the deployment to complete.
-                // This will wait until the desired replicas are all available
-                dc.rollout().status()
-            }
-          }
-        }
-        echo "[ci/cd]  API deployment done..."
+    stage("Deploy") {
+      when {
+        expression { env.SKIP_BUILD == "false" }
       }
-      post {
-        success {
-          script {
-            env.API_DEPLOYED = "true"
-          }
-        }
-      }
-    }
-    stage("Deploy frontend -> DEV") {
-      options {
-        timeout(time: 5, unit: "MINUTES")
-      }
-      environment {
-        COMP_NAME = "app"
-      }
-      when { environment name: "FRONTEND_BUILT", value: "true" }
+      options { timeout(time: 15, unit: "MINUTES") }
       steps {
         script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              def image_name = "${APP_NAME}-${COMP_NAME}"
-              // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
-              // Tag the images for deployment based on the image's hash
-              def hash = cli.getImageTagHash("${image_name}")
-              echo "[ci/cd]  Tagging ${image_name}@${hash} for deployment to ${DESTINATION.toUpperCase()} ..."
-              openshift.tag("${image_name}@${hash}", "${image_name}:${DESTINATION}")
-            }
+          def img_backend = "${APP_NAME}-api"
+          def img_frontend = "${APP_NAME}-app"
 
-            openshift.withProject("${NAME_SPACE}-${DESTINATION}") {
-                def dc = openshift.selector("dc", [ app: APP_NAME, component: COMP_NAME ])
-                echo "[ci/cd]  Found ${dc.count()} DeploymentConfigs: ${dc.names()}"
-                // Wait for the deployment to complete.
-                // This will wait until the desired replicas are all available
-                dc.rollout().status()
-            }
+          // tag release version (if provided)
+          if (RELEASE_VERSION != "") {
+            echo "Tagging images - ${img_backend}:latest, ${img_frontend}:latest..."
+            sh "oc tag ${img_backend}:latest ${img_backend}:${RELEASE_VERSION}"
+            sh "oc tag ${img_frontend}:latest ${img_frontend}:${RELEASE_VERSION}"
+          } else {
+            RELEASE_VERSION = "latest"
           }
-        }
-        echo "[ci/cd]  Frontend deployment done..."
-      }
-      post {
-        success {
-          script {
-            env.FRONTEND_DEPLOYED = "true"
+
+          dir(DEVOPS_DIRECTORY) {
+            sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy api ${DESTINATION} apply"
+            sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy app ${DESTINATION} apply"
           }
         }
       }
     }
-    stage("Notify") {
-      when {
-        anyOf {
-          environment name: "API_DEPLOYED", value: "true"
-          environment name: "FRONTEND_DEPLOYED", value: "true"
-        }
-      }
-      steps {
-        script {
-          if (env.API_DEPLOYED.equalsIgnoreCase("true")) {
-            notify.deploySuccess("${APP_NAME.toUpperCase()} API", DESTINATION.toUpperCase(), CHANGELOG, VANITY_URL, ROCKET_DEPLOY_WEBHOOK)
-          }
-          if (env.FRONTEND_DEPLOYED.equalsIgnoreCase("true")) {
-            notify.deploySuccess("${APP_NAME.toUpperCase()} FRONTEND", DESTINATION.toUpperCase(), CHANGELOG, VANITY_URL, ROCKET_DEPLOY_WEBHOOK)
-          }
-        }
-      }
-    }
-    stage("No Changes") {
-      when {
-        allOf {
-          environment name: "API_DEPLOYED", value: "false"
-          environment name: "FRONTEND_DEPLOYED", value: "false"
-        }
-      }
-      steps {
-        script {
-          echo "[ci/cd]  No changes ..."
-          currentBuild.result = 'ABORTED'
-          notify.noChanges(APP_NAME.toUpperCase(), DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
-        }
-      }
-    }
+
   } // stages
   post {
-    aborted {
-      node('master') {
-        script {
-          notify.deployFailure(APP_NAME.toUpperCase(), DESTINATION.toUpperCase(), "PIPELINE ABORTED", VANITY_URL, ROCKET_DEPLOY_WEBHOOK)
-        }
-    }
-    }
-    failure {
-      node('master') {
-        script {
-          notify.deployFailure(APP_NAME.toUpperCase(), DESTINATION.toUpperCase(), "PIPELINE ERROR", VANITY_URL, ROCKET_DEPLOY_WEBHOOK)
-        }
+    success {
+      script {
+        notify.success(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
       }
     }
-  } // post
+    failure {
+      script {
+        notify.failure(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
+      }
+    }
+  } // post-stages
 } // pipeline

--- a/openshift/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/pipelines/Jenkinsfile.test-to-prod
@@ -17,9 +17,6 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: "5")) // keep 5 builds only
   }
   environment {
-    // To enable pipeline verbose debug output set to "true"
-    DEBUG_OUTPUT = "true"
-
     CI = "true"
     PATHFINDER_URL = "pathfinder.gov.bc.ca"
 
@@ -37,25 +34,32 @@ pipeline {
 
     // Environment Variables that should be set in OpenShift
     // -----------------------------------------------------
+    // The job identifier (i.e 'pr-5' OR 'dev' OR 'master')
+    // JOB_NAME = "dev"
 
-    // The tag used to identify the image we want to deploy.
-    // RELEASE_TAG = "test"
-
-    // Which environment to deploy to.
-    // DESTINATION = "prod"
+    // Which environment to deploy to ('dev' OR 'test' OR 'prod').
+    // DESTINATION = "dev"
 
     // Which instance ID to deploy to (if using multiple instances per environment). Leave empty for default.
     // INSTANCE_ID = ""
 
     // The URI to the application being deployed.
-    // VANITY_URL = "https://pims-prod.pathfinder.gov.bc.ca/"
+    // VANITY_URL="https://pims-prod.pathfinder.gov.bc.ca/"
+
+    ENABLE_VERSION_PROMPT = true // ignored - version prompt always enabled in the PROD pipeline
+    JOB_NAME = sh(script: 'echo "${JOB_NAME:-master}"', returnStdout: true).trim()
+    DESTINATION = sh(script: 'echo "${DESTINATION:-prod}"', returnStdout: true).trim()
+    VANITY_URL = sh(script: 'echo "${VANITY_URL:-https://pims-prod.pathfinder.gov.bc.ca/}"', returnStdout: true).trim()
+
+    // To enable pipeline verbose debug output set to "true"
+    DEBUG_OUTPUT = sh(script: 'echo "${DEBUG_OUTPUT:-false}"', returnStdout: true).trim()
   }
   stages {
     stage("Initialize") {
       steps {
         script {
           // load supporting functions from external script files
-          cli = load "openshift/pipelines/scripts/common.groovy"
+          commonPipeline = load "openshift/pipelines/scripts/common.groovy"
           notify = load "openshift/pipelines/scripts/notify.groovy"
 
           // ensure required secrets and credentials are available in the CI environment
@@ -65,7 +69,7 @@ pipeline {
           // initialize CI environment values
           env.ROCKET_DEPLOY_WEBHOOK = readFile("rocket-deploy-webhook").trim()
 
-          if (DEBUG_OUTPUT.equalsIgnoreCase("true")) {
+          if (new Boolean(DEBUG_OUTPUT)) {
             // Force OpenShift Plugin directives to be verbose
             openshift.logLevel(1)
 
@@ -77,33 +81,29 @@ pipeline {
       }
     }
 
-    stage("Approval") {
+    stage("Approval Prompt") {
       options { timeout(time: 1, unit: "HOURS") }
       input {
         message "Deploy to PROD?"
         ok "Yes, go ahead"
       }
       steps {
-        echo "Promotion from TEST to PROD was approved. Proceeding..."
+        echo "*** Promotion from TEST to PROD was approved. Proceeding... ***"
       }
     }
 
-    stage("Version check") {
+    stage("Version Prompt") {
       steps {
         script {
-          try {
-            timeout(time: 10, unit: "MINUTES") {
-              def app_tag = input(message: "Enter the desired version to release to PRODUCTION", parameters: [
-                string(name: 'VERSION_TAG', defaultValue: '', description: 'Release Version')
-              ])
-              if (app_tag != '') {
-                RELEASE_VERSION = app_tag
-              } else {
-                error "No version specified. Aborting..."
-              }
+          timeout(time: 10, unit: "MINUTES") {
+            def version = input(message: "Enter the desired version to release to PRODUCTION", parameters: [
+              string(name: "RELEASE VERSION", defaultValue: "", description: "Release Version")
+            ])
+            if (version != "") {
+              RELEASE_VERSION = version
+            } else {
+              error "***  No release version specified. Aborting pipeline.  ***"
             }
-          } catch (err) {
-            error "No version specified. Aborting..."
           }
         }
       }
@@ -112,7 +112,7 @@ pipeline {
     stage("Maintenance mode ON") {
       steps {
         script {
-          cli.maintenancePageOn("${DESTINATION}")
+          commonPipeline.maintenancePageOn("${DESTINATION}")
         }
       }
     }
@@ -147,7 +147,7 @@ pipeline {
     stage("Maintenance mode OFF") {
       steps {
         script {
-          cli.maintenancePageOff("${DESTINATION}")
+          commonPipeline.maintenancePageOff("${DESTINATION}")
         }
       }
     }
@@ -157,5 +157,17 @@ pipeline {
         echo "PRODUCTION deployment complete!"
       }
     }
-  }
-}
+  } // stages
+  post {
+    success {
+      script {
+        notify.success(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
+      }
+    }
+    failure {
+      script {
+        notify.failure(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
+      }
+    }
+  } // post-stages
+} // pipeline

--- a/openshift/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/pipelines/Jenkinsfile.test-to-prod
@@ -76,18 +76,18 @@ pipeline {
         }
       }
     }
+
     stage("Approval") {
-      options {
-        timeout(time: 1, unit: "HOURS")
-      }
+      options { timeout(time: 1, unit: "HOURS") }
       input {
         message "Deploy to PROD?"
         ok "Yes, go ahead"
       }
       steps {
-        echo "[ci/cd] Promotion from TEST to PROD was approved. Proceeding..."
+        echo "Promotion from TEST to PROD was approved. Proceeding..."
       }
     }
+
     stage("Version check") {
       steps {
         script {
@@ -108,60 +108,51 @@ pipeline {
         }
       }
     }
+
     stage("Maintenance mode ON") {
       steps {
-        script {
-          dir(MAINTENANCE_DIRECTORY) {
-            sh "./maintenance.sh ${DESTINATION} on"
-          }
-        }
+        dir(MAINTENANCE_DIRECTORY) { sh "./maintenance.sh ${DESTINATION} on" }
       }
     }
+
     stage("Database backup") {
       steps {
-        script {
-          dir(DEVOPS_DIRECTORY) {
-            sh "./player.sh backup ${DESTINATION} apply"
-          }
-        }
+        sh "./openshift/player.sh backup ${DESTINATION} apply"
       }
     }
+
     stage("Database migration") {
-      options {
-        timeout(time: 5, unit: "MINUTES")
-      }
+      options { timeout(time: 5, unit: "MINUTES") }
       steps {
         // pretend we are doing stuff - db backups etc
         sleep(30)
       }
     }
+
     stage("Promote to PROD") {
+      options { timeout(time: 10, unit: "MINUTES") }
+      // These env-vars are required by player.sh below
       environment {
-        // These env-vars are required by player.sh below
         RELEASE_TAG="${RELEASE_VERSION}"
         TARGET_TAG="${DESTINATION}"
       }
       steps {
         script {
-          dir(DEVOPS_DIRECTORY) {
-            sh "./player.sh deploy api apply"
-            sh "./player.sh deploy app apply"
-          }
+          sh "./openshift/player.sh deploy api apply"
+          sh "./openshift/player.sh deploy app apply"
         }
       }
     }
+
     stage("Maintenance mode OFF") {
       steps {
-        script {
-          dir(MAINTENANCE_DIRECTORY) {
-            sh "./maintenance.sh ${DESTINATION} off"
-          }
-        }
+        dir(MAINTENANCE_DIRECTORY) { sh "./maintenance.sh ${DESTINATION} off" }
       }
     }
+
     stage("DONE") {
       steps {
-        echo "[ci/cd]  PRODUCTION deployment complete!"
+        echo "PRODUCTION deployment complete!"
       }
     }
   }

--- a/openshift/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/pipelines/Jenkinsfile.test-to-prod
@@ -111,13 +111,18 @@ pipeline {
 
     stage("Maintenance mode ON") {
       steps {
-        dir(MAINTENANCE_DIRECTORY) { sh "./maintenance.sh ${DESTINATION} on" }
+        script {
+          cli.maintenancePageOn("${DESTINATION}")
+        }
       }
     }
 
     stage("Database backup") {
+      options { timeout(time: 10, unit: "MINUTES") }
       steps {
-        sh "./openshift/player.sh backup ${DESTINATION} apply"
+        dir(DEVOPS_DIRECTORY) {
+          sh "./player.sh backup ${DESTINATION} apply"
+        }
       }
     }
 
@@ -125,7 +130,7 @@ pipeline {
       options { timeout(time: 5, unit: "MINUTES") }
       steps {
         // pretend we are doing stuff - db backups etc
-        sleep(30)
+        sleep(5)
       }
     }
 
@@ -137,16 +142,18 @@ pipeline {
         TARGET_TAG="${DESTINATION}"
       }
       steps {
-        script {
-          sh "./openshift/player.sh deploy api apply"
-          sh "./openshift/player.sh deploy app apply"
+        dir(DEVOPS_DIRECTORY) {
+          sh "./player.sh deploy api apply"
+          sh "./player.sh deploy app apply"
         }
       }
     }
 
     stage("Maintenance mode OFF") {
       steps {
-        dir(MAINTENANCE_DIRECTORY) { sh "./maintenance.sh ${DESTINATION} off" }
+        script {
+          cli.maintenancePageOff("${DESTINATION}")
+        }
       }
     }
 

--- a/openshift/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/pipelines/Jenkinsfile.test-to-prod
@@ -136,15 +136,10 @@ pipeline {
 
     stage("Promote to PROD") {
       options { timeout(time: 10, unit: "MINUTES") }
-      // These env-vars are required by player.sh below
-      environment {
-        RELEASE_TAG="${RELEASE_VERSION}"
-        TARGET_TAG="${DESTINATION}"
-      }
       steps {
         dir(DEVOPS_DIRECTORY) {
-          sh "./player.sh deploy api apply"
-          sh "./player.sh deploy app apply"
+          sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy api ${DESTINATION} apply"
+          sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy app ${DESTINATION} apply"
         }
       }
     }

--- a/openshift/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/pipelines/Jenkinsfile.test-to-prod
@@ -5,6 +5,7 @@
 // ------------------
 def cli
 def notify
+def RELEASE_VERSION
 
 // --------------------
 // Declarative Pipeline
@@ -21,7 +22,6 @@ pipeline {
 
     CI = "true"
     PATHFINDER_URL = "pathfinder.gov.bc.ca"
-    VANITY_URL="https://pims-test.pathfinder.gov.bc.ca/"
 
     // The name of your application
     APP_NAME = "pims"
@@ -33,18 +33,18 @@ pipeline {
     API_DIRECTORY = "backend"
     FRONTEND_DIRECTORY = "frontend"
     MAINTENANCE_DIRECTORY = "maintenance"
+    DEVOPS_DIRECTORY = "openshift"
 
     // Environment Variables that should be set in OpenShift
     // -----------------------------------------------------
 
     // The tag used to identify the image we want to deploy.
-    // IMAGE_TAG = "test"
+    // RELEASE_TAG = "test"
 
     // Which environment to deploy to.
     // DESTINATION = "prod"
 
-    // Which instance ID to deploy to (if using multiple instances per environment)
-    // Leave empty for the default instance
+    // Which instance ID to deploy to (if using multiple instances per environment). Leave empty for default.
     // INSTANCE_ID = ""
 
     // The URI to the application being deployed.
@@ -90,42 +90,38 @@ pipeline {
     }
     stage("Version check") {
       steps {
-        echo "TODO: ask for a version to deploy"
+        script {
+          try {
+            timeout(time: 10, unit: "MINUTES") {
+              def app_tag = input(message: "Enter the desired version to release to PRODUCTION", parameters: [
+                string(name: 'VERSION_TAG', defaultValue: '', description: 'Release Version')
+              ])
+              if (app_tag != '') {
+                RELEASE_VERSION = app_tag
+              } else {
+                error "No version specified. Aborting..."
+              }
+            }
+          } catch (err) {
+            error "No version specified. Aborting..."
+          }
+        }
       }
     }
     stage("Maintenance mode ON") {
-      options {
-        timeout(time: 5, unit: "MINUTES")
-      }
-      environment {
-        COMP_NAME = "api"
-      }
       steps {
         script {
-          try {
-            dir(MAINTENANCE_DIRECTORY) {
-              sh "INSTANCE_ID=${INSTANCE_ID} ./maintenance.sh ${DESTINATION} on"
-            }
-          } catch (e) {
-            echo 'Maintenance Page FAILED'
-            throw e
+          dir(MAINTENANCE_DIRECTORY) {
+            sh "./maintenance.sh ${DESTINATION} on"
           }
         }
       }
     }
     stage("Database backup") {
-      options {
-        timeout(time: 5, unit: "MINUTES")
-      }
       steps {
         script {
-          try {
-            dir('openshift') {
-              sh "INSTANCE_ID=${INSTANCE_ID} ./player.sh backup ${DESTINATION} apply"
-            }
-          } catch (e) {
-            echo 'Database backup FAILED'
-            throw e
+          dir(DEVOPS_DIRECTORY) {
+            sh "./player.sh backup ${DESTINATION} apply"
           }
         }
       }
@@ -139,38 +135,31 @@ pipeline {
         sleep(30)
       }
     }
-    stage("PROD deploy (API)") {
-      steps {
-        echo "TODO: ... "
-      }
-    }
-    stage("PROD deploy (APP)") {
-      steps {
-        echo "TODO: ... "
-      }
-    }
-    stage("Maintenance mode OFF") {
-      options {
-        timeout(time: 5, unit: "MINUTES")
+    stage("Promote to PROD") {
+      environment {
+        // These env-vars are required by player.sh below
+        RELEASE_TAG="${RELEASE_VERSION}"
+        TARGET_TAG="${DESTINATION}"
       }
       steps {
         script {
-          try {
-            dir(MAINTENANCE_DIRECTORY) {
-              sh "INSTANCE_ID=${INSTANCE_ID} ./maintenance.sh ${DESTINATION} off"
-            }
-          } catch (e) {
-            echo 'Maintenance Page FAILED'
-            throw e
+          dir(DEVOPS_DIRECTORY) {
+            sh "./player.sh deploy api apply"
+            sh "./player.sh deploy app apply"
           }
         }
-
+      }
+    }
+    stage("Maintenance mode OFF") {
+      steps {
+        script {
+          dir(MAINTENANCE_DIRECTORY) {
+            sh "./maintenance.sh ${DESTINATION} off"
+          }
+        }
       }
     }
     stage("DONE") {
-      options {
-        timeout(time: 5, unit: "MINUTES")
-      }
       steps {
         echo "[ci/cd]  PRODUCTION deployment complete!"
       }

--- a/openshift/pipelines/scripts/common.groovy
+++ b/openshift/pipelines/scripts/common.groovy
@@ -45,17 +45,17 @@ boolean hasDirectoryChanged(String contextDirectory) {
  * Generates a string containing all the commit messages from
  * the builds in pastBuilds.
  */
- String getChangeLog() {
+String getChangeLog() {
   MAX_MSG_LEN = 512
   def changeString = ""
   def changeLogSets = currentBuild.changeSets
   for (int i = 0; i < changeLogSets.size(); i++) {
-     def entries = changeLogSets[i].items
-     for (int j = 0; j < entries.length; j++) {
-         def entry = entries[j]
-         truncated_msg = entry.msg.take(MAX_MSG_LEN)
-         changeString += " - ${truncated_msg} [${entry.author}]\n"
-     }
+    def entries = changeLogSets[i].items
+    for (int j = 0; j < entries.length; j++) {
+      def entry = entries[j]
+      truncated_msg = entry.msg.take(MAX_MSG_LEN)
+      changeString += " - ${truncated_msg} [${entry.author}]\n"
+    }
   }
   if (!changeString) {
      changeString = "No changes"
@@ -94,8 +94,8 @@ def build(buildconfigs, int waitTimeout) {
       // untilEach and watch - do not support watching multiple named resources,
       // so we have to feed it one at a time.
       it.untilEach(1) {
-          echo "${it.object().status.phase} - ${it.name()}"
-          return (it.object().status.phase == "Complete")
+        echo "${it.object().status.phase} - ${it.name()}"
+        return (it.object().status.phase == "Complete")
       }
     }
   }
@@ -105,35 +105,46 @@ def build(buildconfigs, int waitTimeout) {
 
 // Abort the specified build.
 @NonCPS
-private void abortBuild(build){
-    boolean aborted=false;
-    if (build instanceof org.jenkinsci.plugins.workflow.job.WorkflowRun){
-        int counter=0
-        while (counter<60 && build.isInProgress()){
-            for (org.jenkinsci.plugins.workflow.support.steps.input.InputAction inputAction:build.getActions(org.jenkinsci.plugins.workflow.support.steps.input.InputAction.class)){
-                for (org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution inputStep:inputAction.getExecutions()){
-                    if (!inputStep.isSettled()){
-                        inputStep.doAbort()
-                    }
-                }
-            }
-
-            counter++
-            Thread.sleep(1000) //milliseconds
+private void abortBuild(build) {
+  boolean aborted=false;
+  if (build instanceof org.jenkinsci.plugins.workflow.job.WorkflowRun) {
+    int counter=0
+    while (counter<60 && build.isInProgress()) {
+      for (org.jenkinsci.plugins.workflow.support.steps.input.InputAction inputAction:build.getActions(org.jenkinsci.plugins.workflow.support.steps.input.InputAction.class)){
+        for (org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution inputStep:inputAction.getExecutions()) {
+          if (!inputStep.isSettled()) {
+            inputStep.doAbort()
+          }
         }
-    }
+      }
 
-    if (build.isInProgress()){
-        build.doKill()
+      counter++
+      Thread.sleep(1000) //milliseconds
     }
+  }
 
+  if (build.isInProgress()) {
+    build.doKill()
+  }
 }
 
 // Abort all previous builds in progress for the specified build.
 def abortAllPreviousBuildInProgress(currentBuild) {
-    while(currentBuild.rawBuild.getPreviousBuildInProgress() != null) {
-        abortBuild(currentBuild.rawBuild.getPreviousBuildInProgress())
-    }
+  while(currentBuild.rawBuild.getPreviousBuildInProgress() != null) {
+    abortBuild(currentBuild.rawBuild.getPreviousBuildInProgress())
+  }
+}
+
+def maintenancePageOn(envName) {
+  dir('maintenance') {
+    sh "./maintenance.sh ${envName} on"
+  }
+}
+
+def maintenancePageOff(envName) {
+  dir('maintenance') {
+    sh "./maintenance.sh ${envName} off"
+  }
 }
 
 // --------------------

--- a/openshift/pipelines/scripts/notify.groovy
+++ b/openshift/pipelines/scripts/notify.groovy
@@ -7,61 +7,47 @@ def version = "1.0"
 // Notifications
 // ------------------
 
-/*
- * Sends a rocket chat notification
- */
-def rocketChatSend(url, text, summary, description, color, image_url = "") {
-  def rocketChatURL = url
-  def message = text
-  def payload = JsonOutput.toJson([
-    username: "Jenkins",
-    icon_url: "https://wiki.jenkins.io/download/attachments/2916393/headshot.png",
-    text: message,
-    attachments: [
-      [
-        title: summary,
-        text: description,
-        image_url: image_url,
-        color: color
-      ]
-    ]
-  ])
-
-  writeFile(file: "post.json", text: payload)
-  sh "curl -X POST -H 'Content-Type: application/json' --data @post.json ${rocketChatURL}"
-}
-
-def deploySuccess(appName, environment, changelog, vanity_url, rc_url) {
+def success(appName, version, environment, rc_url = "") {
   rocketChatSend(
     rc_url,
-    "New version of **${appName}**, build [${env.BUILD_DISPLAY_NAME}](${env.BUILD_URL}) in ${environment} 🚀 \n ${vanity_url}",
-    "Changes:",
-    changelog,
+    "${appName}, release: [${version}] was deployed to **${environment}** 🚀",
     "#1ee321",  // green
     "https://i.imgur.com/zHzPWXr.png"
   )
 }
 
-def deployFailure(appName, environment, error_msg, vanity_url, rc_url) {
+def failure(appName, version, environment, rc_url = "") {
   rocketChatSend(
     rc_url,
-    "@all Could not deploy **${appName}**, build [${env.BUILD_DISPLAY_NAME}](${env.BUILD_URL}) to ${environment} 🤕",
-    "${appName} Deployment",
-    error_msg,
+    "Could not deploy ${appName}, release: [${version}] to **${environment}** 🤕",
     "#e3211e",  // red
     "https://i.imgflip.com/1czxka.jpg"
   )
 }
 
-def noChanges(appName, environment, rc_url) {
-  rocketChatSend(
-    rc_url,
-    "@all The CI/CD pipeline ran but no changes were detected for **${appName}**. \n Build [${env.BUILD_DISPLAY_NAME}](${env.BUILD_URL}) was **NOT** deployed to ${environment} 🤕",
-    "${appName} Deployment",
-    "",
-    "#e3211e",  // red
-    "https://i.imgflip.com/3pos4b.jpg"
-  )
+/*
+ * Sends a rocket chat notification
+ */
+def rocketChatSend(rc_url, text, color, image_url = "") {
+  if (rc_url != "") {
+    def message = text
+    def payload = JsonOutput.toJson([
+      username: "Jenkins",
+      icon_url: "https://wiki.jenkins.io/download/attachments/2916393/headshot.png",
+      text: message,
+      attachments: [
+        [
+          image_url: image_url,
+          color: color
+        ]
+      ]
+    ])
+
+    writeFile(file: "post.json", text: payload)
+    sh "curl -X POST -H 'Content-Type: application/json' --data @post.json ${rc_url}"
+  } else {
+    echo text
+  }
 }
 
 return this;

--- a/openshift/player.sh
+++ b/openshift/player.sh
@@ -4,21 +4,24 @@ ARGV=${@:2}
 
 case "$1" in
     backup)
-        ./scripts/oc-backup.sh ${ARGV}
+        cd scripts
+        ./oc-backup.sh ${ARGV}
+        cd ..
         ;;
     restore)
         echo "Not implemented yet"
         ;;
     build)
-        echo "Not implemented yet"
+        cd scripts
+        ./oc-build.sh ${ARGV}
+        cd ..
         ;;
     deploy)
-        echo "Not implemented yet"
+        cd scripts
+        ./oc-deploy.sh ${ARGV}
+        cd ..
         ;;
-    toolbelt)
-        echo "Not implemented yet"
-        ;;
-    scan)
+    sonar-scan)
         echo "Not implemented yet"
         ;;
     zap)

--- a/openshift/player.sh
+++ b/openshift/player.sh
@@ -1,25 +1,22 @@
 #!/bin/bash
 
+DIRECTORY=$(cd `dirname $0` && pwd)
 ARGV=${@:2}
 
-case "$1" in
+pushd ${DIRECTORY}/scripts > /dev/null
+
+case "${1:-}" in
     backup)
-        cd scripts
         ./oc-backup.sh ${ARGV}
-        cd ..
         ;;
     restore)
         echo "Not implemented yet"
         ;;
     build)
-        cd scripts
         ./oc-build.sh ${ARGV}
-        cd ..
         ;;
     deploy)
-        cd scripts
         ./oc-deploy.sh ${ARGV}
-        cd ..
         ;;
     sonar-scan)
         echo "Not implemented yet"
@@ -31,5 +28,7 @@ case "$1" in
         echo "Not implemented yet"
         ;;
     *)
-    echo "You\'re doing it wrong..."
+    echo "You are doing it wrong..."
 esac
+
+popd > /dev/null

--- a/openshift/player.sh
+++ b/openshift/player.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-DIRECTORY=$(cd `dirname $0` && pwd)
+THIS_DIRECTORY=$(cd `dirname $0` && pwd)
 ARGV=${@:2}
 
-pushd ${DIRECTORY}/scripts > /dev/null
+# the oc-scripts need to be run from the scripts folder
+pushd ${THIS_DIRECTORY}/scripts > /dev/null
 
 case "${1:-}" in
     backup)

--- a/openshift/scripts/common.sh
+++ b/openshift/scripts/common.sh
@@ -15,7 +15,8 @@ IFS=$'\n\t'
 # Receive parameters
 #
 TARGET=${1:-}
-APPLY=$([ "${2:-}" != "apply" ] || echo true)
+LAST_ARG=$(for last in ${@:-''}; do :; done && echo "${last}")
+APPLY=$([ "${LAST_ARG:-}" != "apply" ] || echo true)
 
 # Load environment variables from a file
 #
@@ -46,11 +47,15 @@ $(oc whoami &>/dev/null) || {
 display_helper() {
   set +e
   if [ ! "${APPLY}" ]; then
-    echo -e "\n*** This is a dry run.  Use 'apply' to deploy. ***"
+    echo -e "\n*** This is a dry run.  Use 'apply' to do a real run. ***\n"
+    echo -e "OC commands that would be executed"
+    echo -e "==================================\n"
+  else
+    echo -e "\nOC commands executed"
+    echo -e "====================\n"
   fi
-  echo
   for i in $*; do
-    echo -e "$i\n"
+    echo -e "  $i"
   done
   set -e
 }

--- a/openshift/scripts/envars
+++ b/openshift/scripts/envars
@@ -1,6 +1,7 @@
 GIT_URL="${GIT_URL:-$(git remote get-url origin)}"
 GIT_BRANCH="${GIT_BRANCH:-$(git describe --all --contains HEAD)}"
-NAME_APP="${NAME_APP:-$(echo ${GIT_URL##*/} | sed -e 's/\.[^.]*$//')}"
+
+APP_NAME="${APP_NAME:-pims}"
 
 PROJ_PREFIX="${PROJ_PREFIX:-jcxjin}"
 PROJ_TOOLS="${PROJ_TOOLS:-$(echo ${PROJ_PREFIX})-tools}"
@@ -8,4 +9,6 @@ PROJ_DEV="${PROJ_DEV:-$(echo ${PROJ_PREFIX})-dev}"
 PROJ_TEST="${PROJ_TEST:-$(echo ${PROJ_PREFIX})-test}"
 PROJ_PROD="${PROJ_PROD:-$(echo ${PROJ_PREFIX})-prod}"
 
+TAG_DEV="${TAG_DEV:-dev}"
+TAG_TEST="${TAG_TEST:-test}"
 TAG_PROD="${TAG_PROD:-prod}"

--- a/openshift/scripts/oc-backup.sh
+++ b/openshift/scripts/oc-backup.sh
@@ -6,15 +6,15 @@ source "$(dirname ${0})/common.sh"
 #% OpenShift Database Helper
 #%
 #%   Intended for use with a pull request-based pipeline.
-#%   Targets incl.: dev, test and prod.
+#%   Targets incl.: 'dev', 'test' and 'prod'
 #%
 #% Usage:
 #%
-#%   ${THIS_FILE} [TARGER] [apply]
+#%   ${THIS_FILE} [TARGET] [apply]
 #%
 #% Examples:
 #%
-#%   Provide a target environment (dev, test or prod). Defaults to a dry-run.
+#%   Provide a target environment ('dev' OR 'test' OR 'prod'). Defaults to a dry-run.
 #%   ${THIS_FILE} dev
 #%
 #%   Apply when satisfied.

--- a/openshift/scripts/oc-build.sh
+++ b/openshift/scripts/oc-build.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+source "$(dirname ${0})/common.sh"
+
+#%
+#% OpenShift Build Helper
+#%
+#%   This command starts a new build for the provided build config
+#%
+#%   Targets builds incl.: 'api', 'app-base' and 'app'
+#%   Git Branch: Git Branch to build (i.e. 'master' OR 'dev') -- defaults to 'dev'
+#%
+#% Usage:
+#%
+#%    ${THIS_FILE} [BUILD_NAME] [apply]
+#%
+#% Examples:
+#%
+#%   Provide a target build. Defaults to a dry-run.
+#%    ${THIS_FILE} api
+#%
+#%   Apply when satisfied.
+#%    ${THIS_FILE} api apply
+#%
+#%   Set variables to non-defaults at runtime.  E.g.:
+#%    VERBOSE=true GIT_BRANCH=master ${THIS_FILE} <...>
+#%
+#%
+
+# Receive parameters
+#
+GIT_BRANCH=${GIT_BRANCH:-dev}
+SHORTNAME=${1:-}
+
+# E.g. <buildname>-master
+#
+BUILD_NAME="${APP_NAME}-${SHORTNAME}-${GIT_BRANCH}"
+
+# Cancel non complete builds and start a new build (apply or don't run)
+#
+OC_CANCEL_BUILD="oc -n ${PROJ_TOOLS} cancel-build bc/${BUILD_NAME}"
+OC_START_BUILD="oc -n ${PROJ_TOOLS} start-build ${BUILD_NAME} --wait --follow"
+
+# Execute commands
+#
+if [ "${APPLY}" ]; then
+  eval "${OC_CANCEL_BUILD}"
+  eval "${OC_START_BUILD}"
+  # Get the most recent build version
+  BUILD_LAST=$(oc -n ${PROJ_TOOLS} get bc/${BUILD_NAME} -o 'jsonpath={.status.lastVersion}')
+  # Command to get the build result
+  BUILD_RESULT=$(oc -n ${PROJ_TOOLS} get build/${BUILD_NAME}-${BUILD_LAST} -o 'jsonpath={.status.phase}')
+
+  # Make sure that result is a successful completion
+  if [ "${BUILD_RESULT}" != "Complete" ]; then
+    echo "Build result: ${BUILD_RESULT}"
+    echo -e "\n*** Build not complete! ***\n"
+    exit 1
+  fi
+fi
+
+# Provide oc command instruction
+#
+display_helper "${OC_CANCEL_BUILD}" "${OC_START_BUILD}"

--- a/openshift/scripts/oc-build.sh
+++ b/openshift/scripts/oc-build.sh
@@ -8,7 +8,7 @@ source "$(dirname ${0})/common.sh"
 #%   This command starts a new build for the provided build config
 #%
 #%   Targets builds incl.: 'api', 'app-base' and 'app'
-#%   Git Branch: Git Branch to build (i.e. 'master' OR 'dev') -- defaults to 'dev'
+#%   Job Name: Job identifier (i.e. 'pr-5' OR 'master' or 'dev') -- defaults to 'dev'
 #%
 #% Usage:
 #%
@@ -23,18 +23,18 @@ source "$(dirname ${0})/common.sh"
 #%    ${THIS_FILE} api apply
 #%
 #%   Set variables to non-defaults at runtime.  E.g.:
-#%    VERBOSE=true GIT_BRANCH=master ${THIS_FILE} <...>
+#%    VERBOSE=true JOB_NAME=master ${THIS_FILE} <...>
 #%
 #%
 
 # Receive parameters
 #
-GIT_BRANCH=${GIT_BRANCH:-dev}
+JOB_NAME=${JOB_NAME:-dev}
 SHORTNAME=${1:-}
 
 # E.g. <buildname>-master
 #
-BUILD_NAME="${APP_NAME}-${SHORTNAME}-${GIT_BRANCH}"
+BUILD_NAME="${APP_NAME}-${SHORTNAME}-${JOB_NAME}"
 
 # Cancel non complete builds and start a new build (apply or don't run)
 #

--- a/openshift/scripts/oc-deploy.sh
+++ b/openshift/scripts/oc-deploy.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+source "$(dirname ${0})/common.sh"
+
+#%
+#% OpenShift Deploy Helper
+#%
+#%   This command starts a new deployment for the provided target deployment
+#%   Targets deployments incl.: 'api', 'app-base' and 'app'
+#%
+#% Usage:
+#%
+#%   [RELEASE_TAG=<>] [TARGET_TAG=<>] ${THIS_FILE} [DEPLOY_NAME] [apply]
+#%
+#% Examples:
+#%
+#%   Provide a target deployment. Defaults to a dry-run.
+#%   ${THIS_FILE} api
+#%
+#%   Apply when satisfied.
+#%   ${THIS_FILE} api apply
+#%
+#%   Set variables to non-defaults at runtime.  E.g. to deploy from TEST to PROD:
+#%   RELEASE_TAG=test TARGET_TAG=prod ${THIS_FILE} <...>
+
+# Receive parameters (source and destination)
+#
+RELEASE_TAG=${RELEASE_TAG:-latest}
+TARGET_TAG="${TARGET_TAG:-${TAG_DEV}}"
+PROJ_TARGET="${PROJ_PREFIX}-${TARGET_TAG}"
+SHORTNAME=${1:-}
+
+# E.g. <deploymentname>-prod
+#
+IMG_DEST="${APP_NAME}-${SHORTNAME}"
+DEPLOYMENT_NAME="${APP_NAME}-${SHORTNAME}-${TARGET_TAG}"
+
+# Cancel all previous deployments
+#
+OC_CANCEL_ALL_PREV_DEPLOY="oc -n ${PROJ_TARGET} rollout cancel dc/${DEPLOYMENT_NAME} || true"
+
+# Deploy and follow the progress
+#
+OC_DEPLOY="oc -n ${PROJ_TOOLS} tag ${IMG_DEST}:${RELEASE_TAG} ${IMG_DEST}:${TARGET_TAG}"
+OC_LOG="oc -n ${PROJ_TARGET} logs -f --pod-running-timeout=1m dc/${DEPLOYMENT_NAME}"
+
+if [ "${APPLY}" ]; then
+  echo "canceling previous deployments..."
+  eval "${OC_CANCEL_ALL_PREV_DEPLOY}"
+  count=1
+  timeout=10
+  # Check previous deployment statuses before moving onto new deploying
+  while [ $count -le $timeout ]; do
+    sleep 1
+    PENDINGS="$(oc -n ${PROJ_TARGET} rollout history dc/${DEPLOYMENT_NAME} | awk '{print $2}' | grep -c Pending || true)"
+    RUNNINGS="$(oc -n ${PROJ_TARGET} rollout history dc/${DEPLOYMENT_NAME} | awk '{print $2}' | grep -c Running || true)"
+    if [ "${PENDINGS}" == 0 ] && [ "${RUNNINGS}" == 0 ]; then
+      # No pending or running replica controllers so exit the while loop
+      break 2
+    fi
+    count=$(( $count + 1 ))
+  done
+  if [ $count -gt $timeout ]; then
+    echo "\n*** Reached the timeout for canceling previous deployments ***\n"
+    exit 1
+  fi
+
+  # Execute commands
+  #
+  eval "${OC_DEPLOY}"
+  eval "${OC_LOG}"
+fi
+
+# Provide oc command instructions
+#
+display_helper $OC_CANCEL_ALL_PREV_DEPLOY $OC_DEPLOY $OC_LOG

--- a/openshift/scripts/oc-deploy.sh
+++ b/openshift/scripts/oc-deploy.sh
@@ -6,39 +6,40 @@ source "$(dirname ${0})/common.sh"
 #% OpenShift Deploy Helper
 #%
 #%   This command starts a new deployment for the provided target deployment
-#%   Targets deployments incl.: 'api', 'app-base' and 'app'
+#%   Target deployments incl.: 'api', 'app-base' and 'app'
+#%   Target environments incl.: 'dev', 'test', 'prod'
 #%
 #% Usage:
 #%
-#%   [RELEASE_TAG=<>] [TARGET_TAG=<>] ${THIS_FILE} [DEPLOY_NAME] [apply]
+#%   [RELEASE_TAG=<>] ${THIS_FILE} [DEPLOY_NAME] [ENV_NAME] [apply]
 #%
 #% Examples:
 #%
 #%   Provide a target deployment. Defaults to a dry-run.
-#%   ${THIS_FILE} api
+#%   ${THIS_FILE} api dev
 #%
 #%   Apply when satisfied.
-#%   ${THIS_FILE} api apply
+#%   ${THIS_FILE} api dev apply
 #%
 #%   Set variables to non-defaults at runtime.  E.g. to deploy from TEST to PROD:
-#%   RELEASE_TAG=test TARGET_TAG=prod ${THIS_FILE} <...>
+#%   RELEASE_TAG=test ${THIS_FILE} api prod apply
 
 # Receive parameters (source and destination)
 #
-RELEASE_TAG=${RELEASE_TAG:-latest}
-TARGET_TAG="${TARGET_TAG:-${TAG_DEV}}"
-PROJ_TARGET="${PROJ_PREFIX}-${TARGET_TAG}"
 SHORTNAME=${1:-}
+ENVIRONMENT_NAME="${2:-dev}"
+RELEASE_TAG=${RELEASE_TAG:-latest}
+PROJ_TARGET="${PROJ_PREFIX}-${ENVIRONMENT_NAME}"
 
 # E.g. <deploymentname>-prod
 #
 IMG_DEST="${APP_NAME}-${SHORTNAME}"
-DEPLOYMENT_NAME="${APP_NAME}-${SHORTNAME}-${TARGET_TAG}"
+DEPLOYMENT_NAME="${APP_NAME}-${SHORTNAME}-${ENVIRONMENT_NAME}"
 
 # Trigger the deployment manually when both tags reference the same image hash - retagging won't trigger a deployment
 #
 HASH_SOURCE="$(oc -n ${PROJ_TOOLS} get istag ${IMG_DEST}:${RELEASE_TAG} -o jsonpath='{.image.dockerImageReference}')"
-HASH_TARGET="$(oc -n ${PROJ_TOOLS} get istag ${IMG_DEST}:${TARGET_TAG} -o jsonpath='{.image.dockerImageReference}')"
+HASH_TARGET="$(oc -n ${PROJ_TOOLS} get istag ${IMG_DEST}:${ENVIRONMENT_NAME} -o jsonpath='{.image.dockerImageReference}')"
 MANUAL_DEPLOY=$([ "${HASH_SOURCE:-}" != "${HASH_TARGET:-}" ] || echo true)
 
 # Cancel all previous deployments
@@ -47,7 +48,7 @@ OC_CANCEL_ALL_PREV_DEPLOY="oc -n ${PROJ_TARGET} rollout cancel dc/${DEPLOYMENT_N
 
 # Deploy and follow the progress
 #
-OC_IMG_RETAG="oc -n ${PROJ_TOOLS} tag ${IMG_DEST}:${RELEASE_TAG} ${IMG_DEST}:${TARGET_TAG}"
+OC_IMG_RETAG="oc -n ${PROJ_TOOLS} tag ${IMG_DEST}:${RELEASE_TAG} ${IMG_DEST}:${ENVIRONMENT_NAME}"
 OC_DEPLOY="oc -n ${PROJ_TARGET} rollout latest dc/${DEPLOYMENT_NAME}"
 [ "${MANUAL_DEPLOY}" ] || OC_DEPLOY=""
 OC_STATUS="oc -n ${PROJ_TARGET} rollout status dc/${DEPLOYMENT_NAME} --watch"

--- a/openshift/templates/jenkins/generic-pipeline.yaml
+++ b/openshift/templates/jenkins/generic-pipeline.yaml
@@ -35,10 +35,12 @@ objects:
           env:
             - name: VANITY_URL
               value: ${APP_URI}
-            - name: RELEASE_TAG
-              value: ${GIT_REF}
+            - name: JOB_NAME
+              value: ${JOB_NAME}
             - name: DESTINATION
               value: ${ENV_NAME}
+            - name: ENABLE_VERSION_PROMPT
+              value: ${ENABLE_VERSION_PROMPT}
           jenkinsfilePath: "${JENKINSFILE_PATH}"
       output: {}
       resources: {}
@@ -69,12 +71,10 @@ parameters:
     displayName: Git Reference
     description: Set this to a branch name, tag or other ref of your repository if you are not using the default branch.
     value: dev
-
   - name: JENKINSFILE_PATH
     displayName: Jenkinsfile path
     description: Set this to the path to your Jenkinsfile (include the filename), relative to the contextDir.
     value: openshift/pipelines/Jenkinsfile
-
   - name: APP_URI
     displayName: Application URI
     description: The URI to the application being deployed.
@@ -85,3 +85,12 @@ parameters:
     description: The name for the environment that the build will be deployed to [dev, test, prod]
     required: true
     value: dev
+  - name: JOB_NAME
+    displayName: Job Branch Name
+    description: Job identifier (i.e. 'pr-5' OR 'dev' OR 'master')
+    required: true
+    value: dev
+  - name: ENABLE_VERSION_PROMPT
+    displayName: Enable Version Prompt
+    description: To force asking for a release version before running the pipeline, set to "true"
+    value: false

--- a/openshift/templates/jenkins/generic-pipeline.yaml
+++ b/openshift/templates/jenkins/generic-pipeline.yaml
@@ -35,7 +35,7 @@ objects:
           env:
             - name: VANITY_URL
               value: ${APP_URI}
-            - name: IMAGE_TAG
+            - name: RELEASE_TAG
               value: ${GIT_REF}
             - name: DESTINATION
               value: ${ENV_NAME}

--- a/openshift/templates/jenkins/generic-pipeline.yaml
+++ b/openshift/templates/jenkins/generic-pipeline.yaml
@@ -10,10 +10,10 @@ objects:
   - kind: "BuildConfig"
     apiVersion: "v1"
     metadata:
-      name: "${NAME}-pipeline"
+      name: "${NAME}"
       creationTimestamp: null
       labels:
-        name: "${NAME}-pipeline"
+        name: "${NAME}"
         role: "pipeline"
     spec:
       triggers:
@@ -47,7 +47,7 @@ objects:
       lastVersion: 0
 parameters:
   - name: NAME
-    displayName: Pipeline Name (without -pipeline suffix)
+    displayName: Pipeline Name
     description: Name of the pipeline, e.g cicd, promote-to-test, sonarqube. A -pipeline suffix will be appended to the name provided.
     required: true
   - name: GITHUB_WEBHOOK_SECRET
@@ -73,7 +73,7 @@ parameters:
   - name: JENKINSFILE_PATH
     displayName: Jenkinsfile path
     description: Set this to the path to your Jenkinsfile (include the filename), relative to the contextDir.
-    value: Jenkinsfile
+    value: openshift/pipelines/Jenkinsfile
 
   - name: APP_URI
     displayName: Application URI


### PR DESCRIPTION
This PR refactors our CI/CD pipeline to:

- Ask for a version tag to apply to successful builds. The version is optional for dev builds but **mandatory** for master builds
- Use external shell scripts to build and deploy instead of Jenkins-specific groovy code.

It also provides a PROD pipeline that:

- Asks for a version to deploy (which was provided in the CI/CD build for master builds)
- Brings up the maintenance page
- Performs a DB backup
- Deploys the tagged version to PRODUCTION
- Takes down the maintenance page and re-routes traffic to PROD server

**NOTE** - the `generic-pipeline.yaml` file has been updated with relevant env vars required by the updated pipelines