### PR TITLE
PA-1035 Integrating with Openshift authentication

### DIFF
--- a/openshift/templates/monitoring/grafana-template.yml
+++ b/openshift/templates/monitoring/grafana-template.yml
@@ -1,5 +1,5 @@
-apiVersion: v1
 kind: Template
+apiVersion: v1
 metadata:
   name: pims-grafana-deploy
   annotations:
@@ -7,6 +7,44 @@ metadata:
     description: Deployment template for Grafana
     tags: pims-monitoring
 objects:
+  - kind: Secret
+    apiVersion: v1
+    metadata:
+      name: pims-grafana-password-secret
+      namespace: ${PROJECT_NAME}
+      annotations:
+        description: "Grafana secrets"
+      labels:
+        name: pims-grafana-password-secret
+        app: pims-grafana-tools
+        component: tools
+        role: grafana
+    type: Opaque
+    stringData:
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: ${GRAFANA_SERVICE_ACCOUNT_NAME}
+      labels:
+        name: ${GRAFANA_SERVICE_ACCOUNT_NAME}
+      annotations:
+        serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana"}}'
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      labels:
+        name: grafana
+      name: grafana
+      namespace: ${PROJECT_NAME}
+    spec:
+      host: ${DOMAIN}
+      to:
+        name: grafana
+        kind: Service
+        weight: 100
+      tls:
+        termination: Reencrypt
   - kind: ConfigMap
     apiVersion: v1
     metadata:
@@ -28,97 +66,26 @@ objects:
         - name: Prometheus
           type: prometheus
           access: proxy
-          url: ${PROMETHEUS_DOMAIN}
-
-  - kind: ConfigMap
-    apiVersion: v1
-    metadata:
-      name: pims-monitoring-tools-grafana-ini-config
-      namespace: ${PROJECT_NAME}
-      annotations:
-        description: Grafana ini configuration
-      labels:
-        name: pims-monitoring-tools-grafana-ini-config
-        app: pims
-        component: monitoring
-        env: tools
-        role: prometheus
-    type: Opaque
-    data:
-      grafana.ini: |-
-        [server]
-        root_url = https://${DOMAIN}/
-        domain = ${DOMAIN}
-        enforce_domain = true
-        [auth.github]
-        enabled = true
-        allow_sign_up = true
-        client_id = ${GITHUB_CLIENT_ID}
-        client_secret = ${GITHUB_CLIENT_SECRET}
-        scopes = user:email,read:org
-        allowed_organizations = ${GITHUB_ALLOWED_ORG}
-        auth_url = https://github.com/login/oauth/authorize
-        token_url = https://github.com/login/oauth/access_token
-        api_url = https://api.github.com/user
-
-  - kind: ServiceAccount
-    apiVersion: v1
-    metadata:
-      name: ${GRAFANA_SERVICE_ACCOUNT_NAME}
-      labels:
-        name: ${GRAFANA_SERVICE_ACCOUNT_NAME}
-      namespace: ${PROJECT_NAME}
-  - kind: Route
-    apiVersion: v1
-    metadata:
-      labels:
-        name: grafana
-      name: grafana
-      namespace: ${PROJECT_NAME}
-    spec:
-      host: ${DOMAIN}
-      to:
-        name: grafana
-        kind: Service
-        weight: 100
-      tls:
-        termination: edge
-
-  - kind: Service
-    apiVersion: v1
+          url: ${PROMETHEUS_DATASOURCE_URL}
+  - apiVersion: v1
+    kind: Service
     metadata:
       name: grafana
       namespace: ${PROJECT_NAME}
       labels:
         metrics-infra: grafana
         name: grafana
+      annotations:
+        service.alpha.openshift.io/serving-cert-secret-name: grafana-tls
     spec:
       ports:
         - name: grafana
-          port: 80
-          protocol: TCP
-          targetPort: 3000
+          port: 443
+          targetPort: 8443
       selector:
         app: pims-grafana-tools
-
-  - kind: Secret
-    apiVersion: v1
-    metadata:
-      name: pims-grafana-password-secret
-      namespace: ${PROJECT_NAME}
-      annotations:
-        description: "Grafana secrets"
-      labels:
-        name: pims-grafana-password-secret
-        app: pims-grafana-tools
-        component: tools
-        role: grafana
-    type: Opaque
-    stringData:
-      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
-
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - apiVersion: v1
+    kind: DeploymentConfig
     metadata:
       name: pims-grafana-tools
       namespace: ${PROJECT_NAME}
@@ -144,7 +111,7 @@ objects:
           maxUnavailable: 25%
           timeoutSeconds: 600
           updatePeriodSeconds: 1
-        type: Rolling
+        type: Recreate
       template:
         metadata:
           name: pims-grafana-tools
@@ -154,22 +121,50 @@ objects:
             component: grafana
             env: tools
             role: grafana
+            deploymentConfig: grafana
         spec:
           serviceAccountName: ${GRAFANA_SERVICE_ACCOUNT_NAME}
