### PR TITLE
PIMS-2822 Run migrations in CI build

### DIFF
--- a/docs/DEVOPS.md
+++ b/docs/DEVOPS.md
@@ -1,4 +1,4 @@
-# DevOps Continuous Integration / Continous Deployment
+# DevOps Continuous Integration / Continuous Deployment
 
 First it was [Waterfall](https://en.wikipedia.org/wiki/Waterfall_model), next it was [Agile](https://en.wikipedia.org/wiki/Agile_software_development), and now it's [DevOps](https://aws.amazon.com/devops/what-is-devops/). This is how modern developers approach building great products. With the rise of DevOps has come the new methods of Continuous Integration, Continuous Delivery, (CI/CD) and Continuous Deployment. Conventional software development and delivery methods are rapidly becoming obsolete. Historically, in the agile age, most companies would deploy/ship software in monthly, quarterly, bi-annual, or even annual releases. Now we build and deploy multiple times a day.
 
@@ -8,7 +8,7 @@ First it was [Waterfall](https://en.wikipedia.org/wiki/Waterfall_model), next it
 
 The PIMS project currently uses [GitHub Actions](https://github.com/features/actions), [OpenShift](https://www.openshift.com/) and [Jenkins](https://www.jenkins.io/) to support CI/CD.
 
-The general highlevel workflow is as follows;
+The general high-level workflow is as follows;
 
 1. Fork Repo
 1. Clone Repo
@@ -65,7 +65,7 @@ As changes are merged the CI/CD pipeline build and deploy to the [DEV](https://p
 
 The CI/CD process determines if changes were made. If they were not, it will ask if you want to force a rebuild. If the build, test and scan process completed successfully it will deploy the new build and spin up new containers.
 
-This makes the **DEV** branch unstable, as it can change mulitple times per day.
+This makes the **DEV** branch unstable, as it can change multiple times per day.
 
 Initial QA testing is performed in the **DEV** environment.
 
@@ -73,7 +73,7 @@ Initial QA testing is performed in the **DEV** environment.
 
 Additionally to support a more stable QA process, the images tagged with `dev` can be deployed to the [TEST](https://pims-test.pathfinder.gov.bc.ca) environment.
 
-Within OpenShift there is a pipeline that can be initalized to automate this process.
+Within OpenShift there is a pipeline that can be initialized to automate this process.
 
 The purpose of this is to allow QA or UAT to choose when they want to receive a new build (features, enhancements and bug fixes).
 
@@ -114,7 +114,7 @@ During a Sprint there will be numerous commits to the `dev` branch. These will t
 Every Sprint a new releasable increment is developed.
 These new releases will follow our [versioning](./VERSIONS.md) strategy (`1.0.0` = `[major.minor.patch]`).
 
-When a releaseable increment is ready a PR will be created to merge the `dev` branch into the `master` branch. Upon review and acceptance the `master` branch will be updated, which will inform the Jenkins pipeline to automatically build and deploy a new release to the **TEST** environment.
+When a releasable increment is ready a PR will be created to merge the `dev` branch into the `master` branch. Upon review and acceptance the `master` branch will be updated, which will inform the Jenkins pipeline to automatically build and deploy a new release to the **TEST** environment.
 
 During the pipeline execution it will prompt a request for a _tag_ name. The tag should be the version number selected for the release (i.e. `1.2.4-alpha`). The pipeline will build, test and review the release and also add the `test` tag. The result will be deployed to the **TEST** environment.
 

--- a/openshift/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/pipelines/Jenkinsfile.test-to-prod
@@ -49,7 +49,7 @@ pipeline {
     ENABLE_VERSION_PROMPT = true // ignored - version prompt always enabled in the PROD pipeline
     OC_JOB_NAME = sh(script: 'echo "${OC_JOB_NAME:-master}"', returnStdout: true).trim()
     DESTINATION = sh(script: 'echo "${DESTINATION:-prod}"', returnStdout: true).trim()
-    VANITY_URL = sh(script: 'echo "${VANITY_URL:-https://pims-prod.pathfinder.gov.bc.ca/}"', returnStdout: true).trim()
+    VANITY_URL = sh(script: 'echo "${VANITY_URL:-https://pims.gov.bc.ca/}"', returnStdout: true).trim()
 
     // To enable pipeline verbose debug output set to "true"
     DEBUG_OUTPUT = sh(script: 'echo "${DEBUG_OUTPUT:-false}"', returnStdout: true).trim()
@@ -127,10 +127,15 @@ pipeline {
     }
 
     stage("Database migration") {
-      options { timeout(time: 5, unit: "MINUTES") }
+      options { timeout(time: 15, unit: "MINUTES") }
+      environment {
+        DB_PASSWORD = sh(script: "oc -n jcxjin-prod get secret pims-db-prod-secret -o jsonpath='{.data.DB_PASSWORD}' | base64 -d", returnStdout: true).trim()
+        DB_CONNECTION_STRING = sh(script: "oc -n jcxjin-prod get cm pims-api-prod-db-client -o jsonpath='{.data.CONNECTION_STRINGS_PIMS}'", returnStdout: true).trim()
+      }
       steps {
-        // pretend we are doing stuff - db backups etc
-        sleep(5)
+        dir(DEVOPS_DIRECTORY) {
+          sh "MIGRATION_TAG=${OC_JOB_NAME} ./player.sh migrate ${DESTINATION} -apply"
+        }
       }
     }
 

--- a/openshift/player.sh
+++ b/openshift/player.sh
@@ -18,6 +18,9 @@ case "${1:-}" in
     restore)
         echo "Not implemented yet"
         ;;
+    migrate)
+        ./oc-migrate.sh ${ARGV}
+        ;;
     build)
         ./oc-build.sh ${ARGV}
         ;;

--- a/openshift/scripts/oc-migrate.sh
+++ b/openshift/scripts/oc-migrate.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+source "$(dirname ${0})/common.sh"
+
+#%
+#% OpenShift Database Helper
+#%
+#%   Synchronizes the database state with the current set of models and migrations.
+#%   Targets incl.: 'dev', 'test' and 'prod'
+#%
+#% Usage:
+#%
+#%   [MIGRATION_IMAGE=<>] [MIGRATION_TAG=<>] [DB_CONNECTION_STRING=<>] [DB_PASSWORD=<>] ${THIS_FILE} [TARGET] [-apply]
+#%
+#% Examples:
+#%
+#%   Provide a target environment ('dev' OR 'test' OR 'prod'). Defaults to a dry-run.
+#%   ${THIS_FILE} dev
+#%
+#%   Apply when satisfied.
+#%   ${THIS_FILE} dev -apply
+#%
+#%   Set variables to non-defaults at runtime.  E.g. to migrate the PROD database:
+#%   MIGRATION_TAG=master DB_PASSWORD=<> DB_CONNECTION_STRING=<> ${THIS_FILE} prod -apply
+
+# Target project override for Dev, Test or Prod deployments
+#
+PROJ_TARGET="${PROJ_TARGET:-${PROJ_PREFIX}-${TARGET}}"
+
+# Parameters and mode variables
+#
+[ "${DB_PASSWORD:-}" ] || {
+  fatal_error "DB_PASSWORD environment value must be set"
+}
+[ "${DB_CONNECTION_STRING:-}" ] || {
+  fatal_error "DB_CONNECTION_STRING environment value must be set"
+}
+ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Production}
+MIGRATION_IMAGE=${MIGRATION_IMAGE:-pims-migrations}
+MIGRATION_TAG=${MIGRATION_TAG:-dev}
+COMMAND=${COMMAND:-}
+
+FULL_IMAGE="docker-registry.default.svc:5000/${PROJ_TOOLS}/${MIGRATION_IMAGE}:${MIGRATION_TAG}"
+
+# Rebuild migrations image - e.g. 'pims-migrations-dev' OR 'pims-migrations-master'
+#
+BUILD_NAME="${BUILD_NAME:-${MIGRATION_IMAGE}-${MIGRATION_TAG}}"
+start_build "${BUILD_NAME}"
+
+# Run database migrations
+#
+OC_MIGRATE="oc run migration-job \
+  -n ${PROJ_TARGET} \
+  --image=${FULL_IMAGE} \
+  --image-pull-policy=Always \
+  --attach \
+  --rm \
+  --restart=Never \
+  --env='ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}' \
+  --env='ConnectionStrings__PIMS=${DB_CONNECTION_STRING}' \
+  --env='DB_PASSWORD=${DB_PASSWORD}' \
+  --limits='cpu=1000m,memory=1Gi' \
+  --requests='cpu=500m,memory=512Mi'"
+[ "${COMMAND}" ] && OC_MIGRATE="${OC_MIGRATE} --command -- ${COMMAND}"
+
+# Execute commands
+#
+if [ "${APPLY}" ]; then
+  echo -e "\n[+] Migration Job started\n"
+  eval "${OC_MIGRATE}"
+fi
+
+# Provide oc command instruction
+#
+display_helper "${OC_MIGRATE}"


### PR DESCRIPTION
New bash script created `oc-migrate.sh` that will run a pod that has `dotnet ef` installed - in a similar fashion as you would do `docker run ...`

The `oc` command returns the exit code from the migration process:
- If successful the CI pipeline continues building. 
- If the migration cannot be applied, an error code is returned and the CI pipeline aborts

Once this is merged we will need to test success and failure scenarios to get ready to launch in production.