### PR TITLE
Fix maintenance page in production environment

### DIFF
--- a/maintenance/maintenance.sh
+++ b/maintenance/maintenance.sh
@@ -31,6 +31,9 @@ OC_BUILD=${OC_BUILD:-../openshift/templates/maintenance/caddy.bc.yaml}
 OC_DEPLOY=${OC_DEPLOY:-../openshift/templates/maintenance/caddy.dc.yaml}
 BUILD_PROJECT=${BUILD_PROJECT:-jcxjin-tools}
 
+# support PROD route overrides
+APPLICATION_ROUTE=${APPLICATION_ROUTE:-${APPLICATION_NAME}-${ENVIRONMENT_NAME}${INSTANCE_ID}}
+APPLICATION_SERVICE=${APPLICATION_SERVICE:-${APPLICATION_NAME}-${ENVIRONMENT_NAME}${INSTANCE_ID}}
 
 # Verbose option
 #
@@ -71,16 +74,16 @@ fi
 #
 if [ "${COMMAND}" == "on" ]
 then
-  oc patch route "${APPLICATION_NAME}-${ENVIRONMENT_NAME}${INSTANCE_ID}" -n ${PROJECT} -p \
+  oc patch route "${APPLICATION_ROUTE}" -n ${PROJECT} -p \
     '{ "spec": { "to": { "name": "'$( echo ${STATIC_PAGE_NAME} )'" },
     "port": { "targetPort": "'$( echo ${STATIC_PAGE_PORT} )'" }}}'
   oc patch route ${STATIC_PAGE_NAME} -n ${PROJECT} -p \
-    '{ "spec": { "to": { "name": "'$( echo "${APPLICATION_NAME}-${ENVIRONMENT_NAME}${INSTANCE_ID}" )'" },
+    '{ "spec": { "to": { "name": "'$( echo "${APPLICATION_SERVICE}" )'" },
     "port": { "targetPort": "'$( echo ${APPLICATION_PORT} )'" }}}'
 elif [ "${COMMAND}" == "off" ]
 then
-  oc patch route "${APPLICATION_NAME}-${ENVIRONMENT_NAME}${INSTANCE_ID}" -n ${PROJECT} -p \
-    '{ "spec": { "to": { "name": "'$( echo "${APPLICATION_NAME}-${ENVIRONMENT_NAME}${INSTANCE_ID}" )'" },
+  oc patch route "${APPLICATION_ROUTE}" -n ${PROJECT} -p \
+    '{ "spec": { "to": { "name": "'$( echo "${APPLICATION_SERVICE}" )'" },
     "port": { "targetPort": "'$( echo ${APPLICATION_PORT} )'" }}}'
   oc patch route ${STATIC_PAGE_NAME} -n ${PROJECT} -p \
     '{ "spec": { "to": { "name": "'$( echo ${STATIC_PAGE_NAME} )'" },

--- a/openshift/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/pipelines/Jenkinsfile.test-to-prod
@@ -110,6 +110,9 @@ pipeline {
     }
 
     stage("Maintenance mode ON") {
+      environment {
+        APPLICATION_ROUTE = "pims-gov-bc-ca" // PROD route to direct to maintenance page
+      }
       steps {
         script {
           commonPipeline.maintenancePageOn("${DESTINATION}")
@@ -150,6 +153,9 @@ pipeline {
     }
 
     stage("Maintenance mode OFF") {
+      environment {
+        APPLICATION_ROUTE = "pims-gov-bc-ca" // PROD route to direct to maintenance page
+      }
       steps {
         script {
           commonPipeline.maintenancePageOff("${DESTINATION}")


### PR DESCRIPTION
Just ran the PROD pipeline and noticed the maintenance page is shown under `https://pims-prod.pathfinder...` instead of the main DNS name. This is due to how routes where named and how the maintenance script expects routes to be named in a certain way.

This PR have modifies `maintenance.sh` to accommodate overriding the name of the route to redirect to the Maintenance Page pod.

**NOTE:** 
This code change will need to make its way to `dev` and then to `master` before it can be fully tested