### PR TITLE
PIMS-2816 DevOps - Add SonarQube to pipeline

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10663,6 +10663,15 @@
         }
       }
     },
+    "jest-sonar-reporter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-sonar-reporter/-/jest-sonar-reporter-2.0.0.tgz",
+      "integrity": "sha512-ZervDCgEX5gdUbdtWsjdipLN3bKJwpxbvhkYNXTAYvAckCihobSLr9OT/IuyNIRT1EZMDDwR6DroWtrq+IL64w==",
+      "dev": true,
+      "requires": {
+        "xml": "^1.0.1"
+      }
+    },
     "jest-styled-components": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.0.2.tgz",
@@ -18824,6 +18833,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,7 @@
     "eslint-config-prettier": "6.7.0",
     "eslint-plugin-prettier": "3.1.1",
     "husky": "4.2.3",
+    "jest-sonar-reporter": "2.0.0",
     "jest-styled-components": "7.0.2",
     "prettier": "1.19.1",
     "pretty-quick": "2.0.1",
@@ -98,7 +99,7 @@
     "build": "cross-env CI=true react-scripts build",
     "test": "cross-env CI=true react-scripts test --env=jsdom-fourteen --verbose --watchAll=false --runInBand",
     "test:watch": "react-scripts test --env=jsdom-fourteen",
-    "coverage": "cross-env CI=true react-scripts test --coverage --env=jsdom-fourteen --watchAll=false --runInBand",
+    "coverage": "cross-env CI=true react-scripts test --coverage --testResultsProcessor jest-sonar-reporter --env=jsdom-fourteen --watchAll=false --runInBand",
     "update-snapshots": "react-scripts test -- --updateSnapshot",
     "eject": "react-scripts eject",
     "lint": "eslint src/ --ext .jsx,.js,.ts,.tsx --max-warnings 0",