-          volumes:
-            - name: "pims-monitoring-grafana-datasource-config-volume"
-              configMap:
-                name: pims-monitoring-tools-grafana-datasource-config
-            - name: "pims-monitoring-grafana-ini-config-volume"
-              configMap:
-                name: pims-monitoring-tools-grafana-ini-config
           containers:
-            - name: pims-grafana-tools
-              image: grafana/grafana
+            - name: oauth-proxy
+              image: openshift/oauth-proxy:v1.0.0
+              imagePullPolicy: IfNotPresent
+              ports:
+                - containerPort: 8443
+                  name: public
+              args:
+                - --https-address=:8443
+                - --provider=openshift
+                - --openshift-service-account=${GRAFANA_SERVICE_ACCOUNT_NAME}
+                - --upstream=http://localhost:3000
+                - --tls-cert=/etc/tls/private/tls.crt
+                - --tls-key=/etc/tls/private/tls.key
+                - --cookie-secret=SECRET
+                - --pass-basic-auth=false
+              volumeMounts:
+                - mountPath: /etc/tls/private
+                  name: grafana-tls
+            - image: grafana/grafana
               imagePullPolicy: Always
+              name: grafana
               env:
-                - name: GF_SERVER_ROOT_URL
-                  value: https://${DOMAIN}
+                - name: GF_AUTH_BASIC_ENABLED
+                  value: "true"
+                - name: GF_AUTH_PROXY_ENABLED
+                  value: "true"
+                - name: GF_AUTH_PROXY_HEADER_NAME
+                  value: "X-Forwarded-User"
+                - name: GF_AUTH_PROXY_HEADER_PROPERTY
+                  value: "username"
+                - name: GF_AUTH_PROXY_AUTO_SIGN_UP
+                  value: "true"
+                - name: GF_AUTH_DISABLE_LOGIN_FORM
+                  value: "false"
+                - name: GF_USERS_ALLOW_SIGN_UP
+                  value: "false"
+                - name: GF_USERS_AUTO_ASSIGN_ORG
+                  value: "true"
+                - name: GF_USERS_AUTO_ASSIGN_ORG_ROLE
+                  value: "${GF_USERS_AUTO_ASSIGN_ORG_ROLE}"
                 - name: GF_SECURITY_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:
@@ -177,41 +172,38 @@ objects:
                       key: GF_SECURITY_ADMIN_PASSWORD
               ports:
                 - containerPort: 3000
+                  name: http
                   protocol: TCP
-              resources:
-                requests:
-                  cpu: 100m
-                  memory: 2Gi
-                limits:
-                  cpu: 1
-                  memory: 4Gi
               volumeMounts:
                 - mountPath: /etc/grafana/provisioning/datasources
                   name: pims-monitoring-grafana-datasource-config-volume
-                - mountPath: /etc/grafana
-                  name: pims-monitoring-grafana-ini-config-volume
+              resources: {}
+              securityContext: {}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          volumes:
+            - name: "pims-monitoring-grafana-datasource-config-volume"
+              configMap:
+                name: pims-monitoring-tools-grafana-datasource-config
+            - name: grafana-tls
+              secret:
+                secretName: grafana-tls
           dnsPolicy: ClusterFirst
           restartPolicy: Always
+          schedulerName: default-scheduler
           securityContext: {}
-          terminationGracePeriodSeconds: 30
+          terminationGracePeriodSeconds: 60
       test: false
 parameters:
   - name: GF_SECURITY_ADMIN_PASSWORD
     displayName: Grafana Dashboard Admin Password
     description: Grafana Dashboard Admin Password
     required: true
-  - name: GITHUB_ALLOWED_ORG
-    displayName: Github Allowed Organization
-    description: Github Allowed Organization
+  - name: GF_USERS_AUTO_ASSIGN_ORG_ROLE
+    displayName: Grafana Default User Role
+    description: Grafana Default User Role
     required: true
-  - name: GITHUB_CLIENT_ID
-    displayName: Github Client ID
-    description: Github Client ID
-    required: true
-  - name: GITHUB_CLIENT_SECRET
-    displayName: Github Client Secret
-    description: Github Client Secret
-    required: true
+    value: "Admin"
   - name: GRAFANA_SERVICE_ACCOUNT_NAME
     displayName: Grafana Service Account Name
     description: Grafana Service Account Name
@@ -222,11 +214,11 @@ parameters:
     description: Project Name
     required: true
     value: "jcxjin-tools"
-  - name: PROMETHEUS_DOMAIN
+  - name: PROMETHEUS_DATASOURCE_URL
     displayName: Project Name
     description: Project Name
     required: true
-    value: "pims-prometheus.pathfinder.gov.bc.ca"
+    value: "https://pims-prometheus.pathfinder.gov.bc.ca"
   - name: DOMAIN
     displayName: Project Name
     description: Project Name


### PR DESCRIPTION
I asked for help on how to integrate Github OAuth credentials, and @stephenhillier says they do not give away the client secret to the `bcdevops` org, so Github OAuth with Grafana is not possible for our case, but using an OAuth Proxy is the best option at the moment
