### PR TITLE
pa-745 & pa-635 - Adding v01.01.00 migration

### DIFF
--- a/backend/dal/Configuration/ProjectConfiguration.cs
+++ b/backend/dal/Configuration/ProjectConfiguration.cs
@@ -45,6 +45,9 @@ namespace Pims.Dal.Configuration
             builder.Property(m => m.NetBook).HasColumnType("MONEY");
             builder.Property(m => m.Estimated).HasColumnType("MONEY");
             builder.Property(m => m.Assessed).HasColumnType("MONEY");
+            builder.Property(m => m.Appraised).HasColumnType("MONEY");
+
+            builder.Property(m => m.AppraisedNote).HasColumnType("NVARCHAR(MAX)");
 
             builder.HasOne(m => m.Status).WithMany().HasForeignKey(m => m.StatusId).OnDelete(DeleteBehavior.Cascade);
             builder.HasOne(m => m.Agency).WithMany().HasForeignKey(m => m.AgencyId).OnDelete(DeleteBehavior.ClientCascade);

--- a/backend/dal/Migrations/20201016195846_correctAgencies.cs
+++ b/backend/dal/Migrations/20201016195846_correctAgencies.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using Pims.Dal.Helpers.Migrations;
-
-namespace Pims.Dal.Migrations
-{
-    public partial class correctAgencies : SeedMigration
-    {
-    }
-}

--- a/backend/dal/Migrations/20201023193301_v01.01.01.Designer.cs
+++ b/backend/dal/Migrations/20201023193301_v01.01.01.Designer.cs
@@ -10,8 +10,8 @@ using Pims.Dal;
 namespace Pims.Dal.Migrations
 {
     [DbContext(typeof(PimsContext))]
-    [Migration("20201016195846_correctAgencies")]
-    partial class correctAgencies
+    [Migration("20201023193301_v01.01.01")]
+    partial class v010101
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1242,6 +1242,12 @@ namespace Pims.Dal.Migrations
                     b.Property<int?>("AgencyId1")
                         .HasColumnType("int");
 
+                    b.Property<decimal>("Appraised")
+                        .HasColumnType("MONEY");
+
+                    b.Property<string>("AppraisedNote")
+                        .HasColumnType("NVARCHAR(MAX)");
+
                     b.Property<DateTime?>("ApprovedOn")
                         .HasColumnType("DATETIME2");
 
@@ -1569,6 +1575,60 @@ namespace Pims.Dal.Migrations
                     b.ToTable("ProjectProperties");
                 });
 
+            modelBuilder.Entity("Pims.Dal.Entities.ProjectReport", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime>("CreatedOn")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("DATETIME2")
+                        .HasDefaultValueSql("GETUTCDATE()");
+
+                    b.Property<DateTime?>("From")
+                        .HasColumnType("DATETIME2");
+
+                    b.Property<bool>("IsFinal")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(250)")
+                        .HasMaxLength(250);
+
+                    b.Property<int>("ReportTypeId")
+                        .HasColumnType("int");
+
+                    b.Property<byte[]>("RowVersion")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("rowversion");
+
+                    b.Property<DateTime?>("To")
+                        .IsRequired()
+                        .HasColumnType("DATETIME2");
+
+                    b.Property<Guid?>("UpdatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("UpdatedOn")
+                        .HasColumnType("DATETIME2");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CreatedById");
+
+                    b.HasIndex("UpdatedById");
+
+                    b.HasIndex("Id", "To", "From", "IsFinal");
+
+                    b.ToTable("ProjectReports");
+                });
+
             modelBuilder.Entity("Pims.Dal.Entities.ProjectRisk", b =>
                 {
                     b.Property<int>("Id")
@@ -1640,7 +1700,13 @@ namespace Pims.Dal.Migrations
                         .HasColumnType("int")
                         .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
+                    b.Property<decimal>("Appraised")
+                        .HasColumnType("MONEY");
+
                     b.Property<decimal>("Assessed")
+                        .HasColumnType("MONEY");
+
+                    b.Property<decimal?>("BaselineIntegrity")
                         .HasColumnType("MONEY");
 
                     b.Property<Guid?>("CreatedById")
@@ -1686,6 +1752,9 @@ namespace Pims.Dal.Migrations
                     b.Property<decimal?>("SalesCost")
                         .HasColumnType("MONEY");
 
+                    b.Property<DateTime>("SnapshotOn")
+                        .HasColumnType("DATETIME2");
+
                     b.Property<Guid?>("UpdatedById")
                         .HasColumnType("uniqueidentifier");
 
@@ -1698,7 +1767,7 @@ namespace Pims.Dal.Migrations
 
                     b.HasIndex("UpdatedById");
 
-                    b.HasIndex("ProjectId", "CreatedOn");
+                    b.HasIndex("ProjectId", "SnapshotOn");
 
                     b.ToTable("ProjectSnapshots");
                 });
