### PR TITLE
PIMS-2621 API - Integrate with DataBC Geocoder - PID

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,10 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.ts]
-indent_style = tab
+indent_style = space
+
+[*.cs]
+indent_size = 4
 
 [{*.json,*.md,*.yml,*.groovy,Jenkinsfile*}]
 indent_style = space

--- a/backend/api/Areas/Tools/Controllers/GeocoderController.cs
+++ b/backend/api/Areas/Tools/Controllers/GeocoderController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using MapsterMapper;
 using Microsoft.AspNetCore.Mvc;
@@ -64,6 +65,26 @@ namespace Pims.Api.Areas.Tools.Controllers
             parameters.AddressString = address;
             var result = await _geocoderService.GetSiteAddressesAsync(parameters);
             return new JsonResult(_mapper.Map<Model.AddressModel[]>(result.Features));
+        }
+
+        /// <summary>
+        /// Make a request to Data BC Geocoder for PIDs that belong to the specified 'siteId'.
+        /// </summary>
+        /// <param name="siteId">The site identifier for a parcel.</param>
+        /// <returns>An array of PIDs for the supplied 'siteId'.</returns>
+        [HttpGet("parcels/pids/{siteId}")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(IEnumerable<Model.AddressModel>), 200)]
+        [ProducesResponseType(typeof(Pims.Api.Models.ErrorResponseModel), 400)]
+        [SwaggerOperation(Tags = new[] { "tools-geocoder" })]
+        [HasPermission(Permissions.PropertyEdit)]
+        public async Task<IActionResult> FindSitePidsAsync(Guid siteId)
+        {
+            // var parameters = this.Request.QueryString.ParseQueryString<AddressesParameters>();
+            // parameters.AddressString = address;
+            // var result = await _geocoderService.GetSiteAddressesAsync(parameters);
+            // return new JsonResult(_mapper.Map<Model.AddressModel[]>(result.Features));
+            throw new System.NotImplementedException();
         }
         #endregion
     }

--- a/backend/api/Areas/Tools/Controllers/GeocoderController.cs
+++ b/backend/api/Areas/Tools/Controllers/GeocoderController.cs
@@ -81,7 +81,7 @@ namespace Pims.Api.Areas.Tools.Controllers
         public async Task<IActionResult> FindPidsAsync(Guid siteId)
         {
             var result = await _geocoderService.GetPids(siteId);
-            return new JsonResult(_mapper.Map<Model.SitePidsResponseModel[]>(result));
+            return new JsonResult(_mapper.Map<Model.SitePidsResponseModel>(result));
         }
         #endregion
     }

--- a/backend/api/Areas/Tools/Controllers/GeocoderController.cs
+++ b/backend/api/Areas/Tools/Controllers/GeocoderController.cs
@@ -78,13 +78,10 @@ namespace Pims.Api.Areas.Tools.Controllers
         [ProducesResponseType(typeof(Pims.Api.Models.ErrorResponseModel), 400)]
         [SwaggerOperation(Tags = new[] { "tools-geocoder" })]
         [HasPermission(Permissions.PropertyEdit)]
-        public async Task<IActionResult> FindSitePidsAsync(Guid siteId)
+        public async Task<IActionResult> FindPidsAsync(Guid siteId)
         {
-            // var parameters = this.Request.QueryString.ParseQueryString<AddressesParameters>();
-            // parameters.AddressString = address;
-            // var result = await _geocoderService.GetSiteAddressesAsync(parameters);
-            // return new JsonResult(_mapper.Map<Model.AddressModel[]>(result.Features));
-            throw new System.NotImplementedException();
+            var result = await _geocoderService.GetPids(siteId);
+            return new JsonResult(_mapper.Map<Model.SitePidsResponseModel[]>(result));
         }
         #endregion
     }

--- a/backend/api/Areas/Tools/Mapping/Geocoder/PidsMap.cs
+++ b/backend/api/Areas/Tools/Mapping/Geocoder/PidsMap.cs
@@ -1,0 +1,19 @@
+using Mapster;
+using GModel = Pims.Geocoder.Models;
+using Model = Pims.Api.Areas.Tools.Models.Geocoder;
+
+namespace Pims.Api.Areas.Tools.Mapping.Geocoder
+{
+    /// <summary>
+    /// PidsMap class, maps the model properties.
+    /// </summary>
+    public class PidsMap : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<GModel.SitePidsResponseModel, Model.SitePidsResponseModel>()
+                .Map(dest => dest.SiteId, src => src.SiteID)
+                .Map(dest => dest.Pids, src => src.Pids);
+        }
+    }
+}

