### PR TITLE
PIMS-2628, and other minor fixes

### DIFF
--- a/frontend/src/features/projects/dispose/__snapshots__/ProjectSummaryView.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/__snapshots__/ProjectSummaryView.test.tsx.snap
@@ -530,7 +530,7 @@ exports[`Review Summary View renders approved correctly 1`] = `
       </div>
     </div>
     <h3>
-      Enhanced Referal Process Exemption
+      Enhanced Referral Process Exemption
       <svg
         className="tooltip-icon"
         fill="currentColor"
@@ -581,7 +581,7 @@ exports[`Review Summary View renders approved correctly 1`] = `
             className="form-label"
             htmlFor="input-exemptionRequested"
           >
-            Apply for Enhanced Referal Process exemption
+            Apply for Enhanced Referral Process exemption
           </label>
         </div>
       </div>
@@ -1230,7 +1230,7 @@ exports[`Review Summary View renders denied correctly 1`] = `
       </div>
     </div>
     <h3>
-      Enhanced Referal Process Exemption
+      Enhanced Referral Process Exemption
       <svg
         className="tooltip-icon"
         fill="currentColor"
@@ -1281,7 +1281,7 @@ exports[`Review Summary View renders denied correctly 1`] = `
             className="form-label"
             htmlFor="input-exemptionRequested"
           >
-            Apply for Enhanced Referal Process exemption
+            Apply for Enhanced Referral Process exemption
           </label>
         </div>
       </div>
@@ -1930,7 +1930,7 @@ exports[`Review Summary View renders submitted correctly 1`] = `
       </div>
     </div>
     <h3>
-      Enhanced Referal Process Exemption
+      Enhanced Referral Process Exemption
       <svg
         className="tooltip-icon"
         fill="currentColor"
@@ -1981,7 +1981,7 @@ exports[`Review Summary View renders submitted correctly 1`] = `
             className="form-label"
             htmlFor="input-exemptionRequested"
           >
-            Apply for Enhanced Referal Process exemption
+            Apply for Enhanced Referral Process exemption
           </label>
         </div>
       </div>

--- a/frontend/src/features/projects/dispose/forms/ReviewApproveForm.tsx
+++ b/frontend/src/features/projects/dispose/forms/ReviewApproveForm.tsx
@@ -53,6 +53,8 @@ const ReviewApproveForm = ({
     statusCode: ReviewWorkflowStatus.ExemptionProcess,
   });
 
+  alert(project.exemptionRequested);
+
   return (
     <Fragment>
       <ProjectDraftForm
@@ -72,7 +74,7 @@ const ReviewApproveForm = ({
             exemptionField="exemptionRequested"
             rationaleField="exemptionRationale"
             submissionStep={false}
-            sectionHeader="Enhanced Referal Process Exemption"
+            sectionHeader="Enhanced Referral Process Exemption"
             rationaleInstruction="The agency has requested exemption with the below rationale:"
           />
           <TasksForm tasks={exemptionReviewTasks} className="reviewRequired" />

--- a/frontend/src/features/projects/dispose/forms/ReviewProjectForm.tsx
+++ b/frontend/src/features/projects/dispose/forms/ReviewProjectForm.tsx
@@ -42,10 +42,10 @@ const ReviewProjectForm = ({ canEdit }: { canEdit: boolean }) => {
       <ApprovalConfirmationForm isReadOnly={true} />
       <ExemptionRequest
         submissionStep={true}
-        sectionHeader="Enhanced Referal Process Exemption"
+        sectionHeader="Enhanced Referral Process Exemption"
         exemptionField="exemptionRequested"
         rationaleField="exemptionRationale"
-        exemptionLabel="Apply for Enhanced Referal Process exemption"
+        exemptionLabel="Apply for Enhanced Referral Process exemption"
         tooltip="To fill later"
         rationaleInstruction="Please provide your rationale below for exemption request"
         isReadOnly={isReadOnly || !canEdit}

--- a/frontend/src/features/projects/dispose/forms/disposalYupSchema.ts
+++ b/frontend/src/features/projects/dispose/forms/disposalYupSchema.ts
@@ -63,7 +63,7 @@ export const ProjectDraftStepYupSchema = Yup.object().shape({
   description: Yup.string(),
 });
 
-export const EnhancedReferalExemptionSchema = Yup.object().shape({
+export const EnhancedReferralExemptionSchema = Yup.object().shape({
   exemptionRationale: Yup.string().when(
     'exemptionRequested',
     (exemptionRequested: boolean, schema: any) =>

--- a/frontend/src/features/projects/dispose/steps/ReviewApproveStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/ReviewApproveStep.tsx
@@ -61,9 +61,12 @@ const ReviewApproveStep = ({ formikRef }: IStepProps) => {
     (project.statusCode === ReviewWorkflowStatus.PropertyReview ||
       project.statusCode === ReviewWorkflowStatus.ExemptionReview);
 
-  //validate form and tasks, skipping validation in the case of deny.
+  //validate form and tasks, skipping validation in the case of deny and save.
   const handleValidate = (values: IProject) => {
-    if (submitStatusCode === ReviewWorkflowStatus.Denied) {
+    if (
+      submitStatusCode !== ReviewWorkflowStatus.ApprovedForErp &&
+      submitStatusCode !== ReviewWorkflowStatus.ApprovedForExemption
+    ) {
       return Promise.resolve({});
     }
     let taskErrors = validateTasks(values);

--- a/frontend/src/features/projects/dispose/steps/ReviewProjectStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/ReviewProjectStep.tsx
@@ -13,7 +13,7 @@ import {
   UpdateInfoStepYupSchema,
   ProjectDraftStepYupSchema,
   SelectProjectPropertiesStepYupSchema,
-  EnhancedReferalExemptionSchema,
+  EnhancedReferralExemptionSchema,
 } from '../forms/disposalYupSchema';
 /**
  * Read only version of all step components. TODO: provide ability to update fields on this form.
@@ -33,7 +33,7 @@ const ReviewProjectStep = ({ formikRef }: IStepProps) => {
         onSubmit={onSubmit}
         validationSchema={ProjectDraftStepYupSchema.concat(UpdateInfoStepYupSchema)
           .concat(SelectProjectPropertiesStepYupSchema)
-          .concat(EnhancedReferalExemptionSchema)}
+          .concat(EnhancedReferralExemptionSchema)}
       >
         <Form>
           <ReviewProjectForm canEdit={canEdit} />

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/ReviewProjectStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/ReviewProjectStep.test.tsx.snap
@@ -496,7 +496,7 @@ exports[`renders correctly 1`] = `
       </div>
     </div>
     <h3>
-      Enhanced Referal Process Exemption
+      Enhanced Referral Process Exemption
       <svg
         className="tooltip-icon"
         fill="currentColor"
@@ -547,7 +547,7 @@ exports[`renders correctly 1`] = `
             className="form-label"
             htmlFor="input-exemptionRequested"
           >
-            Apply for Enhanced Referal Process exemption
+            Apply for Enhanced Referral Process exemption
           </label>
         </div>
       </div>

--- a/frontend/src/features/properties/components/forms/ParcelDetailForm.scss
+++ b/frontend/src/features/properties/components/forms/ParcelDetailForm.scss
@@ -103,7 +103,6 @@
     }
     .AutoCompleteText {
       margin-left: 0.25rem;
-      width: 395px;
     }
     .input-group-content {
       padding: 0;


### PR DESCRIPTION
Allow users to save during review approve step without the validation. Validation now only fires on submission (approval button). Fix city input alignment, and spelling of referal -> referral  