### PR TITLE
Do not validate assessed values that are filtered out of the display.

### DIFF
--- a/frontend/src/features/properties/components/forms/subforms/EvaluationForm.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/EvaluationForm.tsx
@@ -112,7 +112,12 @@ export const validateFinancials = (
       financial.fiscalYear === getCurrentFiscalYear() &&
       !financial.value &&
       financial.key !== EvaluationKeys.Appraised &&
-      financial.key !== FiscalKeys.Estimated
+      financial.key !== FiscalKeys.Estimated &&
+      !(
+        financial.key === EvaluationKeys.Assessed &&
+        financial?.year &&
+        financial.year > moment().year()
+      )
     ) {
       errors = setIn(errors, `${nameSpace}.${index}.value`, 'Required');
     }


### PR DESCRIPTION
A recent update to the EvaluationForm broke validation for all parcels with future evaluation dates, because those future assessed values were being filtered from display, but still being validated. This ensures those values aren't displayed and aren't validated.