### PR TITLE
PIMS-2621 Integrate with DataBC Geocoder - PID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ database-clean: ## Re-creates an empty docker database - ready for seeding
 
 database-seed:
 	@echo "$(P) Seeding docker database..."
-	@cd backend/tools/import; make run
+	@cd tools/import; make run
 
 database-refresh: | server-run pause-30 database-clean database-seed ## Refreshes the docker database
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -6,7 +6,7 @@ import { ENVIRONMENT } from 'constants/environment';
 import * as _ from 'lodash';
 
 export interface IGeocoderResponse {
-  siteId: number;
+  siteId: string;
   fullAddress: string;
   address1: string;
   city: string;
@@ -16,13 +16,18 @@ export interface IGeocoderResponse {
   score: number;
 }
 
+export interface IGeocoderPidsResponse {
+  siteId: string;
+  pids: string[];
+}
+
 export interface PimsAPI extends AxiosInstance {
   isPidAvailable: (
     parcelId: number | '' | undefined,
     pid: string | undefined,
   ) => Promise<{ available: boolean }>;
-
   searchAddress: (text: string) => Promise<IGeocoderResponse[]>;
+  getSitePids: (siteId: string) => Promise<IGeocoderPidsResponse>;
 }
 
 export const useApi = (): PimsAPI => {
@@ -63,6 +68,13 @@ export const useApi = (): PimsAPI => {
       `${ENVIRONMENT.apiUrl}/tools/geocoder/addresses?address=${address}+BC`,
     );
     return _.orderBy(data, (r: IGeocoderResponse) => r.score, ['desc']);
+  };
+
+  axios.getSitePids = async (siteId: string): Promise<IGeocoderPidsResponse> => {
+    const { data } = await axios.get<IGeocoderPidsResponse>(
+      `${ENVIRONMENT.apiUrl}/tools/geocoder/parcels/pids/${siteId}`,
+    );
+    return data;
   };
 
   return axios;


### PR DESCRIPTION
This PR adds frontend logic to integrate with the API geocoder PID endpoint. 

In the SubmitProperty form, when a valid address is selected (and if that address returns a non-empty `siteId`) the frontend will request the PIDs associated with that `siteId`. If no `siteId` is supplied, the PID field is cleared in the form.

**NOTE** - there is an outstanding bug that makes the PID not show until you focus on the PID input and then select another field. Some code seems to be running only `onBlur`. There's a separate issue filed to deal with that so the fix is not part of this PR. Until that bug is resolved, you will need to select the PID field and then another field to verify a value has been set from the geocoder request. 😞 
