### PR TITLE
fix tooltips in firefox.

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -39,3 +39,7 @@ div.bootstrap-table {
   color: #fff;
   background-color: $danger-color;
 }
+
+.tooltip {
+  pointer-events: none;
+}


### PR DESCRIPTION
The issue with the help tooltip is an issue throughout the application. All of the question icon tooltips I tested had this flickering behaviour.