### PR TITLE
Improving performance of Property List View

### DIFF
--- a/backend/dal/Services/Concrete/PropertyService.cs
+++ b/backend/dal/Services/Concrete/PropertyService.cs
@@ -106,12 +106,15 @@ namespace Pims.Dal.Services
                 filter.PropertyType = Entities.PropertyTypes.Building;
             }
 
+            var skip = (filter.Page - 1) * filter.Quantity;
             var query = this.Context.GenerateQuery(this.User, filter);
-            var total = query.Count();
             var items = query
-                .Skip((filter.Page - 1) * filter.Quantity)
+                .Skip(skip)
                 .Take(filter.Quantity)
                 .ToArray();
+
+            var count = items.Count();
+            var total = count < filter.Quantity ? skip + count : filter.Page * filter.Quantity + 1; // TODO: temporary way to improve performance as the DB is having memory issues scanning the whole table.
 
             return new Paged<Property>(items, filter.Page, filter.Quantity, total);
         }

--- a/backend/tests/unit/dal/Services/PropertyServiceTest.cs
+++ b/backend/tests/unit/dal/Services/PropertyServiceTest.cs
@@ -42,7 +42,7 @@ namespace Pims.Dal.Test.Services
                 new object[] { new AllPropertyFilter() { PropertyType = Entity.PropertyTypes.Building, Agencies = new int[] { 3 } }, new[] { 1, 3 }, 6, 6 },
                 new object[] { new AllPropertyFilter() { PropertyType = Entity.PropertyTypes.Building, ClassificationId = 2 }, new[] { 1, 3 }, 1, 1 },
                 new object[] { new AllPropertyFilter() { PropertyType = Entity.PropertyTypes.Building, Description = "DescriptionTest" }, new[] { 1, 3 }, 1, 1 },
-                new object[] { new AllPropertyFilter() { PropertyType = Entity.PropertyTypes.Building, Municipality = "Municipality" }, new[] { 1, 3 }, 10, 10 },
+                new object[] { new AllPropertyFilter() { PropertyType = Entity.PropertyTypes.Building, Municipality = "Municipality" }, new[] { 1, 3 }, 11, 10 },
                 new object[] { new AllPropertyFilter() { Tenancy = "BuildingTenancy" }, new[] { 1, 3 }, 1, 1 },
                 new object[] { new AllPropertyFilter() { ConstructionTypeId = 2 }, new[] { 1, 3 }, 1, 1 },
                 new object[] { new AllPropertyFilter() { PredominateUseId = 2 }, new[] { 1, 3 }, 1, 1 },
@@ -67,10 +67,10 @@ namespace Pims.Dal.Test.Services
                 new object[] { new AllPropertyFilter() { PredominateUseId = 2 }, new[] { 1, 3 }, 1, 1 },
                 new object[] { new AllPropertyFilter() { MinRentableArea = 100 }, new[] { 1, 3 }, 1, 1 },
                 new object[] { new AllPropertyFilter() { MinRentableArea = 50, MaxRentableArea = 50 }, new[] { 1, 3 }, 1, 1 },
-                new object[] { new AllPropertyFilter() { PropertyType = Entity.PropertyTypes.Building, ClassificationId = 3 }, new[] { 1, 3 }, 10, 10 },
+                new object[] { new AllPropertyFilter() { PropertyType = Entity.PropertyTypes.Building, ClassificationId = 3 }, new[] { 1, 3 }, 11, 10 },
                 new object[] { new AllPropertyFilter() { PropertyType = Entity.PropertyTypes.Land, ClassificationId = 3 }, new[] { 1, 3 }, 1, 1 },
-                new object[] { new AllPropertyFilter() { Quantity = 5, MinLandArea = 5000, MaxLandArea = 10000 }, new[] { 1, 3 }, 11, 5 },
-                new object[] { new AllPropertyFilter() { Quantity = 2, ClassificationId = 3 }, new[] { 1, 3 }, 11, 2 },
+                new object[] { new AllPropertyFilter() { Quantity = 5, MinLandArea = 5000, MaxLandArea = 10000 }, new[] { 1, 3 }, 6, 5 },
+                new object[] { new AllPropertyFilter() { Quantity = 2, ClassificationId = 3 }, new[] { 1, 3 }, 3, 2 },
                 new object[] { new AllPropertyFilter(), new[] { 3 }, 7, 7 },
             };
         #endregion


### PR DESCRIPTION
## Description

Performance memory issues are occurring on the **Property List View** which is resulting in failed requests.

Removing valid `Count` so that it is one less massive scan against the whole table.

This results in not knowing how many pages of results there are, but should be a lot better than a failed request.