### PR TITLE
PIMS-2489 Allowing building ownership

### DIFF
--- a/backend/dal/Configuration/AgencyConfiguration.cs
+++ b/backend/dal/Configuration/AgencyConfiguration.cs
@@ -25,7 +25,6 @@ namespace Pims.Dal.Configuration
 
             builder.Property(m => m.Email).HasMaxLength(250);
             builder.Property(m => m.AddressTo).HasMaxLength(100);
-            builder.Property(m => m.SendEmail).HasDefaultValue(true);
 
             builder.Property(m => m.Description).HasMaxLength(500);
 

--- a/backend/dal/Services/Admin/Concrete/ProjectService.cs
+++ b/backend/dal/Services/Admin/Concrete/ProjectService.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 using Pims.Core.Extensions;
 using Pims.Dal.Entities;
@@ -105,20 +104,57 @@ namespace Pims.Dal.Services.Admin
             project.ThrowIfNull(nameof(project));
 
             if (project.Workflow != null)
-                this.Context.Entry(project.Workflow).State = EntityState.Unchanged;
+            {
+                var workflow = this.Context.Workflows.Local.FirstOrDefault(w => w.Id == project.WorkflowId);
+                if (workflow != null)
+                    project.Workflow = workflow;
+                else
+                    this.Context.Entry(project.Workflow).State = EntityState.Unchanged;
+            }
             if (project.Status != null)
-                this.Context.Entry(project.Status).State = EntityState.Unchanged;
+            {
+                var status = this.Context.ProjectStatus.Local.FirstOrDefault(w => w.Id == project.StatusId);
+                if (status != null)
+                    project.Status = status;
+                else
+                    this.Context.Entry(project.Status).State = EntityState.Unchanged;
+            }
             if (project.Agency != null)
-                this.Context.Entry(project.Agency).State = EntityState.Unchanged;
+            {
+                var agency = this.Context.Agencies.Local.FirstOrDefault(w => w.Id == project.AgencyId);
+                if (agency != null)
+                    project.Agency = agency;
+                else
+                    this.Context.Entry(project.Agency).State = EntityState.Unchanged;
+            }
             if (project.TierLevel != null)
-                this.Context.Entry(project.TierLevel).State = EntityState.Unchanged;
+            {
+                var tier = this.Context.TierLevels.Local.FirstOrDefault(w => w.Id == project.TierLevelId);
+                if (tier != null)
+                    project.TierLevel = tier;
+                else
+                    this.Context.Entry(project.TierLevel).State = EntityState.Unchanged;
+
+            }
             if (project.Risk != null)
-                this.Context.Entry(project.Risk).State = EntityState.Unchanged;
+            {
+                var risk = this.Context.ProjectRisks.Local.FirstOrDefault(w => w.Id == project.RiskId);
+                if (risk != null)
+                    project.Risk = risk;
+                else
+                    this.Context.Entry(project.Risk).State = EntityState.Unchanged;
+            }
 
             project.Responses.ForEach(r =>
             {
                 if (r.Agency != null)
-                    this.Context.Entry(r.Agency).State = EntityState.Unchanged;
+                {
+                    var agency = this.Context.Agencies.Local.FirstOrDefault(w => w.Id == r.AgencyId);
+                    if (agency != null)
+                        r.Agency = agency;
+                    else
+                        this.Context.Entry(r.Agency).State = EntityState.Unchanged;
+                }
             });
 
             project.Tasks.ForEach(t =>
@@ -126,10 +162,10 @@ namespace Pims.Dal.Services.Admin
                 if (t.Task != null)
                 {
                     var task = this.Context.Tasks.Local.FirstOrDefault(ta => ta.Id == t.TaskId);
-                    if (task == null)
-                        this.Context.Entry(t.Task).State = EntityState.Unchanged;
-                    else
+                    if (task != null)
                         t.Task = task;
+                    else
+                        this.Context.Entry(t.Task).State = EntityState.Unchanged;
                 }
             });
 