@@ -3049,6 +3118,17 @@ namespace Pims.Dal.Migrations
                         .HasForeignKey("ProjectId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.HasOne("Pims.Dal.Entities.User", "UpdatedBy")
+                        .WithMany()
+                        .HasForeignKey("UpdatedById");
+                });
+
+            modelBuilder.Entity("Pims.Dal.Entities.ProjectReport", b =>
+                {
+                    b.HasOne("Pims.Dal.Entities.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedById");
 
                     b.HasOne("Pims.Dal.Entities.User", "UpdatedBy")
                         .WithMany()

--- a/backend/dal/Migrations/20201023193301_v01.01.01.cs
+++ b/backend/dal/Migrations/20201023193301_v01.01.01.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Pims.Dal.Helpers.Migrations;
+
+namespace Pims.Dal.Migrations
+{
+    public partial class v010101 : SeedMigration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            PreUp(migrationBuilder);
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Appraised",
+                table: "Projects",
+                type: "MONEY",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AppraisedNote",
+                table: "Projects",
+                type: "NVARCHAR(MAX)",
+                nullable: true);
+            PostUp(migrationBuilder);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            PreDown(migrationBuilder);
+            migrationBuilder.DropColumn(
+                name: "AppraisedNote",
+                table: "Projects");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Appraised",
+                table: "Projects",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "MONEY");
+            PostDown(migrationBuilder);
+        }
+    }
+}

--- a/backend/dal/Migrations/PimsContextModelSnapshot.cs
+++ b/backend/dal/Migrations/PimsContextModelSnapshot.cs
@@ -1241,7 +1241,10 @@ namespace Pims.Dal.Migrations
                         .HasColumnType("int");
 
                     b.Property<decimal>("Appraised")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("MONEY");
+
+                    b.Property<string>("AppraisedNote")
+                        .HasColumnType("NVARCHAR(MAX)");
 
                     b.Property<DateTime?>("ApprovedOn")
                         .HasColumnType("DATETIME2");

--- a/backend/entities/Project.cs
+++ b/backend/entities/Project.cs
@@ -263,7 +263,7 @@ namespace Pims.Dal.Entities
         [NotMapped]
         [DataMemberAttribute]
         public DateTime? PriorYearAdjustmentOn { get; set; } // TODO: Move to metadata property.
-        
+
         /// <summary>
         /// get/set - When the project was completed.
         /// </summary>
@@ -289,7 +289,7 @@ namespace Pims.Dal.Entities
 
         #region Financials
         /// <summary>
-        /// get/set - The netbook value which is the sum of the properties.
+        /// get/set - The netbook value.
         /// </summary>
         public decimal NetBook { get; set; }
 
@@ -302,19 +302,24 @@ namespace Pims.Dal.Entities
 
 
         /// <summary>
-        /// get/set - The estimated value which is the sum of the properties.
+        /// get/set - The estimated value.
         /// </summary>
         public decimal Estimated { get; set; }
 
         /// <summary>
