### PR TITLE
PIMS-2822 OpenShift templates for DB migration job

### DIFF
--- a/backend/Dockerfile.migrations
+++ b/backend/Dockerfile.migrations
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+
+ENV DOTNET_CLI_HOME=/tmp
+ENV PATH="$PATH:/tmp/.dotnet/tools"
+
+# Switch to root for package installs
+USER 0
+RUN dotnet tool install --global dotnet-ef
+
+WORKDIR /src
+COPY . .
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/src" "/tmp"
+
+# Run container by default as user with id 1001 (default)
+USER 1001
+
+ENTRYPOINT cd /src/dal && dotnet ef database update

--- a/openshift/templates/migrations/build.yaml
+++ b/openshift/templates/migrations/build.yaml
@@ -1,0 +1,67 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: pims-migrations
+parameters:
+  - name: NAME
+    displayName: Name
+    description: The name assigned to all of the frontend objects defined in this template.
+    required: true
+    value: pims-migrations
+  - name: GIT_URL
+    displayName: Git Repo URL
+    description:
+      The URL to your GIT repo, don't use the this default unless your just
+      experimenting.
+    required: true
+    value: https://github.com/bcgov/PIMS.git
+  - name: GIT_REF
+    displayName: Git Reference
+    description: The git reference or branch.
+    required: true
+    value: dev
+  - name: SOURCE_CONTEXT_DIR
+    displayName: Source Context Directory
+    description: The source context directory.
+    required: true
+    value: backend
+  - name: CPU_LIMIT
+    displayName: Resources CPU Limit
+    description: The resources CPU limit (in cores) for this build.
+    required: true
+    value: 1000m
+  - name: MEMORY_LIMIT
+    displayName: Memory Limit
+    description: Maximum amount of memory the container can use.
+    required: true
+    value: 2Gi
+objects:
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: ${NAME}-${GIT_REF}
+    spec:
+      runPolicy: Serial
+      source:
+        type: Git
+        git:
+          uri: "${GIT_URL}"
+          ref: "${GIT_REF}"
+        contextDir: "${SOURCE_CONTEXT_DIR}"
+      strategy:
+        type: Docker
+        dockerStrategy:
+          dockerfilePath: Dockerfile.migrations
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "${NAME}:${GIT_REF}"
+      resources:
+        limits:
+          cpu: ${CPU_LIMIT}
+          memory: ${MEMORY_LIMIT}
+      postCommit: {}

--- a/openshift/templates/migrations/migration-job.yaml
+++ b/openshift/templates/migrations/migration-job.yaml
@@ -1,0 +1,63 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: migration-job
+parameters:
+  - name: IMAGE
+    displayName: Image Name
+    description: Docker registry reference image.
+    required: true
+    value: pims-migrations
+  - name: IMAGE_TAG
+    displayName: Image Tag Name
+    description: The image tag that will be used for this job.
+    required: true
+    value: dev
+  - name: NAMESPACE
+    description: Target namespace reference (i.e. 'jcxjin-tools')
+    displayName: Namespace
+    required: true
+    value: jcxjin-tools
+  - name: ENV_NAME
+    displayName: Environment name
+    description: The name for this environment [dev, test, prod]
+    required: true
+    value: dev
+  - name: ASPNETCORE_ENVIRONMENT
+    displayName: AspNetCore Environment
+    description: The ASP Net Core deployment environment setting,
+      [Development, Staging, Production].
+    required: true
+    value: Production
+objects:
+  - kind: Pod
+    apiVersion: v1
+    metadata:
+      generateName: migration-job-
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: 900
+      containers:
+        - name: dotnet-ef
+          image: docker-registry.default.svc:5000/${NAMESPACE}/${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: ${ASPNETCORE_ENVIRONMENT}
+            - name: ConnectionStrings__PIMS
+              valueFrom:
+                configMapKeyRef:
+                  name: pims-api-${ENV_NAME}-db-client
+                  key: CONNECTION_STRINGS_PIMS
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pims-db-${ENV_NAME}-secret
+                  key: DB_PASSWORD
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi


### PR DESCRIPTION
This PR sets up the ground work for running EF migrations from within the CI pipeline. 

The main idea here is to create a custom build with `dotnet-ef` bundled. Then a migration job "pod" will be created in CI builds to migrate the database.

### Running an ad-hoc migration job

```bash
oc process -f migration-job.yaml -p ENV_NAME=prod -p IMAGE_TAG=master -o yaml | oc -n jcxjin-prod create -f - 
```

![image](https://user-images.githubusercontent.com/24322224/88131325-9349b880-cb91-11ea-8de5-6af5c12179bc.png)