--- a/backend/api/Areas/Tools/Mapping/Geocoder/PidsMap.cs
+++ b/backend/api/Areas/Tools/Mapping/Geocoder/PidsMap.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Mapster;
 using GModel = Pims.Geocoder.Models;
 using Model = Pims.Api.Areas.Tools.Models.Geocoder;
@@ -13,7 +15,12 @@ namespace Pims.Api.Areas.Tools.Mapping.Geocoder
         {
             config.NewConfig<GModel.SitePidsResponseModel, Model.SitePidsResponseModel>()
                 .Map(dest => dest.SiteId, src => src.SiteID)
-                .Map(dest => dest.Pids, src => src.Pids);
+                .Map(dest => dest.Pids, src => StringToList(src.Pids));
+        }
+
+        private IEnumerable<string> StringToList(string commaSeparated)
+        {
+            return commaSeparated != null ? commaSeparated.Split(",") : Array.Empty<string>();
         }
     }
 }

--- a/backend/api/Areas/Tools/Models/Geocoder/SitePidsResponseModel.cs
+++ b/backend/api/Areas/Tools/Models/Geocoder/SitePidsResponseModel.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pims.Api.Areas.Tools.Models.Geocoder
+{
+    public class SitePidsResponseModel
+    {
+        #region Properties
+        public Guid SiteId { get; set; }
+        public IEnumerable<string> Pids { get; set; }
+        #endregion
+    }
+}

--- a/backend/geocoder/GeocoderService.cs
+++ b/backend/geocoder/GeocoderService.cs
@@ -80,14 +80,14 @@ namespace Pims.Geocoder
         }
 
         /// <summary>
-        /// Sends an HTTP request to Geocoder for PIDs that belong to the specified 'siteId'.
+        /// Sends an HTTP request to Geocoder for all parcel identifiers (PIDs) associated with an individual site.
         /// A 'siteId' is a unique identifier assigned to every site in B.C.
         /// Valid 'siteId' values for an address are returned by GetSiteAddressesAsync.
         /// </summary>
         /// <param name="siteId">The site identifier</param>
         /// <param name="outputFormat">The output format. Defaults to "json"</param>
         /// <returns></returns>
-        public async Task<SitePidsResponseModel> GetSitePids(Guid siteId, string outputFormat = "json")
+        public async Task<SitePidsResponseModel> GetPids(Guid siteId, string outputFormat = "json")
         {
             var endpoint = this.Options.Parcels.PidsUrl.Replace("{siteId}", siteId.ToString());
             var uri = new Uri(GenerateUrl(endpoint, outputFormat));

--- a/backend/geocoder/GeocoderService.cs
+++ b/backend/geocoder/GeocoderService.cs
@@ -54,8 +54,8 @@ namespace Pims.Geocoder
         /// <summary>
         /// Sends an HTTP request to Geocoder for addresses that match the specified 'address'.
         /// </summary>
-        /// <param name="address"></param>
-        /// <param name="outputFormat"></param>
+        /// <param name="address">The address to geocode</param>
+        /// <param name="outputFormat">The output format. Defaults to "json"</param>
         /// <returns></returns>
         public async Task<FeatureCollectionModel> GetSiteAddressesAsync(string address, string outputFormat = "json")
         {
@@ -69,14 +69,29 @@ namespace Pims.Geocoder
         /// <summary>
         /// Sends an HTTP request to Geocoder for addresses that match the specified 'parameters'.
         /// </summary>
-        /// <param name="parameters"></param>
-        /// <param name="outputFormat"></param>
+        /// <param name="parameters">The address search paramenters</param>
+        /// <param name="outputFormat">The output format. Defaults to "json"</param>
         /// <returns></returns>
         public async Task<FeatureCollectionModel> GetSiteAddressesAsync(AddressesParameters parameters, string outputFormat = "json")
         {
-            var uri = new Uri($"{GenerateUrl(this.Options.Sites.AddressesUrl, outputFormat)}");
+            var uri = new Uri(GenerateUrl(this.Options.Sites.AddressesUrl, outputFormat));
             var url = QueryHelpers.AddQueryString(uri.AbsoluteUri, parameters.ToQueryStringDictionary());
             return await this.Client.GetAsync<FeatureCollectionModel>(url);
+        }
+
+        /// <summary>
+        /// Sends an HTTP request to Geocoder for PIDs that belong to the specified 'siteId'.
+        /// A 'siteId' is a unique identifier assigned to every site in B.C.
+        /// Valid 'siteId' values for an address are returned by GetSiteAddressesAsync.
+        /// </summary>
+        /// <param name="siteId">The site identifier</param>
+        /// <param name="outputFormat">The output format. Defaults to "json"</param>
+        /// <returns></returns>
+        public async Task<SitePidsResponseModel> GetSitePids(Guid siteId, string outputFormat = "json")
+        {
+            var endpoint = this.Options.Parcels.PidsUrl.Replace("{siteId}", siteId.ToString());
+            var uri = new Uri(GenerateUrl(endpoint, outputFormat));
+            return await this.Client.GetAsync<SitePidsResponseModel>(uri);
         }
         #endregion
     }

--- a/backend/geocoder/IGeocoderService.cs
+++ b/backend/geocoder/IGeocoderService.cs
@@ -1,5 +1,6 @@
 using Pims.Geocoder.Models;
 using Pims.Geocoder.Parameters;
+using System;
 using System.Threading.Tasks;
 
 namespace Pims.Geocoder
@@ -8,6 +9,6 @@ namespace Pims.Geocoder
     {
         Task<FeatureCollectionModel> GetSiteAddressesAsync(string address, string outputFormat = "json");
         Task<FeatureCollectionModel> GetSiteAddressesAsync(AddressesParameters parameters, string outputFormat = "json");
-        Task<SitePidsResponseModel> GetSitePids(string siteId, string outputFormat = "json");
+        Task<SitePidsResponseModel> GetPids(Guid siteId, string outputFormat = "json");
     }
 }