-        /// get/set - The assessed value which is the sum of the properties.
+        /// get/set - The assessed value.
         /// </summary>
         public decimal Assessed { get; set; }
 
         /// <summary>
-        /// get/set - The appraised value which is the sum of the properties.
+        /// get/set - The appraised value.
         /// </summary>
         public decimal Appraised { get; set; }
+
+        /// <summary>
+        /// get/set - Information about the appraised value.
+        /// </summary>
+        public string AppraisedNote { get; set; }
 
         /// <summary>
         /// get/set - The sales cost.

--- a/backend/entities/ProjectSnapshot.cs
+++ b/backend/entities/ProjectSnapshot.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Pims.Dal.Entities
 {
@@ -31,22 +30,22 @@ namespace Pims.Dal.Entities
 
         #region Financials
         /// <summary>
-        /// get/set - The netbook value which is the sum of the properties.
+        /// get/set - The netbook value.
         /// </summary>
         public decimal NetBook { get; set; }
 
         /// <summary>
-        /// get/set - The estimated value which is the sum of the properties.
+        /// get/set - The estimated value.
         /// </summary>
         public decimal Estimated { get; set; }
 
         /// <summary>
-        /// get/set - The assessed value which is the sum of the properties.
+        /// get/set - The assessed value.
         /// </summary>
         public decimal Assessed { get; set; }
 
         /// <summary>
-        /// get/set - The appraised value which is the sum of the properties.
+        /// get/set - The appraised value.
         /// </summary>
         public decimal Appraised { get; set; }
 

--- a/scripts/db-migration.sh
+++ b/scripts/db-migration.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+MNAME=$1;
+cd backend/dal;
+
+FILE1=./Migrations/$(basename ./Migrations/*_$MNAME.cs);
+echo "Updating migration '$FILE1'";
+
+sed -i "2iusing Pims.Dal.Helpers.Migrations;" $FILE1;
+
+search=":\ Migration";
+replace=":\ SeedMigration";
+sed -i "s/$search/$replace/" $FILE1;
+
+fl1=$(grep -n "protected override void Up(MigrationBuilder migrationBuilder)" $FILE1 | head -n 1 | cut -d: -f1);
+l1=$(($fl1 + 2));
+sed -i "${l1}i\ \ \ \ \ \ \ \ \ \ \ \ PreUp(migrationBuilder);" $FILE1;
+
+fl=$(grep -n "protected override void Down(MigrationBuilder migrationBuilder)" $FILE1 | head -n 1 | cut -d: -f1);
+l2=$(($fl - 2));
+sed -i "${l2}i\ \ \ \ \ \ \ \ \ \ \ \ PostUp(migrationBuilder);" $FILE1;
+
+l3=$(($fl + 3));
+sed -i "${l3}i\ \ \ \ \ \ \ \ \ \ \ \ PreDown(migrationBuilder);" $FILE1;
+
+eofl=$(wc -l $FILE1 | awk '{ print $1 }');
+l4=$(($eofl - 2));
+sed -i "${l4}i\ \ \ \ \ \ \ \ \ \ \ \ PostDown(migrationBuilder);" $FILE1;
+
+code -r $FILE1
+


### PR DESCRIPTION
## Description

Creating new database migration **v01.01.00** which contains updates to the **Project** and **ProjectSnapshot** tables.

Updating makefile with a few more shortcuts to get things done quicker;
- `make db-add n={migration name}` = create a new migration and auto complete the code changes for scripts
- `make db-drop` = drop the whole database
- `make npm-refresh` = If npm packages change, get the frontend rebuilt and working again
- `make db-remove` = remote the prior migration and files from code and the db
- `make db-migrations` = list all the migrations
- `make db-rollback n={migration name}` = rollback the specified db migration
` `make build n={service name}` = build the specific service
- `make up n={service name}` = spin up the specific service
- `make stop n={service name}` = stop the specific service