### PR TITLE
Fixing keycloak sync error

### DIFF
--- a/backend/api/Areas/Admin/Controllers/AgencyController.cs
+++ b/backend/api/Areas/Admin/Controllers/AgencyController.cs
@@ -1,0 +1,137 @@
+using MapsterMapper;
+using Entity = Pims.Dal.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Model = Pims.Api.Areas.Admin.Models.Agency;
+using Pims.Api.Policies;
+using Pims.Dal.Security;
+using Pims.Dal.Services.Admin;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Pims.Api.Areas.Admin.Controllers
+{
+    /// <summary>
+    /// AgencyController class, provides endpoints for managing agencys.
+    /// </summary>
+    [HasPermission(Permissions.AgencyAdmin)]
+    [ApiController]
+    [Area("admin")]
+    [ApiVersion("1.0")]
+    [Route("v{version:apiVersion}/[area]/agencies")]
+    [Route("[area]/agencies")]
+    public class AgencyController : ControllerBase
+    {
+        #region Variables
+        private readonly ILogger<AgencyController> _logger;
+        private readonly IPimsAdminService _pimsAdminService;
+        private readonly IMapper _mapper;
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Creates a new instance of a AgencyController class.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="pimsAdminService"></param>
+        /// <param name="mapper"></param>
+        public AgencyController(ILogger<AgencyController> logger, IPimsAdminService pimsAdminService, IMapper mapper)
+        {
+            _logger = logger;
+            _pimsAdminService = pimsAdminService;
+            _mapper = mapper;
+        }
+        #endregion
+
+        #region Endpoints
+        /// <summary>
+        /// GET - Returns a paged array of agencys from the datasource.
+        /// </summary>
+        /// <returns>Paged object with an array of agencys.</returns>
+        [HttpGet]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(Api.Models.PageModel<Model.AgencyModel>), 200)]
+        [ProducesResponseType(typeof(Api.Models.ErrorResponseModel), 400)]
+        [SwaggerOperation(Tags = new[] { "admin-agency" })]
+        public IActionResult GetAgencies()
+        {
+            var agencies = _pimsAdminService.Agency.GetAll();
+            return new JsonResult(_mapper.Map<Model.AgencyModel[]>(agencies));
+        }
+
+        /// <summary>
+        /// GET - Returns a agency for the specified 'id' from the datasource.
+        /// </summary>
+        /// <param name="id">The unique 'id' for the agency to return.</param>
+        /// <returns>The agency requested.</returns>
+        [HttpGet("{id}")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(Model.AgencyModel), 200)]
+        [ProducesResponseType(typeof(Api.Models.ErrorResponseModel), 400)]
+        [SwaggerOperation(Tags = new[] { "admin-agency" })]
+        public IActionResult GetAgency(int id)
+        {
+            var agency = _pimsAdminService.Agency.Get(id);
+            return new JsonResult(_mapper.Map<Model.AgencyModel>(agency));
+        }
+
+        /// <summary>
+        /// POST - Add a new agency to the datasource.
+        /// </summary>
+        /// <param name="model">The agency model.</param>
+        /// <returns>The agency added.</returns>
+        [HttpPost]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(Model.AgencyModel), 201)]
+        [ProducesResponseType(typeof(Api.Models.ErrorResponseModel), 400)]
+        [SwaggerOperation(Tags = new[] { "admin-agency" })]
+        public IActionResult AddAgency([FromBody] Model.AgencyModel model)
+        {
+            var entity = _mapper.Map<Entity.Agency>(model);
+            var addedEntity = _pimsAdminService.Agency.Add(entity);
+
+            var agency = _mapper.Map<Model.AgencyModel>(addedEntity);
+
+            return CreatedAtAction(nameof(GetAgency), new { id = agency.Id }, agency);
+        }
+
+        /// <summary>
+        /// PUT - Update the agency in the datasource.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="model">The agency model.</param>
+        /// <returns>The agency updated.</returns>
+        [HttpPut("{id}")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(Model.AgencyModel), 200)]
+        [ProducesResponseType(typeof(Api.Models.ErrorResponseModel), 400)]
+        [SwaggerOperation(Tags = new[] { "admin-agency" })]
+        public IActionResult UpdateAgency([FromBody] Model.AgencyModel model)
+        {
+            var entity = _mapper.Map<Entity.Agency>(model);
+            var updatedEntity = _pimsAdminService.Agency.Update(entity);
+
+            var agency = _mapper.Map<Model.AgencyModel>(updatedEntity);
+            return new JsonResult(agency);
+        }
+
+        /// <summary>
+        /// DELETE - Delete the agency from the datasource.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="model">The agency model.</param>
+        /// <returns>The agency who was deleted.</returns>
+        [HttpDelete("{id}")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(Model.AgencyModel), 200)]
+        [ProducesResponseType(typeof(Api.Models.ErrorResponseModel), 400)]
+        [SwaggerOperation(Tags = new[] { "admin-agency" })]
+        public IActionResult DeleteAgency([FromBody] Model.AgencyModel model)
+        {
+            var entity = _mapper.Map<Entity.Agency>(model);
+            _pimsAdminService.Agency.Remove(entity);
+
+            return new JsonResult(model);
+        }
+        #endregion
+    }
+}