--- a/backend/geocoder/IGeocoderService.cs
+++ b/backend/geocoder/IGeocoderService.cs
@@ -8,5 +8,6 @@ namespace Pims.Geocoder
     {
         Task<FeatureCollectionModel> GetSiteAddressesAsync(string address, string outputFormat = "json");
         Task<FeatureCollectionModel> GetSiteAddressesAsync(AddressesParameters parameters, string outputFormat = "json");
+        Task<SitePidsResponseModel> GetSitePids(string siteId, string outputFormat = "json");
     }
 }

--- a/backend/geocoder/Models/SitePidsResponseModel.cs
+++ b/backend/geocoder/Models/SitePidsResponseModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace Pims.Geocoder.Models
 {
@@ -7,7 +6,7 @@ namespace Pims.Geocoder.Models
     {
         #region Properties
         public Guid SiteID { get; set; }
-        public IEnumerable<string> Pids { get; set; }
+        public string Pids { get; set; }
         #endregion
     }
 }

--- a/backend/geocoder/Models/SitePidsResponseModel.cs
+++ b/backend/geocoder/Models/SitePidsResponseModel.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pims.Geocoder.Models
+{
+    public class SitePidsResponseModel
+    {
+        #region Properties
+        public Guid SiteID { get; set; }
+        public IEnumerable<string> Pids { get; set; }
+        #endregion
+    }
+}

--- a/backend/tests/unit/api/Controllers/Tools/GeocoderControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/Tools/GeocoderControllerTest.cs
@@ -13,6 +13,7 @@ using Pims.Geocoder;
 using Pims.Geocoder.Parameters;
 using Pims.Geocoder.Models;
 using FluentAssertions;
