### PR TITLE
PIMS-1657 Updating Keycloak Sync Tool

### DIFF
--- a/auth/keycloak/Dockerfile
+++ b/auth/keycloak/Dockerfile
@@ -1,7 +1,7 @@
 # >docker build -t keycloak .
 # >docker run --env-file=../../.env -d keycloak
 # https://hub.docker.com/r/jboss/keycloak/
-FROM jboss/keycloak:10.0.2
+FROM jboss/keycloak:11.0.0
 
 EXPOSE 8080
 

--- a/auth/keycloak/README.md
+++ b/auth/keycloak/README.md
@@ -46,7 +46,7 @@ $ /opt/jboss/keycloak/bin/standalone.sh \
   -Djboss.management.http.port=7777
 ```
 
-Or (this doens't appear to work on Windows)
+Or (this doesn't appear to work on Windows)
 
 ```bash
 $ docker exec -it keycloak bash /opt/jboss/keycloak/bin/standalone.sh -Djboss.socket.binding.port-offset=100 -Dkeycloak.migration.action=export -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.strategy=OVERWRITE_EXISTING -Dkeycloak.migration.realmName=pims -Dkeycloak.migration.usersExportStrategy=REALM_FILE -Dkeycloak.migration.file=/tmp/realm-export-new.json

--- a/backend/dal/Services/Concrete/UserService.cs
+++ b/backend/dal/Services/Concrete/UserService.cs
@@ -63,8 +63,8 @@ namespace Pims.Dal.Services
 
             var id = this.User.GetUserId();
 
-            var entity = this.Context.Users.Find(id);
-            var exists = entity != null;
+            var user = this.Context.Users.Find(id);
+            var exists = user != null;
             if (!exists)
             {
                 var username = this.User.GetUsername() ?? _options.ServiceAccount?.Username ??
@@ -78,18 +78,18 @@ namespace Pims.Dal.Services
 
                 this.Logger.LogInformation($"User Activation: id:{id}, email:{email}, username:{username}, first:{givenName}, surname:{surname}");
 
-                entity = new User(id, username, email, givenName, surname);
-                this.Context.Users.Add(entity);
+                user = new User(id, username, email, givenName, surname);
+                this.Context.Users.Add(user);
             }
             else
             {
-                entity.LastLogin = DateTime.UtcNow;
-                this.Context.Entry(entity).State = EntityState.Modified;
+                user.LastLogin = DateTime.UtcNow;
+                this.Context.Entry(user).State = EntityState.Modified;
             }
 
             this.Context.CommitTransaction();
-            if (!exists) this.Logger.LogInformation($"User Activated: '{id}' - '{entity.Username}'.");
-            return entity;
+            if (!exists) this.Logger.LogInformation($"User Activated: '{id}' - '{user.Username}'.");
+            return user;
         }
 
         #region Access Requests

--- a/tools/keycloak/sync/Pims.Tools.Keycloak.Sync.csproj
+++ b/tools/keycloak/sync/Pims.Tools.Keycloak.Sync.csproj
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="bin\**" />
+    <EmbeddedResource Remove="bin\**" />
+    <None Remove="bin\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove=".env" />
     <None Remove="appsettings.development.json" />
     <None Remove="appsettings.json" />

--- a/tools/keycloak/sync/README.md
+++ b/tools/keycloak/sync/README.md
@@ -86,9 +86,24 @@ First login to Keycloak, create the `pims-service-account` Client and apply the 
 
 4. Copy the Client Secret and place it in your `.env` file. And update the environment value to the appropiate one _[Local, Development, Test, Production]_.\_
 
+   Modify the `/tools/keycloak/sync/.env`
+
    ```conf
    ASPNETCORE_ENVIRONMENT=Local
    Auth__Keycloak__Secret={Keycloak client secret}
+   ```
+
+   Modify the `/tools/import/.env`
+
+   ```conf
+   ASPNETCORE_ENVIRONMENT=Local
+   Auth__Keycloak__Secret={Keycloak client secret}
+   ```
+
+   Modify the `/backend/api/.env`
+
+   ```conf
+   Keycloak__ServiceAccount__Secret={Keycloak client secret}
    ```
 
 5. Run the Keycloak Sync Tool
@@ -98,3 +113,10 @@ First login to Keycloak, create the `pims-service-account` Client and apply the 
    ```
 
 > NOTE - If you have users in your pims database that have `agencies` attributes of non-existing agencies, you will receive errors in the last portion of the sync when attempting to reconcile users. You can ignore these errors for the most part, but realize that the users will need to be manually updated with correct agency values when you login to PIMS (using a **System Administrator** account).
+
+6. Add users to Keycloak
+
+   - Login to Keycloak and select the **PIMS Realm**
+   - Go to **Manage - Users**
+   - Click **Add user** button and fill out form, click **Save** button
+   - Go to the new user's **Credentials** tab and enter a password

--- a/tools/keycloak/sync/RealmFactory.cs
+++ b/tools/keycloak/sync/RealmFactory.cs
@@ -9,7 +9,6 @@ using Pims.Tools.Keycloak.Sync.Configuration.Realm;
 using SKModel = Pims.Tools.Keycloak.Sync.Models.Keycloak;
 using KModel = Pims.Tools.Core.Keycloak.Models;
 using Pims.Core.Exceptions;
-using System;
 
 namespace Pims.Tools.Keycloak.Sync
 {


### PR DESCRIPTION
## Description

Cleaning up Keycloak Sync Tool code.
Updating documentation.
Updating Keycloak docker container version.

The original reason for this story was to simplify the Keycloak Sync Tool when run the first time.  However Keycloak does not have a Service Account available until you manually create one.  Which means as long as the **import** feature in Keycloak is broken, we'll simply need to manually create the Service Account the first time.