--- a/backend/api/Areas/Admin/Mapping/Agency/AgencyMap.cs
+++ b/backend/api/Areas/Admin/Mapping/Agency/AgencyMap.cs
@@ -1,0 +1,22 @@
+using Mapster;
+using Model = Pims.Api.Areas.Admin.Models.Agency;
+using Entity = Pims.Dal.Entities;
+
+namespace Pims.Api.Areas.Admin.Mapping.Agency
+{
+    public class AgencyMap : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<Entity.Agency, Model.AgencyModel>()
+                .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.ParentId, src => src.ParentId)
+                .Inherits<Entity.CodeEntity<int>, Api.Models.CodeModel<int>>();
+
+            config.NewConfig<Model.AgencyModel, Entity.Agency>()
+                .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.ParentId, src => src.ParentId)
+                .Inherits<Api.Models.CodeModel<int>, Entity.CodeEntity<int>>();
+        }
+    }
+}

--- a/backend/api/Areas/Admin/Models/Agency/AgencyModel.cs
+++ b/backend/api/Areas/Admin/Models/Agency/AgencyModel.cs
@@ -1,0 +1,16 @@
+namespace Pims.Api.Areas.Admin.Models.Agency
+{
+    /// <summary>
+    /// AgencyModel class, provides a model that represents the agency.
+    /// </summary>
+    public class AgencyModel : Api.Models.CodeModel<int>
+    {
+        #region Properties
+        /// <summary>
+        /// get/set - The agency description.
+        /// </summary>
+        /// <value></value>
+        public string Description { get; set; }
+        #endregion
+    }
+}

--- a/backend/dal/Security/Permissions.cs
+++ b/backend/dal/Security/Permissions.cs
@@ -24,11 +24,14 @@ namespace Pims.Dal.Security
         [Display(GroupName = "admin", Name = "admin-roles", Description = "Can administer application roles.")]
         AdminRoles = 4,
 
+        [Display(GroupName = "admin", Name = "admin-agencies", Description = "Can administer application roles.")]
+        AdminAgencies = 5,
+
         [Display(GroupName = "admin", Name = "admin-properties", Description = "Can administer properties.")]
-        AdminProperties = 5,
+        AdminProperties = 6,
 
         [Display(GroupName = "admin", Name = "admin-projects", Description = "Can administer projects.")]
-        AdminProjects = 6,
+        AdminProjects = 7,
 
         [Display(GroupName = "property", Name = "property-view", Description = "Can view properties from inventory.")]
         PropertyView = 10,

--- a/backend/dal/Services/Admin/Concrete/AgencyService.cs
+++ b/backend/dal/Services/Admin/Concrete/AgencyService.cs
@@ -41,6 +41,17 @@ namespace Pims.Dal.Services.Admin
         }
 
         /// <summary>
+        /// Get the agency for the specified 'id'.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <exception cref="KeyNotFoundException">Agency does not exists for the specified 'id'.</exception>
+        /// <returns></returns>
+        public Agency Get(int id)
+        {
+            return this.Context.Agencies.Find(id) ?? throw new KeyNotFoundException();
+        }
+
+        /// <summary>
         /// Updates the specified agency in the datasource.
         /// </summary>
         /// <param name="entity"></param>

--- a/backend/dal/Services/Admin/IAgencyService.cs
+++ b/backend/dal/Services/Admin/IAgencyService.cs
@@ -9,5 +9,6 @@ namespace Pims.Dal.Services.Admin
     public interface IAgencyService : IBaseService<Agency>
     {
         IEnumerable<Agency> GetAll();
+        Agency Get(int id);
     }
 }

--- a/backend/tools/keycloak/sync/Models/UserModel.cs
+++ b/backend/tools/keycloak/sync/Models/UserModel.cs
@@ -101,7 +101,11 @@ namespace Pims.Tools.Keycloak.Sync.Models
             this.Email = user.Email;
             this.IsDisabled = !user.Enabled;
             this.EmailVerified = user.EmailVerified;
-            this.Agencies = user.Attributes?.ContainsKey("agencies") ?? false ? user.Attributes["agencies"].Select(a => new AgencyModel() { Id = Int32.Parse(a) }).ToArray() : null;
+            this.Agencies = user.Attributes?.ContainsKey("agencies") ?? false ? user.Attributes["agencies"].Select(a => {
+                if (Int32.TryParse(a, out int id))
+                    return new AgencyModel() { Id = id };
+                return null;
+            }).Where(a => a != null).ToList() : null;
         }
         #endregion
     }

--- a/backend/tools/keycloak/sync/Pims.Tools.Keycloak.Sync.csproj
+++ b/backend/tools/keycloak/sync/Pims.Tools.Keycloak.Sync.csproj
@@ -14,7 +14,6 @@
     <None Remove="appsettings.json" />
     <None Remove="appsettings.local.json" />
     <None Remove="appsettings.test.json" />
-    <None Remove="realm.development.json" />
     <None Remove="realm.json" />
     <None Remove="realm.local.json" />
     <None Remove="realm.test.json" />
@@ -42,9 +41,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="appsettings.test.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="realm.development.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="realm.json">


### PR DESCRIPTION
## Description

A fix for the annoying issue where running the keycloak sync tool throws an error if an agency doesn't exist.

It will now ignore the missing agencies and provide a summary of the sync at the end of the log.