+using System;
 
 namespace Pims.Api.Test.Controllers.Tools
 {
@@ -41,7 +42,7 @@ namespace Pims.Api.Test.Controllers.Tools
 
             var addresses = new FeatureCollectionModel()
             {
-                Features = new []
+                Features = new[]
                 {
                     new FeatureModel()
                     {
@@ -80,7 +81,46 @@ namespace Pims.Api.Test.Controllers.Tools
             first.Latitude.Should().Be(1d);
             first.Longitude.Should().Be(2d);
         }
+        #endregion
 
+        # region FindParcelPidsAsync
+        [Fact]
+        public async void FindParcelPidsAsync_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<GeocoderController>(Permissions.PropertyEdit);
+
+            var testSiteId = Guid.NewGuid();
+            var response = new SitePidsResponseModel()
+            {
+                SiteID = testSiteId,
+                Pids = new[] { "test1", "test2" }
+            };
+
+            var service = helper.GetService<Mock<IGeocoderService>>();
+            service.Setup(m => m.GetSitePids(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
+
+            // Act
+            var result = await controller.FindSitePidsAsync(testSiteId);
+
+            // Assert
+            JsonResult actionResult = Assert.IsType<JsonResult>(result);
+
+            // TODO: Finish test
+            Assert.True(false, "Partial implementation. This test needs to be completed");
+
+            // var results = Assert.IsAssignableFrom<IEnumerable<Model.AddressModel>>(actionResult.Value);
+            // results.Should().HaveCount(1);
+            // var first = results.First();
+            // first.Score.Should().Be(1);
+            // first.SiteId.Should().Be("test");
+            // first.FullAddress.Should().Be("test");
+            // first.ProvinceCode.Should().Be("test");
+            // first.Address1.Should().Be("test test");
+            // first.Latitude.Should().Be(1d);
+            // first.Longitude.Should().Be(2d);
+        }
         #endregion
         #endregion
     }

--- a/backend/tests/unit/api/Controllers/Tools/GeocoderControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/Tools/GeocoderControllerTest.cs
@@ -83,9 +83,9 @@ namespace Pims.Api.Test.Controllers.Tools
         }
         #endregion
 
-        # region FindParcelPidsAsync
+        # region FindPidsAsync
         [Fact]
-        public async void FindParcelPidsAsync_Success()
+        public async void FindPidsAsync_Success()
         {
             // Arrange
             var helper = new TestHelper();
@@ -99,27 +99,17 @@ namespace Pims.Api.Test.Controllers.Tools
             };
 
             var service = helper.GetService<Mock<IGeocoderService>>();
-            service.Setup(m => m.GetSitePids(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
+            service.Setup(m => m.GetPids(It.IsAny<Guid>(), It.IsAny<string>())).ReturnsAsync(response);
 
             // Act
-            var result = await controller.FindSitePidsAsync(testSiteId);
+            var result = await controller.FindPidsAsync(testSiteId);
 
             // Assert
             JsonResult actionResult = Assert.IsType<JsonResult>(result);
-
-            // TODO: Finish test
-            Assert.True(false, "Partial implementation. This test needs to be completed");
-
-            // var results = Assert.IsAssignableFrom<IEnumerable<Model.AddressModel>>(actionResult.Value);
-            // results.Should().HaveCount(1);
-            // var first = results.First();
-            // first.Score.Should().Be(1);
-            // first.SiteId.Should().Be("test");
-            // first.FullAddress.Should().Be("test");
-            // first.ProvinceCode.Should().Be("test");
-            // first.Address1.Should().Be("test test");
-            // first.Latitude.Should().Be(1d);
-            // first.Longitude.Should().Be(2d);
+            var results = Assert.IsAssignableFrom<Model.SitePidsResponseModel>(actionResult.Value);
+            results.SiteId.Should().Be(testSiteId);
+            results.Pids.Should().HaveCount(2);
+            results.Pids.First().Should().Be("test1");
         }
         #endregion
         #endregion

--- a/backend/tests/unit/api/Controllers/Tools/GeocoderControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/Tools/GeocoderControllerTest.cs
@@ -95,7 +95,7 @@ namespace Pims.Api.Test.Controllers.Tools
             var response = new SitePidsResponseModel()
             {
                 SiteID = testSiteId,
-                Pids = new[] { "test1", "test2" }
+                Pids = "test1,test2"
             };
 
             var service = helper.GetService<Mock<IGeocoderService>>();

--- a/backend/tests/unit/api/Routes/Tools/GeocoderControllerTest.cs
+++ b/backend/tests/unit/api/Routes/Tools/GeocoderControllerTest.cs
@@ -4,6 +4,7 @@ using Xunit;
 using System.Diagnostics.CodeAnalysis;
 using Pims.Api.Areas.Tools.Controllers;
 using Pims.Dal.Security;
+using System;
 
 namespace Pims.Api.Test.Routes.Project
 {
@@ -52,6 +53,19 @@ namespace Pims.Api.Test.Routes.Project
             // Assert
             Assert.NotNull(endpoint);
             endpoint.HasGet("addresses");
+            endpoint.HasPermissions(Permissions.PropertyEdit);
+        }
+
+        [Fact]
+        public void FindPidsAsync_Route()
+        {
+            // Arrange
+            var endpoint = typeof(GeocoderController).FindMethod(nameof(GeocoderController.FindPidsAsync), typeof(Guid));
+
+            // Act
+            // Assert
+            Assert.NotNull(endpoint);
+            endpoint.HasGet("parcels/pids/{siteId}");
             endpoint.HasPermissions(Permissions.PropertyEdit);
         }
         #endregion


### PR DESCRIPTION
This is the API portion of the Geocoder PID integration

New API endpoint:

`/api/tools/geocoder/parcels/pids/{siteId}`

^ this mirrors the geocoder API endpoint for consistency in case we add more endpoints later.

You get a `siteId` as part of the response for a valid address in `api/tools/geocoder/addresses`

New unit tests that cover the new feature