@@ -151,20 +187,56 @@ namespace Pims.Dal.Services.Admin
                 if (project == null) throw new ArgumentNullException();
 
                 if (project.Workflow != null)
-                    this.Context.Entry(project.Workflow).State = EntityState.Unchanged;
+                {
+                    var workflow = this.Context.Workflows.Local.FirstOrDefault(w => w.Id == project.WorkflowId);
+                    if (workflow != null)
+                        project.Workflow = workflow;
+                    else
+                        this.Context.Entry(project.Workflow).State = EntityState.Unchanged;
+                }
                 if (project.Status != null)
-                    this.Context.Entry(project.Status).State = EntityState.Unchanged;
+                {
+                    var status = this.Context.ProjectStatus.Local.FirstOrDefault(w => w.Id == project.StatusId);
+                    if (status != null)
+                        project.Status = status;
+                    else
+                        this.Context.Entry(project.Status).State = EntityState.Unchanged;
+                }
                 if (project.Agency != null)
-                    this.Context.Entry(project.Agency).State = EntityState.Unchanged;
+                {
+                    var agency = this.Context.Agencies.Local.FirstOrDefault(w => w.Id == project.AgencyId);
+                    if (agency != null)
+                        project.Agency = agency;
+                    else
+                        this.Context.Entry(project.Agency).State = EntityState.Unchanged;
+                }
                 if (project.TierLevel != null)
-                    this.Context.Entry(project.TierLevel).State = EntityState.Unchanged;
+                {
+                    var tier = this.Context.TierLevels.Local.FirstOrDefault(w => w.Id == project.TierLevelId);
+                    if (tier != null)
+                        project.TierLevel = tier;
+                    else
+                        this.Context.Entry(project.TierLevel).State = EntityState.Unchanged;
+                }
                 if (project.Risk != null)
-                    this.Context.Entry(project.Risk).State = EntityState.Unchanged;
+                {
+                    var risk = this.Context.ProjectRisks.Local.FirstOrDefault(w => w.Id == project.RiskId);
+                    if (risk != null)
+                        project.Risk = risk;
+                    else
+                        this.Context.Entry(project.Risk).State = EntityState.Unchanged;
+                }
 
                 project.Responses.ForEach(r =>
                 {
                     if (r.Agency != null)
-                        this.Context.Entry(r.Agency).State = EntityState.Unchanged;
+                    {
+                        var agency = this.Context.Agencies.Local.FirstOrDefault(w => w.Id == r.AgencyId);
+                        if (agency != null)
+                            r.Agency = agency;
+                        else
+                            this.Context.Entry(r.Agency).State = EntityState.Unchanged;
+                    }
                 });
 
                 project.Tasks.ForEach(t =>
@@ -172,10 +244,10 @@ namespace Pims.Dal.Services.Admin
                     if (t.Task != null)
                     {
                         var task = this.Context.Tasks.Local.FirstOrDefault(ta => ta.Id == t.TaskId);
-                        if (task == null)
-                            this.Context.Entry(t.Task).State = EntityState.Unchanged;
-                        else
+                        if (task != null)
                             t.Task = task;
+                        else
+                            this.Context.Entry(t.Task).State = EntityState.Unchanged;
                     }
                 });
 

--- a/backend/entities/Agency.cs
+++ b/backend/entities/Agency.cs
@@ -34,7 +34,7 @@ namespace Pims.Dal.Entities
         /// <summary>
         /// get/set - Whether notifications should be sent to this agency.
         /// </summary>
-        public bool SendEmail { get; set; }
+        public bool SendEmail { get; set; } = true;
 
         /// <summary>
         /// get/set - The name or title of whom the notification should be addressed to.

--- a/backend/tests/unit/dal/Services/ParcelServiceTest.cs
+++ b/backend/tests/unit/dal/Services/ParcelServiceTest.cs
@@ -536,7 +536,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView).AddAgency(1);
 
             using var init = helper.InitializeDatabase(user);
             var parcel = init.CreateParcel(1, 1, 1);