@@ -110,7 +111,13 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,ts,tsx}",
-      "!<rootDir>/node_modules"
+      "!<rootDir>/node_modules/**",
+      "!<rootDir>/coverage/**",
+      "!<rootDir>/public/**",
+      "!<rootDir>/build/**",
+      "!<rootDir>/src/serviceWorker.**",
+      "!<rootDir>/src/setupProxy.*",
+      "!<rootDir>/src/setupTests.*"
     ],
     "coverageThreshold": {
       "global": {

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -6,15 +6,14 @@ sonar.projectName=PIMS Frontend (React)
 
 # Paths below are relative to the sonar-project.properties file. Defaults to .
 sonar.sources=src
-sonar.exclusions=**/node_modules/**, **/coverage/**, **.spec.**
+sonar.exclusions=node_modules/**, coverage/**, src/**/*.spec.**, src/**/*.test.**
 
 sonar.tests=src
-sonar.test.inclusions=**.spec.**
+sonar.test.inclusions=src/**/*.spec.**, src/**/*.test.**
 
 # --- integrate code coverage reports into SonarQube ---
-
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.testExecutionReportPaths=coverage/test-report.xml
+sonar.testExecutionReportPaths=test-report.xml
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -11,10 +11,10 @@ sonar.exclusions=**/node_modules/**, **/coverage/**, **.spec.**
 sonar.tests=src
 sonar.test.inclusions=**.spec.**
 
-# --- TODO: integrate code coverage reports into SonarQube ---
+# --- integrate code coverage reports into SonarQube ---
 
-# sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
-# sonar.testExecutionReportPaths=frontend/coverage/test-report.xml
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.testExecutionReportPaths=coverage/test-report.xml
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -163,8 +163,8 @@ pipeline {
                 sh """
                 sonar-scanner \
                   -Dsonar.host.url='${SONARQUBE_URL_INT}' \
-                  -Dsonar.projectKey='bcgov_PIMS_FE' \
-                  -Dsonar.projectName='PIMS React Frontend (${OC_JOB_NAME.toUpperCase()})'
+                  -Dsonar.projectKey='pims-frontend-${OC_JOB_NAME}' \
+                  -Dsonar.projectName='PIMS Frontend [${OC_JOB_NAME.toUpperCase()}]'
                 """
               }
             }
@@ -210,8 +210,8 @@ pipeline {
           steps {
             script {
               dir(DEVOPS_DIRECTORY) {
-                sh "OC_JOB_NAME=${OC_JOB_NAME} ./player.sh build app-base apply"
-                sh "OC_JOB_NAME=${OC_JOB_NAME} ./player.sh build app apply"
+                sh "OC_JOB_NAME=${OC_JOB_NAME} ./player.sh build app-base -apply"
+                sh "OC_JOB_NAME=${OC_JOB_NAME} ./player.sh build app -apply"
               }
             }
           }
@@ -219,7 +219,7 @@ pipeline {
         stage("Backend") {
           steps {
             dir(DEVOPS_DIRECTORY) {
-              sh "OC_JOB_NAME=${OC_JOB_NAME} ./player.sh build api apply"
+              sh "OC_JOB_NAME=${OC_JOB_NAME} ./player.sh build api -apply"
             }
           }
         }
@@ -270,8 +270,8 @@ pipeline {
           }
 
           dir(DEVOPS_DIRECTORY) {
-            sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy api ${DESTINATION} apply"
-            sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy app ${DESTINATION} apply"
+            sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy api ${DESTINATION} -apply"
+            sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy app ${DESTINATION} -apply"
           }
         }
       }

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -34,6 +34,9 @@ pipeline {
     MAINTENANCE_DIRECTORY = "maintenance"
     DEVOPS_DIRECTORY = "openshift"
 
+    // SonarQube configuration
+    SONARQUBE_URL_INT = "http://sonarqube:9000"
+
     // Environment Variables that should be set in OpenShift
     // -----------------------------------------------------
     // The job identifier (i.e 'pr-5' OR 'dev' OR 'master')
@@ -154,6 +157,16 @@ pipeline {
           steps {
             script {
               commonPipeline.runFrontendTests()
+
+              echo 'Performing SonarQube static code analysis...'
+              dir('frontend') {
+                sh """
+                sonar-scanner \
+                  -Dsonar.host.url='${SONARQUBE_URL_INT}' \
+                  -Dsonar.projectKey='bcgov_PIMS_FE' \
+                  -Dsonar.projectName='PIMS React Frontend (${OC_JOB_NAME.toUpperCase()})'
+                """
+              }
             }
           }
           post {
@@ -214,6 +227,7 @@ pipeline {
     }
 
     stage("Quality Gate") {
+      agent { label 'jenkins-slave-npm' }
       when {
         expression { new Boolean(env.SKIP_BUILD) == false }
       }

--- a/openshift/pipelines/Jenkinsfile.cicd
+++ b/openshift/pipelines/Jenkinsfile.cicd
@@ -156,17 +156,10 @@ pipeline {
           agent { label 'jenkins-slave-npm' }
           steps {
             script {
+              // pull code
+              checkout scm
               commonPipeline.runFrontendTests()
-
-              echo 'Performing SonarQube static code analysis...'
-              dir('frontend') {
-                sh """
-                sonar-scanner \
-                  -Dsonar.host.url='${SONARQUBE_URL_INT}' \
-                  -Dsonar.projectKey='pims-frontend-${OC_JOB_NAME}' \
-                  -Dsonar.projectName='PIMS Frontend [${OC_JOB_NAME.toUpperCase()}]'
-                """
-              }
+              commonPipeline.runFrontendStaticAnalysis(SONARQUBE_URL_INT, OC_JOB_NAME)
             }
           }
           post {

--- a/openshift/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/pipelines/Jenkinsfile.test-to-prod
@@ -121,7 +121,7 @@ pipeline {
       options { timeout(time: 10, unit: "MINUTES") }
       steps {
         dir(DEVOPS_DIRECTORY) {
-          sh "./player.sh backup ${DESTINATION} apply"
+          sh "./player.sh backup ${DESTINATION} -apply"
         }
       }
     }
@@ -138,8 +138,8 @@ pipeline {
       options { timeout(time: 10, unit: "MINUTES") }
       steps {
         dir(DEVOPS_DIRECTORY) {
-          sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy api ${DESTINATION} apply"
-          sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy app ${DESTINATION} apply"
+          sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy api ${DESTINATION} -apply"
+          sh "RELEASE_TAG=${RELEASE_VERSION} ./player.sh deploy app ${DESTINATION} -apply"
         }
       }
     }

--- a/openshift/pipelines/scripts/common.groovy
+++ b/openshift/pipelines/scripts/common.groovy
@@ -10,20 +10,29 @@ def version = "1.0"
 
 // Run Tests
 def runFrontendTests() {
-  // pull code
-  checkout scm
   timeout(20) {
     dir('frontend') {
-      sh 'node --version'
-      sh 'npm --version'
       echo 'Installing NPM Dependencies...'
       sh 'npm ci'
-      echo 'Reporting Outdated and Vulnerable Dependencies...'
+      echo 'Reporting Vulnerable Dependencies...'
       sh 'npm audit || true'
-      sh 'npm outdated || true'
       echo "Linting and Testing Frontend..."
       sh 'npm run lint'
       sh 'npm run coverage'
+    }
+  }
+}
+
+def runFrontendStaticAnalysis(String sonarUrl, String jobName) {
+  timeout(20) {
+    dir('frontend') {
+      echo 'Performing SonarQube static code analysis...'
+      sh """
+      sonar-scanner \
+        -Dsonar.host.url='${sonarUrl}' \
+        -Dsonar.projectKey='pims-frontend-${jobName}' \
+        -Dsonar.projectName='PIMS Frontend [${jobName.toUpperCase()}]'
+      """
     }
   }
 }


### PR DESCRIPTION
Initial PR that runs SonarQube scans for React/JavaScript in the CI/CD. 
The backend scan will be added in my next PR.

**NOTE** - this PR also fixes a bug in the build pipelines where they are running in "dry run" mode without actually deploying new code.