--- a/frontend/src/features/properties/components/forms/subforms/BuildingForm.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/BuildingForm.tsx
@@ -63,6 +63,7 @@ interface BuildingProps {
   nameSpace?: string;
   index?: number;
   disabled?: boolean;
+  allowEdit?: boolean;
 }
 const BuildingForm = <T extends any>(props: BuildingProps & FormikProps<T>) => {
   const keycloak = useKeycloakWrapper();

--- a/frontend/src/features/properties/components/forms/subforms/PagedBuildingForms.test.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/PagedBuildingForms.test.tsx
@@ -98,7 +98,7 @@ describe('PagedBuildingForms functionality', () => {
     return (
       <Provider store={store}>
         <Formik initialValues={initialValues} onSubmit={onSubmit}>
-          <PagedBuildingForms></PagedBuildingForms>
+          <PagedBuildingForms allowEdit={true}></PagedBuildingForms>
         </Formik>
       </Provider>
     );

--- a/frontend/src/features/properties/components/forms/subforms/PagedBuildingForms.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/PagedBuildingForms.tsx
@@ -12,6 +12,7 @@ import PaginatedFormErrors from './PaginatedFormErrors';
 interface PagedBuildingFormsProps {
   /** controls whether this form can be interacted with */
   disabled?: boolean;
+  allowEdit?: boolean;
 }
 const NUMBER_OF_EVALUATIONS_PER_PAGE = 1;
 
@@ -49,6 +50,7 @@ const PagedBuildingForms: React.FC<PagedBuildingFormsProps> = (props: PagedBuild
   };
   // the current paginated page.
   const [currentPage, setCurrentPage] = useState<number>(0);
+
   return (
     <Col>
       <h3>Buildings</h3>
@@ -57,7 +59,7 @@ const PagedBuildingForms: React.FC<PagedBuildingFormsProps> = (props: PagedBuild
         render={arrayHelpers => (
           <div>
             <span className="buildingPaginate">
-              {!props.disabled && (
+              {!props.disabled && !!props.allowEdit && (
                 <>
                   <Button
                     className="pagedBuildingButton page-link"
@@ -106,6 +108,7 @@ const PagedBuildingForms: React.FC<PagedBuildingFormsProps> = (props: PagedBuild
                 <BuildingForm
                   {...(formikProps as any)}
                   disabled={props.disabled}
+                  allowEdit={props.allowEdit}
                   nameSpace="buildings"
                   index={currentPage}
                 />

--- a/frontend/src/hooks/useKeycloakWrapper.tsx
+++ b/frontend/src/hooks/useKeycloakWrapper.tsx
@@ -22,7 +22,7 @@ export interface IUserInfo {
 /**
  * IKeycloak interface, represents the keycloak object for the authenticated user.
  */
-interface IKeycloak {
+export interface IKeycloak {
   obj: any;
   displayName?: string;
   username: string;

--- a/openshift/templates/pims-api/deploy.yaml
+++ b/openshift/templates/pims-api/deploy.yaml
@@ -123,6 +123,22 @@ objects:
     stringData:
       CHES_USERNAME: ${CHES_USERNAME}
       CHES_PASSWORD: ${CHES_PASSWORD}
+  - kind: Secret
+    apiVersion: v1
+    metadata:
+      name: ${APP_NAME}-${ENV_NAME}${ID}-geocoder-secret
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      annotations:
+        description: "Geocoder client secrets"
+      labels:
+        name: ${APP_NAME}-${ENV_NAME}${ID}-geocoder-secret
+        app: ${APP_NAME}
+        component: ${COMP_NAME}
+        env: ${ENV_NAME}
+        role: backend
+    type: Opaque
+    stringData:
+      GEOCODER_KEY: ${GEOCODER_KEY}
   - kind: ConfigMap
     apiVersion: v1
     metadata:
@@ -276,6 +292,11 @@ objects:
                     secretKeyRef:
                       name: ${APP_NAME}-${ENV_NAME}${ID}-ches-secret
                       key: CHES_PASSWORD
+                - name: Geocoder__Key
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-${ENV_NAME}${ID}-geocoder-secret
+                      key: GEOCODER_KEY
               resources:
                 limits:
                   cpu: "${CPU_LIMIT}"
@@ -394,6 +415,11 @@ parameters:
   - name: CHES_PASSWORD
     displayName: CHES Username password.
     description: The Common Hosted Email Service password.
+    required: true
+
+  - name: GEOCODER_KEY
+    displayName: Geocoder Secret Key.
+    description: The Geocoder secret key that must be .
     required: true
 
   - name: HEALTH_SCHEME

--- a/tools/import/appsettings.Production.json
+++ b/tools/import/appsettings.Production.json
@@ -17,6 +17,6 @@
     }
   },
   "Api": {
-    "Uri": "https://pims-prod.pathfinder.gov.bc.ca/api"
+    "Uri": "https://pims.gov.bc.ca/api"
   }
 }

--- a/tools/keycloak/sync/appsettings.json
+++ b/tools/keycloak/sync/appsettings.json
@@ -24,7 +24,7 @@
   "RetryAttempts": 2,
   "AbortAfterFailure": 1,
   "Api": {
-    "Uri": "https://pims-prod.pathfinder.gov.bc.ca/api"
+    "Uri": "https://pims.gov.bc.ca/api"
   },
   "Serialization": {
     "Json": {

--- a/tools/keycloak/sync/realm.json
+++ b/tools/keycloak/sync/realm.json
@@ -215,7 +215,7 @@
         "Protocol": "openid-connect",
         "BearerOnly": true,
         "AuthorizationServicesEnabled": false,
-        "RedirectUris": ["https://pims.pathfinder.gov.bc.ca/api/*"],
+        "RedirectUris": ["https://pims.gov.bc.ca/api/*"],
         "WebOrigins": ["+"],
         "Attributes": {
           "login_theme": "bcgov-v2"
@@ -235,10 +235,10 @@
         "ImplicitFlowEnabled": false,
         "DirectAccessGrantsEnabled": true,
         "AuthorizationServicesEnabled": false,
-        "RootUrl": "https://pims.pathfinder.gov.bc.ca",
-        "RedirectUris": ["https://pims.pathfinder.gov.bc.ca/*"],
+        "RootUrl": "https://pims.gov.bc.ca",
+        "RedirectUris": ["https://pims.gov.bc.ca/*"],
         "BaseUrl": "/",
-        "WebOrigins": ["https://pims.pathfinder.gov.bc.ca"],
+        "WebOrigins": ["https://pims.gov.bc.ca"],
         "ProtocolMappers": [
           {
             "Name": "agencies",
@@ -425,8 +425,8 @@
         "DirectAccessGrantsEnabled": true,
         "ServiceAccountsEnabled": true,
         "AuthorizationServicesEnabled": false,
-        "RootUrl": "https://pims.pathfinder.gov.bc.ca/api",
-        "RedirectUris": ["https://pims.pathfinder.gov.bc.ca/api/*"],
+        "RootUrl": "https://pims.gov.bc.ca/api",
+        "RedirectUris": ["https://pims.gov.bc.ca/api/*"],
         "BaseUrl": "/",
         "WebOrigins": ["*"],
         "ServiceAccount": {
@@ -457,8 +457,8 @@
         "DirectAccessGrantsEnabled": true,
         "ServiceAccountsEnabled": true,
         "AuthorizationServicesEnabled": true,
-        "RootUrl": "https://pims.pathfinder.gov.bc.ca/api",
-        "RedirectUris": ["https://pims.pathfinder.gov.bc.ca/api/*"],
+        "RootUrl": "https://pims.gov.bc.ca/api",
+        "RedirectUris": ["https://pims.gov.bc.ca/api/*"],
         "BaseUrl": "/",
         "WebOrigins": ["*"],
         "ProtocolMappers": [


### PR DESCRIPTION
## Description

Provide a way to allow agencies to view and edit buildings they own when they don't own the parcel.

Adding `Geocoder` Secret to Deployment Configuration.

Fixing possible bug in production when adding projects.

Updating Keycloak configuration for production.