### PR TITLE
PA-635 frontend spl reports feature, as well as permission changes to…

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -35,6 +35,11 @@ div.bootstrap-table {
   background-color: $dark-variant-color;
 }
 
+.Toastify__toast.Toastify__toast--warning {
+  color: black;
+  background-color: $accent-color;
+}
+
 .Toastify__toast.Toastify__toast--error {
   color: #fff;
   background-color: $danger-color;

--- a/frontend/src/components/common/GenericModal.tsx
+++ b/frontend/src/components/common/GenericModal.tsx
@@ -10,8 +10,44 @@ interface ModalProps {
   handleOk?: Function;
   /** Optional text to display on the cancel button. Default is Cancel. */
   cancelButtonText?: string;
+  /** Optional variant that will override the default variant of warning. */
+  cancelButtonVariant?:
+    | 'link'
+    | 'warning'
+    | 'primary'
+    | 'secondary'
+    | 'success'
+    | 'danger'
+    | 'info'
+    | 'dark'
+    | 'light'
+    | 'outline-primary'
+    | 'outline-secondary'
+    | 'outline-success'
+    | 'outline-danger'
+    | 'outline-info'
+    | 'outline-dark'
+    | 'outline-light';
   /** Optional test to display on the ok button. Default is Ok. */
   okButtonText?: string;
+  /** Optional variant that will override the default variant of primary. */
+  okButtonVariant?:
+    | 'link'
+    | 'warning'
+    | 'primary'
+    | 'secondary'
+    | 'success'
+    | 'danger'
+    | 'info'
+    | 'dark'
+    | 'light'
+    | 'outline-primary'
+    | 'outline-secondary'
+    | 'outline-success'
+    | 'outline-danger'
+    | 'outline-info'
+    | 'outline-dark'
+    | 'outline-light';
   /** Optional title to display - no default. */
   title?: string;
   /** Optional message to display - no default. */
@@ -64,11 +100,15 @@ const GenericModal = (props: ModalProps) => {
         <Modal.Body style={{ maxHeight: '500px' }}>{props.message}</Modal.Body>
 
         <Modal.Footer>
-          <Button variant="primary" onClick={ok}>
+          <Button variant={props.okButtonVariant ?? 'primary'} onClick={ok}>
             {props.okButtonText ?? 'Ok'}
           </Button>
           {props.cancelButtonText && (
-            <Button variant="warning" onClick={close} style={{ width: 'unset' }}>
+            <Button
+              variant={props.cancelButtonVariant ?? 'warning'}
+              onClick={close}
+              style={{ width: 'unset' }}
+            >
               {props.cancelButtonText}
             </Button>
           )}

--- a/frontend/src/components/common/TooltipWrapper.tsx
+++ b/frontend/src/components/common/TooltipWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Overlay, Tooltip, OverlayTrigger } from 'react-bootstrap';
+import { Tooltip, OverlayTrigger, OverlayTriggerProps } from 'react-bootstrap';
 
-interface ITooltipWrapperProps extends Partial<React.ComponentPropsWithRef<typeof Overlay>> {
+interface ITooltipWrapperProps extends Partial<OverlayTriggerProps> {
   toolTip?: string;
   toolTipId: string;
 }
@@ -13,10 +13,7 @@ interface ITooltipWrapperProps extends Partial<React.ComponentPropsWithRef<typeo
 const TooltipWrapper: React.FunctionComponent<ITooltipWrapperProps> = props => {
   return (
     <>
-      <OverlayTrigger
-        placement={props.placement}
-        overlay={<Tooltip id={props.toolTipId}>{props.toolTip}</Tooltip>}
-      >
+      <OverlayTrigger {...props} overlay={<Tooltip id={props.toolTipId}>{props.toolTip}</Tooltip>}>
         {props.children}
       </OverlayTrigger>
     </>

--- a/frontend/src/components/common/form/Button.scss
+++ b/frontend/src/components/common/form/Button.scss
@@ -8,7 +8,7 @@
     height: auto;
     &:hover {
       text-decoration: none;
-      opacity: 1;
+      opacity: 0.8;
     }
   }
 

--- a/frontend/src/components/common/form/FastDatePicker.tsx
+++ b/frontend/src/components/common/form/FastDatePicker.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, memo, useEffect, useState } from 'react';
 import { ErrorMessage, getIn, FormikProps } from 'formik';
 import DatePicker, { ReactDatePickerProps } from 'react-datepicker';
 import moment from 'moment';
-import { FormGroup, FormControlProps } from 'react-bootstrap';
+import { FormGroup, FormControlProps, Form } from 'react-bootstrap';
 import { formikFieldMemo } from 'utils';
 import classNames from 'classnames';
 import GenericModal from '../GenericModal';
@@ -24,6 +24,8 @@ type OptionalAttributes = {
   minDate?: Date;
   /** warn the user if they select a date that is older then the current date */
   oldDateWarning?: boolean;
+  /** form label */
+  label?: string;
 };
 
 export type FastDatePickerProps = FormControlProps &
@@ -41,6 +43,7 @@ const FormikDatePicker: FunctionComponent<FastDatePickerProps> = ({
   outerClassName,
   minDate,
   oldDateWarning,
+  label,
   formikProps: {
     values,
     initialValues,
@@ -77,7 +80,8 @@ const FormikDatePicker: FunctionComponent<FastDatePickerProps> = ({
   const isValid = !error && touch && value && !disabled ? 'is-valid ' : '';
   return (
     <FormGroup className={outerClassName ?? ''}>
-      <span className={isInvalid}></span>
+      {!!label && <Form.Label>{label}</Form.Label>}
+
       <DatePicker
         showYearDropdown
         scrollableYearDropdown

--- a/frontend/src/constants/claims.ts
+++ b/frontend/src/constants/claims.ts
@@ -16,6 +16,8 @@ export enum Claims {
   PROJECT_EDIT = 'project-edit',
   PROJECT_ADD = 'project-add',
   PROJECT_DELETE = 'project-delete',
+  REPORTS_VIEW = 'reports-view',
+  REPORTS_SPL = 'reports-spl',
 }
 
 export default Claims;

--- a/frontend/src/customAxios.ts
+++ b/frontend/src/customAxios.ts
@@ -12,8 +12,8 @@ const defaultEnvelope = (x: any) => ({ data: { records: x } });
  * errorToast is displayed when the request fails for any reason. By default this will return an error from axios.
  */
 export interface LifecycleToasts {
-  loadingToast: () => React.ReactText;
-  successToast: () => React.ReactText;
+  loadingToast?: () => React.ReactText;
+  successToast?: () => React.ReactText;
   errorToast?: () => React.ReactText;
 }
 
@@ -42,7 +42,7 @@ const CustomAxios = ({
         throw new axios.Cancel(JSON.stringify(envelope(storedValue)));
       }
     }
-    if (lifecycleToasts) {
+    if (lifecycleToasts?.loadingToast) {
       loadingToastId = lifecycleToasts.loadingToast();
     }
     return config;
@@ -50,7 +50,7 @@ const CustomAxios = ({
 
   instance.interceptors.response.use(
     response => {
-      if (lifecycleToasts) {
+      if (lifecycleToasts?.successToast) {
         loadingToastId && toast.dismiss(loadingToastId);
         lifecycleToasts.successToast();
       }
@@ -60,7 +60,6 @@ const CustomAxios = ({
       if (axios.isCancel(error)) {
         return Promise.resolve(error.message);
       }
-
       if (lifecycleToasts?.errorToast) {
         loadingToastId && toast.dismiss(loadingToastId);
         lifecycleToasts.errorToast();

--- a/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`Manage Users Component Snapshot matches 1`] = `
     </div>
   </form>
   <div
-    className="sc-fzoiQi hZnSPn container-fluid"
+    className="sc-fznxKY ebtZXx container-fluid"
   >
     <div
       className="table"

--- a/frontend/src/features/projects/common/__snapshots__/ProjectSummaryView.test.tsx.snap
+++ b/frontend/src/features/projects/common/__snapshots__/ProjectSummaryView.test.tsx.snap
@@ -666,7 +666,7 @@ exports[`Review Summary View renders approved correctly 1`] = `
       }
     />
     <div
-      className="sc-fzokOt cycZXj"
+      className="sc-fzqBZW cSdQOS"
     >
       <button
         className="btn btn-warning"
@@ -1360,7 +1360,7 @@ exports[`Review Summary View renders denied correctly 1`] = `
       }
     />
     <div
-      className="sc-fzokOt cycZXj"
+      className="sc-fzqBZW cSdQOS"
     >
       <button
         className="btn btn-warning"
@@ -2054,7 +2054,7 @@ exports[`Review Summary View renders submitted correctly 1`] = `
       }
     />
     <div
-      className="sc-fzokOt cycZXj"
+      className="sc-fzqBZW cSdQOS"
     >
       <button
         className="btn btn-warning"

--- a/frontend/src/features/projects/common/interfaces.ts
+++ b/frontend/src/features/projects/common/interfaces.ts
@@ -129,6 +129,8 @@ export interface IProject {
   agencyResponseNote?: string;
   offersNote?: string;
   agencyId: number;
+  agency?: string;
+  subAgency?: string;
   statusId: number;
   status?: IStatus;
   exemptionRationale?: string;

--- a/frontend/src/features/projects/dispose/__snapshots__/ProjectDisposeLayout.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/__snapshots__/ProjectDisposeLayout.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`dispose project draft step display stepper renders correctly based off 
     className="step-content container-fluid"
   >
     <div
-      className="sc-fzokOt cycZXj"
+      className="sc-fzqBZW cSdQOS"
     >
       <button
         className="btn btn-primary"

--- a/frontend/src/features/projects/erp/forms/__snapshots__/ExemptionEnhancedReferralCompleteForm.test.tsx.snap
+++ b/frontend/src/features/projects/erp/forms/__snapshots__/ExemptionEnhancedReferralCompleteForm.test.tsx.snap
@@ -20,9 +20,6 @@ exports[`ExemptionEnhancedReferralCompleteForm renders successfully 1`] = `
       <div
         className="col-md-2 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -86,9 +83,6 @@ exports[`ExemptionEnhancedReferralCompleteForm renders successfully 1`] = `
       <div
         className="col-md-2 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -144,7 +138,7 @@ exports[`ExemptionEnhancedReferralCompleteForm renders successfully 1`] = `
           Proceed to SPL
         </button>
         <div
-          className="sc-fzoiQi gnA-DBP"
+          className="sc-fznxKY cHliGV"
         >
           OR
         </div>

--- a/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
       </h5>
     </div>
     <div
-      className="sc-fzoXzr cIZMlc"
+      className="sc-fzqNqU dZqUFU"
     >
       Approved for ERP
     </div>
@@ -343,9 +343,6 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -382,9 +379,6 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -1177,9 +1171,6 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -1216,9 +1207,6 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -1299,9 +1287,6 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -1362,10 +1347,10 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
       }
     />
     <div
-      className="sc-fzqNJr FcpLd"
+      className="sc-fzoyAV cGutgP"
     />
     <div
-      className="sc-fzqNJr FcpLd"
+      className="sc-fzoyAV cGutgP"
     >
       <span>
         <button
@@ -1448,7 +1433,7 @@ exports[`ERP Approval Step renders correctly 1`] = `
       </h5>
     </div>
     <div
-      className="sc-fzoXzr cIZMlc"
+      className="sc-fzqNqU dZqUFU"
     >
       Approved for ERP
     </div>
@@ -1523,9 +1508,6 @@ exports[`ERP Approval Step renders correctly 1`] = `
             <div
               className="col-md-8 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -1562,9 +1544,6 @@ exports[`ERP Approval Step renders correctly 1`] = `
             <div
               className="col-md-8 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -1601,9 +1580,6 @@ exports[`ERP Approval Step renders correctly 1`] = `
             <div
               className="col-md-8 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -1640,9 +1616,6 @@ exports[`ERP Approval Step renders correctly 1`] = `
             <div
               className="col-md-8 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -2019,9 +1992,6 @@ exports[`ERP Approval Step renders correctly 1`] = `
             <div
               className="col-md-2 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -2094,9 +2064,6 @@ exports[`ERP Approval Step renders correctly 1`] = `
             <div
               className="col-md-2 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -2135,7 +2102,7 @@ exports[`ERP Approval Step renders correctly 1`] = `
             </div>
           </div>
           <div
-            className="sc-fznWqX fApSkZ"
+            className="sc-fzpmMD itvViV"
           >
             OR
           </div>
@@ -2150,9 +2117,6 @@ exports[`ERP Approval Step renders correctly 1`] = `
             <div
               className="col-md-2 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -2194,7 +2158,7 @@ exports[`ERP Approval Step renders correctly 1`] = `
                 Proceed to SPL
               </button>
               <div
-                className="sc-fznWqX fApSkZ"
+                className="sc-fzpmMD itvViV"
               >
                 OR
               </div>

--- a/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`GRE Transfer Step renders correctly 1`] = `
       </h5>
     </div>
     <div
-      className="sc-fzpjYC jfJTfT"
+      className="sc-fzoyTs dcehPm"
     >
       Transferred within the Greater Revenue Entity
     </div>

--- a/frontend/src/features/projects/erp/tabs/__snapshots__/EnhancedReferralTab.test.tsx.snap
+++ b/frontend/src/features/projects/erp/tabs/__snapshots__/EnhancedReferralTab.test.tsx.snap
@@ -24,9 +24,6 @@ exports[`EnhancedReferralTab renders correctly 1`] = `
       <div
         className="col-md-8 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -63,9 +60,6 @@ exports[`EnhancedReferralTab renders correctly 1`] = `
       <div
         className="col-md-8 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -102,9 +96,6 @@ exports[`EnhancedReferralTab renders correctly 1`] = `
       <div
         className="col-md-8 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -141,9 +132,6 @@ exports[`EnhancedReferralTab renders correctly 1`] = `
       <div
         className="col-md-8 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -334,9 +322,6 @@ exports[`EnhancedReferralTab renders correctly 1`] = `
       <div
         className="col-md-2 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -409,9 +394,6 @@ exports[`EnhancedReferralTab renders correctly 1`] = `
       <div
         className="col-md-2 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -465,9 +447,6 @@ exports[`EnhancedReferralTab renders correctly 1`] = `
       <div
         className="col-md-2 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -663,9 +642,6 @@ exports[`EnhancedReferralTab renders correctly when approved for exemption 1`] =
       <div
         className="col-md-2 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >
@@ -729,9 +705,6 @@ exports[`EnhancedReferralTab renders correctly when approved for exemption 1`] =
       <div
         className="col-md-2 form-group"
       >
-        <span
-          className=""
-        />
         <div
           className="react-datepicker-wrapper"
         >

--- a/frontend/src/features/projects/list/ProjectListView.test.tsx
+++ b/frontend/src/features/projects/list/ProjectListView.test.tsx
@@ -2,7 +2,7 @@ import ProjectListView from './ProjectListView';
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import { render, cleanup, getByTitle } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { create } from 'react-test-renderer';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';

--- a/frontend/src/features/projects/list/ProjectListView.test.tsx
+++ b/frontend/src/features/projects/list/ProjectListView.test.tsx
@@ -140,15 +140,15 @@ describe('Project list view', () => {
       items: [],
     });
 
-    const { queryByText, getByTitle } = render(
+    const { queryByText, queryByTitle } = render(
       <Provider store={store}>
         <Router history={history}>
           <ProjectListView />
         </Router>
       </Provider>,
     );
-    expect(getByTitle('Export Generic Report')).not.toBeInTheDOM();
-    expect(getByTitle('Export CSV')).not.toBeInTheDOM();
+    expect(queryByTitle('Export Generic Report')).not.toBeInTheDOM();
+    expect(queryByTitle('Export CSV')).not.toBeInTheDOM();
     expect(queryByText('SPL Report')).not.toBeInTheDOM();
   });
 });

--- a/frontend/src/features/projects/list/ProjectListView.test.tsx
+++ b/frontend/src/features/projects/list/ProjectListView.test.tsx
@@ -2,7 +2,7 @@ import ProjectListView from './ProjectListView';
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, getByTitle } from '@testing-library/react';
 import { create } from 'react-test-renderer';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -131,7 +131,7 @@ describe('Project list view', () => {
     expect(noResults).toBeInTheDocument();
   });
 
-  it('Displays appropriate buttons by default', async () => {
+  it('Does not display export buttons by default', async () => {
     mockedService.getProjectList.mockResolvedValueOnce({
       quantity: 0,
       total: 0,
@@ -140,36 +140,15 @@ describe('Project list view', () => {
       items: [],
     });
 
-    const { getByText, queryByText } = render(
+    const { queryByText, getByTitle } = render(
       <Provider store={store}>
         <Router history={history}>
           <ProjectListView />
         </Router>
       </Provider>,
     );
-    expect(getByText('Export Generic Report')).toBeInTheDocument();
-    expect(getByText('Export CSV')).toBeInTheDocument();
-    expect(queryByText('Export SPL Report')).toBeNull();
-  });
-
-  it('Displays appropriate buttons by default', async () => {
-    mockedService.getProjectList.mockResolvedValueOnce({
-      quantity: 0,
-      total: 0,
-      page: 1,
-      pageIndex: 0,
-      items: [],
-    });
-
-    const { getByText, queryByText } = render(
-      <Provider store={store}>
-        <Router history={history}>
-          <ProjectListView />
-        </Router>
-      </Provider>,
-    );
-    expect(getByText('Export Generic Report')).toBeInTheDocument();
-    expect(getByText('Export CSV')).toBeInTheDocument();
-    expect(queryByText('Export SPL Report')).toBeNull();
+    expect(getByTitle('Export Generic Report')).not.toBeInTheDOM();
+    expect(getByTitle('Export CSV')).not.toBeInTheDOM();
+    expect(queryByText('SPL Report')).not.toBeInTheDOM();
   });
 });

--- a/frontend/src/features/projects/list/ProjectListView.tsx
+++ b/frontend/src/features/projects/list/ProjectListView.tsx
@@ -12,7 +12,7 @@ import { IProjectFilter, IProject } from '.';
 import { columns as cols } from './columns';
 import { Table } from 'components/Table';
 import service from '../apiService';
-import { FaFolder, FaFolderOpen } from 'react-icons/fa';
+import { FaFolder, FaFolderOpen, FaFileExcel, FaFileAlt } from 'react-icons/fa';
 import { Properties } from './properties';
 import FilterBar from 'components/SearchBar/FilterBar';
 import { Col } from 'react-bootstrap';
@@ -26,6 +26,7 @@ import { ENVIRONMENT } from 'constants/environment';
 import queryString from 'query-string';
 import download from 'utils/download';
 import { mapLookupCode, mapStatuses } from 'utils';
+import styled from 'styled-components';
 
 interface IProjectFilterState {
   name?: string;
@@ -43,17 +44,22 @@ const initialValues = {
 const getProjectReportUrl = (filter: IProjectFilter) =>
   `${ENVIRONMENT.apiUrl}/reports/projects?${filter ? queryString.stringify(filter) : ''}`;
 
-const getProjectFinancialReportUrl = (filter: IProjectFilter) =>
+export const getProjectFinancialReportUrl = (filter?: IProjectFilter) =>
   `${ENVIRONMENT.apiUrl}/reports/projects/surplus/properties/list?${
     filter ? queryString.stringify(filter) : ''
   }`;
+
+const FileIcon = styled(Button)`
+  background-color: white !important;
+  color: #003366 !important;
+`;
 
 const initialQuery: IProjectFilter = {
   page: 1,
   quantity: 10,
 };
 
-const getServerQuery = (state: {
+export const getServerQuery = (state: {
   pageIndex: number;
   pageSize: number;
   filter: IProjectFilterState;
@@ -292,15 +298,21 @@ const ProjectListView: React.FC<IProps> = ({ filterable, title, mode }) => {
           />
         )}
         <Container fluid className="TableToolbar">
-          <h3 className="mr-auto">{title}</h3>
-          <Button className="mr-2" onClick={() => fetch('excel', 'generic')}>
-            Export Generic Report
-          </Button>
-          <Button className="mr-2" onClick={() => fetch('csv', 'generic')}>
-            Export CSV
-          </Button>
-          {keycloak.hasClaim(Claims.ADMIN_PROJECTS) && (
-            <Button onClick={() => fetch('excel', 'spl')}>Export SPL Report</Button>
+          <h3 className="mr-4">{title}</h3>
+          {keycloak.hasClaim(Claims.REPORTS_SPL) && (
+            <Button className="mr-auto" onClick={() => history.push('/splReports')}>
+              SPL Report
+            </Button>
+          )}
+          {keycloak.hasClaim(Claims.REPORTS_VIEW) && (
+            <>
+              <FileIcon className="mr-1 p-0" onClick={() => fetch('excel', 'generic')}>
+                <FaFileExcel size={36} />
+              </FileIcon>
+              <FileIcon className="mr-1 p-0" onClick={() => fetch('csv', 'generic')}>
+                <FaFileAlt size={36} />
+              </FileIcon>
+            </>
           )}
         </Container>
         <Table<IProject>

--- a/frontend/src/features/projects/list/ProjectListView.tsx
+++ b/frontend/src/features/projects/list/ProjectListView.tsx
@@ -307,10 +307,10 @@ const ProjectListView: React.FC<IProps> = ({ filterable, title, mode }) => {
           {keycloak.hasClaim(Claims.REPORTS_VIEW) && (
             <>
               <FileIcon className="mr-1 p-0" onClick={() => fetch('excel', 'generic')}>
-                <FaFileExcel size={36} />
+                <FaFileExcel size={36} title="Export Generic Report" />
               </FileIcon>
               <FileIcon className="mr-1 p-0" onClick={() => fetch('csv', 'generic')}>
-                <FaFileAlt size={36} />
+                <FaFileAlt title="Export CSV" size={36} />
               </FileIcon>
             </>
           )}

--- a/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
@@ -14,34 +14,10 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
       className="TableToolbar container-fluid"
     >
       <h3
-        className="mr-auto"
+        className="mr-4"
       >
         Surplus Property Program Projects - Approval Requests
       </h3>
-      <button
-        className="Button mr-2 btn btn-primary"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-      >
-        <div
-          className="Button__value"
-        >
-          Export Generic Report
-        </div>
-      </button>
-      <button
-        className="Button mr-2 btn btn-primary"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-      >
-        <div
-          className="Button__value"
-        >
-          Export CSV
-        </div>
-      </button>
     </div>
     <div
       className="table"

--- a/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
@@ -162,34 +162,10 @@ exports[`Project list view Matches snapshot 1`] = `
       className="TableToolbar container-fluid"
     >
       <h3
-        className="mr-auto"
+        className="mr-4"
       >
         My Agency's Projects
       </h3>
-      <button
-        className="Button mr-2 btn btn-primary"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-      >
-        <div
-          className="Button__value"
-        >
-          Export Generic Report
-        </div>
-      </button>
-      <button
-        className="Button mr-2 btn btn-primary"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-      >
-        <div
-          className="Button__value"
-        >
-          Export CSV
-        </div>
-      </button>
     </div>
     <div
       className="table"

--- a/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
+++ b/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
       </h5>
     </div>
     <div
-      className="sc-fznJRM DFkLw"
+      className="sc-fzoXWK bJauRU"
     >
       Approved for ERP
     </div>
@@ -357,9 +357,6 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -396,9 +393,6 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -1191,9 +1185,6 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -1230,9 +1221,6 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -1313,9 +1301,6 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                 <div
                   className="col-md-8 form-group"
                 >
-                  <span
-                    className=""
-                  />
                   <div
                     className="react-datepicker-wrapper"
                   >
@@ -1376,10 +1361,10 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
       }
     />
     <div
-      className="sc-fzqNJr FcpLd"
+      className="sc-fzoyAV cGutgP"
     />
     <div
-      className="sc-fzqNJr FcpLd"
+      className="sc-fzoyAV cGutgP"
     >
       <span>
         <button
@@ -1462,7 +1447,7 @@ exports[`SPL Approval Step renders correctly 1`] = `
       </h5>
     </div>
     <div
-      className="sc-fznJRM DFkLw"
+      className="sc-fzoXWK bJauRU"
     >
       Approved for ERP
     </div>
@@ -1570,9 +1555,6 @@ exports[`SPL Approval Step renders correctly 1`] = `
             <div
               className="col-md-2 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -1736,9 +1718,6 @@ exports[`SPL Approval Step renders correctly 1`] = `
             <div
               className="col-md-2 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >
@@ -1966,9 +1945,6 @@ exports[`SPL Approval Step renders correctly 1`] = `
             <div
               className="col-md-2 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >

--- a/frontend/src/features/properties/components/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
@@ -1605,7 +1605,7 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
           </div>
         </div>
         <div
-          className="sc-fzoiQi giOLty"
+          className="sc-fznxKY dIqxyo"
         />
       </div>
     </form>

--- a/frontend/src/features/properties/components/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
@@ -561,9 +561,6 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
         <div
           className="col-md-10 form-group"
         >
-          <span
-            className=""
-          />
           <div
             className="react-datepicker-wrapper"
           >

--- a/frontend/src/features/properties/components/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
@@ -625,9 +625,6 @@ exports[`PagedBuildingForms functionality displays any pre-existing buildings 1`
             <div
               className="col-md-10 form-group"
             >
-              <span
-                className=""
-              />
               <div
                 className="react-datepicker-wrapper"
               >

--- a/frontend/src/features/splReports/columns.tsx
+++ b/frontend/src/features/splReports/columns.tsx
@@ -1,0 +1,152 @@
+import { ISnapshot } from './interfaces';
+import { CellProps } from 'react-table';
+import { formatMoney } from 'utils';
+
+const howManyColumns = 13;
+const totalWidthPercent = 100; // how wide the table should be; e.g. 100%
+
+// Setup a few sample widths: x/2, 1x, 2x (percentage-based)
+const unit = Math.floor(totalWidthPercent / howManyColumns);
+const spacing = {
+  xxsmall: 1,
+  xsmall: unit / 4,
+  small: unit / 2,
+  medium: unit,
+  large: unit * 2,
+  xlarge: unit * 4,
+  xxlarge: unit * 8,
+};
+
+export const columns: any[] = [
+  {
+    Header: 'SPP No.',
+    accessor: 'project.projectNumber', // accessor is the "key" in the data
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 65, // px
+  },
+  {
+    Header: 'Fiscal Year',
+    accessor: 'project.actualFiscalYear',
+    align: 'left',
+    responsive: false,
+    width: 50,
+    minWidth: 50,
+  },
+  {
+    Header: 'Agency',
+    accessor: (row: ISnapshot) => row?.project?.agency ?? row?.project?.subAgency ?? '',
+    align: 'left',
+    responsive: false,
+    width: 50,
+    minWidth: 50,
+  },
+  {
+    Header: 'Name',
+    accessor: 'project.name',
+    align: 'left',
+    responsive: true,
+    width: spacing.medium,
+    minWidth: 80,
+  },
+  {
+    Header: 'CMV',
+    accessor: 'estimated',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.estimated);
+    },
+  },
+  {
+    Header: 'NBV',
+    accessor: 'netBook',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.netBook);
+    },
+  },
+  {
+    Header: 'Sales Cost',
+    accessor: 'salesCost',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.salesCost);
+    },
+  },
+  {
+    Header: 'Program Cost',
+    accessor: 'programCost',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.programCost);
+    },
+  },
+  {
+    Header: 'Gain Loss',
+    accessor: 'gainLoss',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.gainLoss);
+    },
+  },
+  {
+    Header: 'OCG Fin. Stmts.',
+    accessor: 'ocgFinancialStatements',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.ocgFinancialStatement);
+    },
+  },
+  {
+    Header: 'Interest Comp.',
+    accessor: 'interestComponent',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.interestComponent);
+    },
+  },
+  {
+    Header: 'Net Proceeds',
+    accessor: 'netProceeds',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.netProceeds);
+    },
+  },
+  {
+    Header: 'Baseline Integrity',
+    accessor: 'baselineIntegrity',
+    align: 'left',
+    responsive: true,
+    width: spacing.small,
+    minWidth: 80,
+    Cell: (props: CellProps<ISnapshot>) => {
+      return formatMoney(props.row.original.baselineIntegrity);
+    },
+  },
+];

--- a/frontend/src/features/splReports/components/Backdrop.scss
+++ b/frontend/src/features/splReports/components/Backdrop.scss
@@ -1,0 +1,10 @@
+@import '../../../variables';
+
+.backdrop {
+  width: 100%;
+  height: calc(100% - #{$footer-height} - #{$header-height} - #{$navbar-height});
+  position: fixed;
+  z-index: 1;
+  top: $header-height + $navbar-height;
+  background-color: rgba(0, 0, 0, 0.5);
+}

--- a/frontend/src/features/splReports/components/Backdrop.tsx
+++ b/frontend/src/features/splReports/components/Backdrop.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import './Backdrop.scss';
+
+interface IBackdropProps {
+  show: boolean;
+  onClick: any;
+}
+
+/**
+ * Provides a generic floating backdrop alpha layer that hides itself when clicked.
+ */
+const Backdrop: React.FunctionComponent<IBackdropProps> = ({ show, onClick }) => {
+  return show ? <div className="backdrop" onClick={onClick}></div> : null;
+};
+
+export default Backdrop;

--- a/frontend/src/features/splReports/components/ElipsisControls.scss
+++ b/frontend/src/features/splReports/components/ElipsisControls.scss
@@ -1,0 +1,28 @@
+@import '../../../colors.scss';
+
+.elipsis-dropdown {
+  .elipsis-primary {
+    margin: 5px;
+    background-color: white;
+    border: 0;
+  }
+  .dropdown-toggle:after {
+    display: none;
+  }
+  .dropdown-menu.show {
+    transform: translate(-132px, 0px) !important;
+    padding: 0;
+  }
+  .dropdown-item {
+    color: black;
+  }
+  .dropdown-item.disabled {
+    color: #6c757d;
+  }
+  .dropdown-item:hover {
+    background-color: $accent-color;
+  }
+  .dropdown-item.danger:hover {
+    background-color: $danger-color;
+  }
+}

--- a/frontend/src/features/splReports/components/ElipsisControls.tsx
+++ b/frontend/src/features/splReports/components/ElipsisControls.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { FaEllipsisH } from 'react-icons/fa';
+import { Dropdown, DropdownButton } from 'react-bootstrap';
+import { IReport } from '../interfaces';
+import './ElipsisControls.scss';
+
+interface IElipsisControlsProps {
+  /** The underlying report that this control is mapped to. */
+  report: IReport;
+  /** function to invoke when the open dropdown item is clicked */
+  onOpen: (report: IReport) => void;
+  /** function to invoke when the Mark as Final dropdown item is clicked */
+  onFinal: (report: IReport) => void;
+  /** function to invoke when the open dropdown item is clicked */
+  onDelete: (report: IReport) => void;
+}
+
+/**
+ * Dropdown controls spawned from an elipsis button. uses open, final, and delete functions.
+ */
+const ElipsisControls: React.FunctionComponent<IElipsisControlsProps> = ({
+  report,
+  onOpen,
+  onFinal,
+  onDelete,
+}) => {
+  return (
+    <DropdownButton
+      id={`${report.id}-elipsis-controls`}
+      bsPrefix="elipsis"
+      className="elipsis-dropdown"
+      title={<FaEllipsisH />}
+    >
+      <Dropdown.Item eventKey="1" onClick={() => onOpen(report)}>
+        Open
+      </Dropdown.Item>
+      <Dropdown.Item eventKey="2" onClick={() => onFinal(report)}>
+        Mark as Final
+      </Dropdown.Item>
+      <Dropdown.Item className="danger" eventKey="3" onClick={() => onDelete(report)}>
+        Delete
+      </Dropdown.Item>
+    </DropdownButton>
+  );
+};
+
+export default ElipsisControls;

--- a/frontend/src/features/splReports/components/ReportControls.tsx
+++ b/frontend/src/features/splReports/components/ReportControls.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import { Formik, Form } from 'formik';
+import { Input, Button, Check, SelectOption } from 'components/common/form';
+import ResetButton from 'components/common/form/ResetButton';
+import { FaFileExcel, FaFileAlt } from 'react-icons/fa';
+import { Row, Form as BSForm } from 'react-bootstrap';
+import { IReport } from '../interfaces';
+import _ from 'lodash';
+import { formatApiDateTime, generateUtcNowDateTime } from 'utils';
+import styled from 'styled-components';
+
+interface IReportControlsProps {
+  /** the active report being displayed, snapshot data is displayed based on this report */
+  currentReport?: IReport;
+  /** a full list of spl reports in the system */
+  reports: IReport[];
+  /** the action to take if a report is saved */
+  onSave: (report: IReport) => void;
+  /** the action to take if a report's 'To' date is updated to the current date/time */
+  onRefresh: (report: IReport) => void;
+  /** the action to take if a report's 'From' date is updated to point to a different, older spl report. */
+  onFromChange: (reportId: number) => void;
+  /** the action to take if a user clicks one of the export icons. */
+  onExport: (report: IReport, accept: 'csv' | 'excel') => void;
+}
+
+/** This object will be used to initialize new spl reports. */
+export const defaultReport: IReport = {
+  name: '',
+  reportTypeId: 0,
+  isFinal: false,
+  to: generateUtcNowDateTime(),
+};
+
+/** get all of the other reports that have a 'To' date before this date */
+const getOtherOlderReports = (reports: IReport[], currentReport?: IReport) => {
+  return currentReport !== undefined
+    ? _.filter(
+        reports,
+        report => !!report.id && report.id !== currentReport.id && currentReport.to > report.to,
+      )
+    : [];
+};
+
+const FileIcon = styled(Button)`
+  background-color: white !important;
+  color: #003366 !important;
+  padding: 6px 5px;
+`;
+
+/**
+ * return a list of SelectOptions based on the passed reports, only returning dates older then the current report.
+ */
+const reportsToOptions = (reports: IReport[]) => {
+  const options = _.map(
+    reports,
+    (report: IReport) =>
+      ({
+        value: report.id,
+        label: report.name?.length ? report.name : formatApiDateTime(report.to),
+      } as SelectOption),
+  );
+  options.unshift({
+    value: '',
+    label: 'Choose a report',
+  });
+  return options;
+};
+
+/**
+ * Formik based Report Controls. Maintains independent state from the SplReportContainer. However, the formik container accepts initial state from the SplReportContainer.
+ */
+const ReportControls: React.FunctionComponent<IReportControlsProps> = ({
+  reports,
+  currentReport,
+  onSave,
+  onRefresh,
+  onFromChange,
+  onExport,
+}) => {
+  const otherReports = getOtherOlderReports(reports, currentReport);
+  const reportOptions = reportsToOptions(otherReports);
+  let reportOn = formatApiDateTime(currentReport?.to);
+  const fromId = _.find(reports, { to: currentReport?.from })?.id;
+  return currentReport ? (
+    <Formik
+      initialValues={{ ...defaultReport, ...currentReport }}
+      onSubmit={values => onSave(values)}
+      enableReinitialize
+    >
+      {({ dirty, values }) => (
+        <Form className="report-form">
+          <Row noGutters className="d-flex align-items-center">
+            {reportOptions.length > 1 ? (
+              <BSForm.Group>
+                <BSForm.Control
+                  label="From: "
+                  options={reportOptions}
+                  as="select"
+                  value={fromId}
+                  disabled={values.isFinal}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                    onFromChange(+e.target.value)
+                  }
+                >
+                  {reportOptions.map((option: SelectOption) => (
+                    <option key={option.value} value={option.value} className="option">
+                      {option.label}
+                    </option>
+                  ))}
+                </BSForm.Control>
+              </BSForm.Group>
+            ) : (
+              <BSForm.Group>
+                <BSForm.Label>From: N/A</BSForm.Label>
+              </BSForm.Group>
+            )}
+            <BSForm.Group className="h-75">
+              <BSForm.Label>To:</BSForm.Label>
+              <BSForm.Control type="input" disabled value={reportOn}></BSForm.Control>
+            </BSForm.Group>
+            <ResetButton
+              disabled={values.isFinal}
+              onClick={() => onRefresh(currentReport)}
+              className="mr-3"
+            />
+            <Input label="Name:" field="name" disabled={values.isFinal} />
+            <Check label="Is Final:" field="isFinal" />
+            <Button className="h-75 mr-auto" type="submit" disabled={!dirty}>
+              Save
+            </Button>
+            <FileIcon>
+              <FaFileExcel size={36} onClick={() => onExport(currentReport, 'excel')} />
+            </FileIcon>
+            <FileIcon>
+              <FaFileAlt size={36} onClick={() => onExport(currentReport, 'csv')} />
+            </FileIcon>
+          </Row>
+        </Form>
+      )}
+    </Formik>
+  ) : (
+    <p>Please Create or Select a Report</p>
+  );
+};
+
+export default ReportControls;

--- a/frontend/src/features/splReports/components/ReportControls.tsx
+++ b/frontend/src/features/splReports/components/ReportControls.tsx
@@ -8,6 +8,7 @@ import { IReport } from '../interfaces';
 import _ from 'lodash';
 import { formatApiDateTime, generateUtcNowDateTime } from 'utils';
 import styled from 'styled-components';
+import { Prompt } from 'react-router-dom';
 
 interface IReportControlsProps {
   /** the active report being displayed, snapshot data is displayed based on this report */
@@ -89,54 +90,60 @@ const ReportControls: React.FunctionComponent<IReportControlsProps> = ({
       enableReinitialize
     >
       {({ dirty, values }) => (
-        <Form className="report-form">
-          <Row noGutters className="d-flex align-items-center">
-            {reportOptions.length > 1 ? (
-              <BSForm.Group>
-                <BSForm.Control
-                  label="From: "
-                  options={reportOptions}
-                  as="select"
-                  value={fromId}
-                  disabled={values.isFinal}
-                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                    onFromChange(+e.target.value)
-                  }
-                >
-                  {reportOptions.map((option: SelectOption) => (
-                    <option key={option.value} value={option.value} className="option">
-                      {option.label}
-                    </option>
-                  ))}
-                </BSForm.Control>
+        <>
+          <Form className="report-form">
+            <Row noGutters className="d-flex align-items-center">
+              {reportOptions.length > 1 ? (
+                <BSForm.Group>
+                  <BSForm.Control
+                    label="From: "
+                    options={reportOptions}
+                    as="select"
+                    value={fromId}
+                    disabled={values.isFinal}
+                    onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                      onFromChange(+e.target.value)
+                    }
+                  >
+                    {reportOptions.map((option: SelectOption) => (
+                      <option key={option.value} value={option.value} className="option">
+                        {option.label}
+                      </option>
+                    ))}
+                  </BSForm.Control>
+                </BSForm.Group>
+              ) : (
+                <BSForm.Group>
+                  <BSForm.Label>From: N/A</BSForm.Label>
+                </BSForm.Group>
+              )}
+              <BSForm.Group className="h-75">
+                <BSForm.Label>To:</BSForm.Label>
+                <BSForm.Control type="input" disabled value={reportOn}></BSForm.Control>
               </BSForm.Group>
-            ) : (
-              <BSForm.Group>
-                <BSForm.Label>From: N/A</BSForm.Label>
-              </BSForm.Group>
-            )}
-            <BSForm.Group className="h-75">
-              <BSForm.Label>To:</BSForm.Label>
-              <BSForm.Control type="input" disabled value={reportOn}></BSForm.Control>
-            </BSForm.Group>
-            <ResetButton
-              disabled={values.isFinal}
-              onClick={() => onRefresh(currentReport)}
-              className="mr-3"
-            />
-            <Input label="Name:" field="name" disabled={values.isFinal} />
-            <Check label="Is Final:" field="isFinal" />
-            <Button className="h-75 mr-auto" type="submit" disabled={!dirty}>
-              Save
-            </Button>
-            <FileIcon>
-              <FaFileExcel size={36} onClick={() => onExport(currentReport, 'excel')} />
-            </FileIcon>
-            <FileIcon>
-              <FaFileAlt size={36} onClick={() => onExport(currentReport, 'csv')} />
-            </FileIcon>
-          </Row>
-        </Form>
+              <ResetButton
+                disabled={values.isFinal}
+                onClick={() => onRefresh(currentReport)}
+                className="mr-3"
+              />
+              <Input label="Name:" field="name" disabled={values.isFinal} />
+              <Check label="Is Final:" field="isFinal" />
+              <Button className="h-75 mr-auto" type="submit" disabled={!dirty}>
+                Save
+              </Button>
+              <FileIcon>
+                <FaFileExcel size={36} onClick={() => onExport(currentReport, 'excel')} />
+              </FileIcon>
+              <FileIcon>
+                <FaFileAlt size={36} onClick={() => onExport(currentReport, 'csv')} />
+              </FileIcon>
+            </Row>
+          </Form>
+          <Prompt
+            when={dirty}
+            message="You have unsaved changes, are you sure you want to leave? Your unsaved changes will be lost."
+          />
+        </>
       )}
     </Formik>
   ) : (

--- a/frontend/src/features/splReports/components/ReportForm.tsx
+++ b/frontend/src/features/splReports/components/ReportForm.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import Table from 'components/Table/Table';
+import { IReport, ISnapshot } from '../interfaces';
+import { columns } from '../columns';
+
+interface IReportFormProps {
+  currentReport?: IReport;
+  snapshots?: ISnapshot[];
+}
+
+/**
+ * Wrapper component for a table displaying read only snapshot data.
+ */
+const ReportForm: React.FunctionComponent<IReportFormProps> = ({ currentReport, snapshots }) => {
+  const data: ISnapshot[] = snapshots ?? [];
+  return currentReport ? (
+    <Table
+      name="spl report table"
+      columns={columns}
+      data={data}
+      loading={snapshots === undefined}
+      hideToolbar
+    ></Table>
+  ) : null;
+};
+
+export default ReportForm;

--- a/frontend/src/features/splReports/components/ReportList.tsx
+++ b/frontend/src/features/splReports/components/ReportList.tsx
@@ -10,6 +10,8 @@ import TooltipWrapper from 'components/common/TooltipWrapper';
 interface IReportListProps {
   /** a list of all spl reports in the system */
   reports: IReport[];
+  /** The currently selected report in this listview. */
+  currentReport?: IReport;
   /** The action to take if a report is selected */
   onOpen: (report: IReport) => void;
   /** The action to take if a report is set to final */
@@ -33,6 +35,7 @@ const ReportList: React.FunctionComponent<IReportListProps> = ({
   onFinal,
   onOpen,
   onAdd,
+  currentReport,
   reports,
 }) => {
   return (
@@ -49,6 +52,7 @@ const ReportList: React.FunctionComponent<IReportListProps> = ({
         reports.map((report, index) => (
           <ReportListitem
             key={`${report.name}${index}`}
+            className={currentReport?.id === report?.id ? 'active' : ''}
             {...{ report, onOpen, onDelete, onFinal }}
           ></ReportListitem>
         ))

--- a/frontend/src/features/splReports/components/ReportList.tsx
+++ b/frontend/src/features/splReports/components/ReportList.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import ReportListitem from './ReportListItem';
+import { IReport } from '../interfaces';
+import styled from 'styled-components';
+import { Button } from 'react-bootstrap';
+import { FaPlus } from 'react-icons/fa';
+import { defaultReport } from './ReportControls';
+import TooltipWrapper from 'components/common/TooltipWrapper';
+
+interface IReportListProps {
+  /** a list of all spl reports in the system */
+  reports: IReport[];
+  /** The action to take if a report is selected */
+  onOpen: (report: IReport) => void;
+  /** The action to take if a report is set to final */
+  onFinal: (report: IReport) => void;
+  /** The action to take if a report is deleted */
+  onDelete: (report: IReport) => void;
+  /** the action to take if a new report is added */
+  onAdd: (report: IReport) => void;
+}
+
+const SidebarHeader = styled.span`
+  display: flex;
+  justify-content: space-between;
+`;
+
+/**
+ * Sidebar displaying a list of reports, and controls to manage those reports.
+ */
+const ReportList: React.FunctionComponent<IReportListProps> = ({
+  onDelete,
+  onFinal,
+  onOpen,
+  onAdd,
+  reports,
+}) => {
+  return (
+    <>
+      <SidebarHeader>
+        <h2>SPL Reports</h2>
+        <Button>
+          <TooltipWrapper toolTipId="no-spl-reports" toolTip="Click here to create an SPL report">
+            <FaPlus size={32} onClick={() => onAdd(defaultReport)} />
+          </TooltipWrapper>
+        </Button>
+      </SidebarHeader>
+      {reports.length ? (
+        reports.map((report, index) => (
+          <ReportListitem
+            key={`${report.name}${index}`}
+            {...{ report, onOpen, onDelete, onFinal }}
+          ></ReportListitem>
+        ))
+      ) : (
+        <p>Click '+' to add an SPL report</p>
+      )}
+    </>
+  );
+};
+
+export default ReportList;

--- a/frontend/src/features/splReports/components/ReportListItem.tsx
+++ b/frontend/src/features/splReports/components/ReportListItem.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { Row, Col, Form } from 'react-bootstrap';
+import ElipsisControls from './ElipsisControls';
+import { IReport } from '../interfaces';
+import { formatApiDateTime } from 'utils';
+
+interface IReportListitemProps {
+  /** The underlying report that this control is mapped to. */
+  report: IReport;
+  /** function to invoke when this list item's name is clicked. */
+  onOpen: (report: IReport) => void;
+  /** function to invoke when the checkbox is clicked */
+  onFinal: (report: IReport) => void;
+  /** function to invoke when the open dropdown item is clicked */
+  onDelete: (report: IReport) => void;
+}
+
+const ListItemRow = styled(Row)`
+  background-color: white;
+  min-height: 2rem;
+  align-items: center;
+  margin: 0;
+`;
+
+/**
+ * This element will replace overly long report text with ...
+ */
+const Report = styled(Col)`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  :hover {
+    color: #3b99fc;
+    cursor: pointer;
+  }
+`;
+
+const CheckBox = styled(Form.Control)`
+  height: auto;
+  width: auto;
+`;
+
+const FlexCol = styled(Col)`
+  display: flex;
+  align-items: center;
+  padding: 0px;
+`;
+
+const getName = (report: IReport) =>
+  !!report.name?.length ? report.name : formatApiDateTime(report.to);
+
+/**
+ * Control that represents a report list item with click functionality, a checkbox representing final report state, and elipsis controls.
+ */
+const ReportListitem: React.FunctionComponent<IReportListitemProps> = ({
+  report,
+  onOpen,
+  onDelete,
+  onFinal,
+}) => {
+  return (
+    <>
+      <ListItemRow>
+        <Report onClick={() => onOpen(report)} md={9} title={getName(report)}>
+          {getName(report)}
+        </Report>
+        <FlexCol md={3}>
+          <CheckBox
+            type="checkbox"
+            checked={report.isFinal}
+            onChange={() => onFinal(report)}
+          ></CheckBox>
+          <ElipsisControls {...{ onOpen, onFinal, onDelete, report }} />
+        </FlexCol>
+      </ListItemRow>
+    </>
+  );
+};
+
+export default ReportListitem;

--- a/frontend/src/features/splReports/components/ReportListItem.tsx
+++ b/frontend/src/features/splReports/components/ReportListItem.tsx
@@ -8,6 +8,8 @@ import { formatApiDateTime } from 'utils';
 interface IReportListitemProps {
   /** The underlying report that this control is mapped to. */
   report: IReport;
+  /** The class of this report item. */
+  className?: string;
   /** function to invoke when this list item's name is clicked. */
   onOpen: (report: IReport) => void;
   /** function to invoke when the checkbox is clicked */
@@ -59,10 +61,11 @@ const ReportListitem: React.FunctionComponent<IReportListitemProps> = ({
   onOpen,
   onDelete,
   onFinal,
+  className,
 }) => {
   return (
     <>
-      <ListItemRow>
+      <ListItemRow className={className}>
         <Report onClick={() => onOpen(report)} md={9} title={getName(report)}>
           {getName(report)}
         </Report>

--- a/frontend/src/features/splReports/components/SplReportLayout.scss
+++ b/frontend/src/features/splReports/components/SplReportLayout.scss
@@ -8,6 +8,9 @@
       display: block;
     }
   }
+  div.active.row {
+    background-color: $accent-color;
+  }
 
   .report-content {
     height: calc(100vh - #{$footer-height} - #{$header-height} - #{$navbar-height});

--- a/frontend/src/features/splReports/components/SplReportLayout.scss
+++ b/frontend/src/features/splReports/components/SplReportLayout.scss
@@ -1,0 +1,98 @@
+@import '../../../variables';
+@import '../../../colors.scss';
+.spl-reports {
+  .side-bar.side-bar-show {
+    transform: translateX(0);
+    width: 300px;
+    > span {
+      display: block;
+    }
+  }
+
+  .report-content {
+    height: calc(100vh - #{$footer-height} - #{$header-height} - #{$navbar-height});
+    overflow-y: scroll;
+  }
+
+  .side-bar {
+    z-index: 101;
+    transition: 0.3s ease-in-out;
+    width: 300px;
+    grid-template-columns: 275px 25px;
+    height: calc(100vh - #{$footer-height} - #{$header-height} - #{$navbar-height});
+    position: fixed;
+    z-index: 5;
+    top: $header-height + $navbar-height;
+    left: 0;
+    overflow-x: hidden;
+    background-color: $form-background-color;
+    display: grid;
+
+    > button {
+      border: none;
+      background-color: rgba(0, 0, 0, 0.1);
+      svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+    :focus {
+      outline: 1px dotted;
+    }
+    .backdrop {
+      background-color: rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  .tbody > .tr-wrapper:nth-child(even) {
+    background-color: whitesmoke;
+  }
+
+  .tbody > .tr-wrapper:nth-child(odd) {
+    background-color: white;
+  }
+
+  .close {
+    transform: translateX(-275px);
+  }
+
+  .form-group {
+    display: flex;
+    align-items: flex-end;
+    margin-bottom: 0;
+    padding-right: 1rem;
+    label {
+      white-space: nowrap;
+      padding-right: 0.5rem;
+      margin-bottom: 0;
+    }
+  }
+
+  @media (max-width: 1400px) {
+    .table .tbody .td {
+      font-size: 10px;
+      padding: 5px;
+    }
+  }
+
+  @media (max-width: 1200px) {
+    .table .tr .td:nth-child(8),
+    .table .tr .th:nth-child(8),
+    .table .tr .td:nth-child(9),
+    .table .tr .th:nth-child(9) {
+      display: none !important;
+    }
+  }
+
+  @media (max-width: 1000px) {
+    .table .tr .td:nth-child(10),
+    .table .tr .th:nth-child(10),
+    .table .tr .td:nth-child(11),
+    .table .tr .th:nth-child(11) {
+      display: none !important;
+    }
+    .table .tr {
+      min-width: 500px !important;
+    }
+  }
+}

--- a/frontend/src/features/splReports/components/SplReportLayout.tsx
+++ b/frontend/src/features/splReports/components/SplReportLayout.tsx
@@ -47,7 +47,9 @@ const SplReportLayout: React.FunctionComponent<ISplReportLayoutProps> = ({
     <div className="spl-reports">
       <div className={classNames('side-bar', showSidebar ? 'side-bar-show open' : 'close')}>
         <span>
-          <ReportList {...{ onOpen, onFinal, onDelete, reports, onAdd }}></ReportList>
+          <ReportList
+            {...{ onOpen, onFinal, onDelete, reports, onAdd, currentReport }}
+          ></ReportList>
         </span>
         <button onClick={() => setShowSidebar(!showSidebar)}>
           {showSidebar ? <FaChevronLeft></FaChevronLeft> : <FaChevronRight></FaChevronRight>}

--- a/frontend/src/features/splReports/components/SplReportLayout.tsx
+++ b/frontend/src/features/splReports/components/SplReportLayout.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import './SplReportLayout.scss';
+import ReportList from './ReportList';
+import { FaChevronRight, FaChevronLeft } from 'react-icons/fa';
+import Backdrop from './Backdrop';
+import classNames from 'classnames';
+import { IReport, ISnapshot } from '../interfaces';
+import ReportControls from './ReportControls';
+import ReportForm from './ReportForm';
+
+interface ISplReportLayoutProps {
+  showSidebar: boolean;
+  setShowSidebar: Function;
+  onOpen: (report: IReport) => void;
+  onFinal: (report: IReport) => void;
+  onDelete: (report: IReport) => void;
+  onSave: (report: IReport) => void;
+  onAdd: (report: IReport) => void;
+  onRefresh: (report: IReport) => void;
+  onFromChange: (id: number) => void;
+  onExport: (report: IReport, accept: 'csv' | 'excel') => void;
+  reports: IReport[];
+  snapshots?: ISnapshot[];
+  currentReport?: IReport;
+}
+
+/**
+ * Top level layout component. Provides layout css and structure for the SPL Reports component.
+ */
+const SplReportLayout: React.FunctionComponent<ISplReportLayoutProps> = ({
+  showSidebar,
+  setShowSidebar,
+  onOpen,
+  onFinal,
+  onDelete,
+  onSave,
+  onRefresh,
+  onAdd,
+  onFromChange,
+  onExport,
+  reports,
+  snapshots,
+  currentReport,
+  children,
+}) => {
+  return (
+    <div className="spl-reports">
+      <div className={classNames('side-bar', showSidebar ? 'side-bar-show open' : 'close')}>
+        <span>
+          <ReportList {...{ onOpen, onFinal, onDelete, reports, onAdd }}></ReportList>
+        </span>
+        <button onClick={() => setShowSidebar(!showSidebar)}>
+          {showSidebar ? <FaChevronLeft></FaChevronLeft> : <FaChevronRight></FaChevronRight>}
+        </button>
+      </div>
+      <div className="ml-4 report-content">
+        <Backdrop show={showSidebar} onClick={() => setShowSidebar(false)} />
+        <ReportControls
+          reports={reports}
+          currentReport={currentReport}
+          onSave={onSave}
+          onRefresh={onRefresh}
+          onFromChange={onFromChange}
+          onExport={onExport}
+        />
+        <ReportForm currentReport={currentReport} snapshots={snapshots} />
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default SplReportLayout;

--- a/frontend/src/features/splReports/containers/SplReportContainer.tsx
+++ b/frontend/src/features/splReports/containers/SplReportContainer.tsx
@@ -15,6 +15,7 @@ import { useDispatch } from 'react-redux';
 import GenericModal from 'components/common/GenericModal';
 import { toast } from 'react-toastify';
 import { useRouterReport } from '../hooks/useRouterReport';
+import { Prompt } from 'react-router-dom';
 
 interface ISplReportContainerProps {}
 

--- a/frontend/src/features/splReports/containers/SplReportContainer.tsx
+++ b/frontend/src/features/splReports/containers/SplReportContainer.tsx
@@ -1,0 +1,195 @@
+import * as React from 'react';
+import SplReportLayout from '../components/SplReportLayout';
+import { useState, useEffect } from 'react';
+import { IReport, ISnapshot } from '../interfaces';
+import { useProjectSnapshotApi } from '../hooks/useProjectSnapshotApi';
+import _ from 'lodash';
+import { generateUtcNowDateTime } from 'utils';
+import useDeepCompareEffect from 'hooks/useDeepCompareEffect';
+import {
+  getServerQuery,
+  getProjectFinancialReportUrl,
+} from 'features/projects/list/ProjectListView';
+import download from 'utils/download';
+import { useDispatch } from 'react-redux';
+import GenericModal from 'components/common/GenericModal';
+import { toast } from 'react-toastify';
+import { useRouterReport } from '../hooks/useRouterReport';
+
+interface ISplReportContainerProps {}
+
+/**
+ * Container providing api and event handling logic for spl reports.
+ */
+const SplReportContainer: React.FunctionComponent<ISplReportContainerProps> = () => {
+  const [showSidebar, setShowSidebar] = useState(false);
+  const [currentReport, setCurrentReport] = useState<IReport | undefined>(undefined);
+  const [reports, setReports] = useState<IReport[]>([]);
+  const [snapshots, setSnapshots] = useState<ISnapshot[] | undefined>();
+  const [reportIdToDelete, setReportIdToDelete] = useState<number | undefined>();
+  const [reportToSave, setReportToSave] = useState<IReport | undefined>();
+  const dispatch = useDispatch();
+  useRouterReport({ currentReport, setCurrentReport, reports });
+  const {
+    getProjectReports,
+    getProjectReportSnapshots,
+    getProjectReportSnapshotsById,
+    refreshProjectReportSnapshots,
+    deleteProjectReport,
+    addProjectReport,
+    updateProjectReport,
+  } = useProjectSnapshotApi();
+
+  const id = currentReport?.id;
+  useEffect(() => {
+    const fetch = async () => {
+      if (id) {
+        const data = await getProjectReportSnapshotsById(id);
+        setSnapshots(data);
+      }
+    };
+    fetch();
+  }, [id, getProjectReportSnapshotsById]);
+
+  const getReports = React.useCallback(async () => {
+    const data = await getProjectReports();
+    setReports(data);
+    if (data.length && !id) {
+      setCurrentReport(data[0]);
+    } else if (data.length === 0) {
+      setShowSidebar(true);
+    }
+  }, [getProjectReports, id]);
+
+  useDeepCompareEffect(() => {
+    getReports();
+  }, [getProjectReports, getReports, currentReport]);
+
+  /**
+   * API call wrapper functions
+   */
+  const deleteReport = async (report: IReport) => {
+    report.id && (await deleteProjectReport(report));
+    getReports();
+    if (report.id === currentReport?.id) {
+      setCurrentReport(undefined);
+    }
+  };
+  const addReport = async (report: IReport) => {
+    const addedReport = await addProjectReport(report);
+    setCurrentReport(addedReport);
+  };
+  const updateReport = async (report: IReport) => {
+    const updatedReport = await updateProjectReport(report);
+    if (report.id === currentReport?.id) {
+      setCurrentReport(updatedReport);
+    } else {
+      getReports();
+    }
+  };
+  const refreshSnapshots = async (report: IReport) => {
+    const data = await refreshProjectReportSnapshots(report);
+    const now = generateUtcNowDateTime();
+    setCurrentReport({
+      ...currentReport,
+      to: now,
+    } as IReport);
+    setSnapshots(data);
+  };
+  const changeFrom = async (report: IReport) => {
+    const data = await getProjectReportSnapshots(report);
+    setCurrentReport(report);
+    setSnapshots(data);
+  };
+  const exportReport = (report: IReport, accept: 'csv' | 'excel') => {
+    const query = getServerQuery({ pageIndex: 0, pageSize: 1, filter: {}, agencyIds: [] });
+    return dispatch(
+      download({
+        url: getProjectFinancialReportUrl({ ...query, all: true, reportId: report?.id }),
+        fileName: `spl_report.${accept === 'csv' ? 'csv' : 'xlsx'}`,
+        actionType: 'projects-report',
+        headers: {
+          Accept: accept === 'csv' ? 'text/csv' : 'application/vnd.ms-excel',
+        },
+      }),
+    );
+  };
+
+  /**
+   * Event Action Functions
+   */
+  const onDelete = (report: IReport) => {
+    if (report.isFinal && _.find(reports, { id: report.id })?.isFinal) {
+      toast.warning(
+        "Deleting 'Final' reports is not allowed. You must remove the 'Final' flag on this report to delete it",
+        { autoClose: 10000 },
+      );
+    } else {
+      setCurrentReport(report);
+      setReportIdToDelete(report.id);
+    }
+  };
+  const onSave = (report: IReport) => {
+    if (!report.isFinal && _.find(reports, { id: report.id })?.isFinal) {
+      setReportToSave(report);
+    } else {
+      updateReport(report);
+    }
+  };
+  const onFinal = (report: IReport) => {
+    const finalReport = { ...report, isFinal: !report.isFinal };
+    onSave(finalReport);
+  };
+
+  return (
+    <SplReportLayout
+      showSidebar={showSidebar}
+      setShowSidebar={setShowSidebar}
+      onOpen={report => setCurrentReport(report)}
+      onDelete={onDelete}
+      onFinal={onFinal}
+      onRefresh={refreshSnapshots}
+      onSave={onSave}
+      onAdd={addReport}
+      onExport={exportReport}
+      onFromChange={(id: number) => {
+        changeFrom({ ...currentReport, from: _.find(reports, { id: id })?.to } as IReport);
+      }}
+      reports={reports}
+      snapshots={snapshots}
+      currentReport={currentReport}
+    >
+      <GenericModal
+        display={!!reportIdToDelete}
+        title="Confirm Delete"
+        okButtonText="Delete"
+        okButtonVariant="danger"
+        cancelButtonText="Cancel"
+        cancelButtonVariant="secondary"
+        message="Are you sure you want to delete this report? this action cannot be undone."
+        handleOk={() => {
+          const report = _.find(reports, { id: reportIdToDelete });
+          report && deleteReport(report);
+          setReportIdToDelete(undefined);
+        }}
+        handleCancel={() => setReportIdToDelete(undefined)}
+      ></GenericModal>
+      <GenericModal
+        display={!!reportToSave}
+        title="Really Remove 'Final' Flag?"
+        okButtonText="Remove 'Final'"
+        okButtonVariant="danger"
+        cancelButtonText="Cancel"
+        cancelButtonVariant="secondary"
+        message="Are you sure you want to remove the 'Final' flag on this report? Removing the 'Final' flag will allow this report to be modified or deleted"
+        handleOk={() => {
+          reportToSave && updateReport(reportToSave);
+          setReportToSave(undefined);
+        }}
+        handleCancel={() => setReportToSave(undefined)}
+      ></GenericModal>
+    </SplReportLayout>
+  );
+};
+
+export default SplReportContainer;

--- a/frontend/src/features/splReports/containers/SplReportContainer.tsx
+++ b/frontend/src/features/splReports/containers/SplReportContainer.tsx
@@ -15,7 +15,6 @@ import { useDispatch } from 'react-redux';
 import GenericModal from 'components/common/GenericModal';
 import { toast } from 'react-toastify';
 import { useRouterReport } from '../hooks/useRouterReport';
-import { Prompt } from 'react-router-dom';
 
 interface ISplReportContainerProps {}
 

--- a/frontend/src/features/splReports/hooks/useProjectSnapshotApi.ts
+++ b/frontend/src/features/splReports/hooks/useProjectSnapshotApi.ts
@@ -1,0 +1,156 @@
+import { ISnapshot } from './../interfaces';
+import CustomAxios, { LifecycleToasts } from 'customAxios';
+import { useDispatch } from 'react-redux';
+import { showLoading, hideLoading } from 'react-redux-loading-bar';
+import { AxiosInstance } from 'axios';
+import { ENVIRONMENT } from 'constants/environment';
+import * as _ from 'lodash';
+import { IReport } from '../interfaces';
+import { useCallback } from 'react';
+import { toast } from 'react-toastify';
+
+export interface IGeocoderResponse {
+  siteId: string;
+  fullAddress: string;
+  address1: string;
+  city: string;
+  provinceCode: string;
+  latitude: number;
+  longitude: number;
+  score: number;
+}
+
+export interface IGeocoderPidsResponse {
+  siteId: string;
+  pids: string[];
+}
+
+export interface PimsAPI extends AxiosInstance {
+  getProjectSnapshots: () => Promise<IReport[]>;
+  deleteProjectSnapshot: (id: number) => void;
+}
+
+const getAxios = (dispatch: Function, toasts?: LifecycleToasts) => {
+  const axios = CustomAxios({ lifecycleToasts: toasts }) as PimsAPI;
+
+  axios.defaults.baseURL = baseUrl;
+
+  axios.interceptors.request.use(
+    config => {
+      dispatch(showLoading());
+      return config;
+    },
+    error => dispatch(hideLoading()),
+  );
+
+  axios.interceptors.response.use(
+    config => {
+      dispatch(hideLoading());
+      return config;
+    },
+    error => dispatch(hideLoading()),
+  );
+  return axios;
+};
+
+const baseUrl = `${ENVIRONMENT.apiUrl}/projects/reports`;
+
+const deleteToasts: LifecycleToasts = {
+  loadingToast: () => toast.dark('Deleting Report'),
+  successToast: () => toast.dark('Report Deleted'),
+  errorToast: () => toast.error('Unable to Delete Report'),
+};
+
+const addToasts: LifecycleToasts = {
+  loadingToast: () => toast.dark('Adding Report'),
+  successToast: () => toast.dark('Report Added'),
+  errorToast: () => toast.error('Unable to Add Report'),
+};
+
+const updateToasts: LifecycleToasts = {
+  loadingToast: () => toast.dark('Updating Report'),
+  successToast: () => toast.dark('Report Updated'),
+  errorToast: () => toast.error('Unable to Update Report'),
+};
+
+const snapshotToasts: LifecycleToasts = {
+  errorToast: () => toast.dark('Failed to load snapshots'),
+};
+
+/**
+ * Network API hook. Provide a set of functions to access and manipulate API data related to SPL Reports.
+ */
+export const useProjectSnapshotApi = () => {
+  const dispatch = useDispatch();
+  const defaultAxios = useCallback(
+    getAxios(dispatch, { errorToast: () => toast.error('Failed to load reports') }),
+    [],
+  );
+
+  const getProjectReports = useCallback(async (): Promise<IReport[]> => {
+    const { data } = await defaultAxios.get<IReport[]>('');
+    return _.orderBy(data, (r: IReport) => r.to, ['desc']);
+  }, [defaultAxios]);
+
+  const getProjectReportSnapshotsById = useCallback(
+    async (id: number): Promise<ISnapshot[]> => {
+      const { data } = await defaultAxios.get<ISnapshot[]>(`snapshots/${id}`);
+      return _.orderBy(data, ['projectId', 'snapshotOn'], ['asc', 'desc']);
+    },
+    [defaultAxios],
+  );
+
+  const getProjectReportSnapshots = useCallback(
+    async (report: IReport): Promise<ISnapshot[]> => {
+      const { data } = await getAxios(dispatch, snapshotToasts).post<ISnapshot[]>(
+        `snapshots/${report.id}`,
+        report,
+      );
+      return _.orderBy(data, ['projectId', 'snapshotOn'], ['asc', 'desc']);
+    },
+    [dispatch],
+  );
+
+  const refreshProjectReportSnapshots = useCallback(
+    async (report: IReport): Promise<ISnapshot[]> => {
+      const { data } = await getAxios(dispatch, snapshotToasts).get<ISnapshot[]>(
+        `refresh/${report.id}`,
+      );
+      return _.orderBy(data, ['projectId', 'snapshotOn'], ['asc', 'desc']);
+    },
+    [dispatch],
+  );
+
+  const deleteProjectReport = useCallback(
+    async (report: IReport) => {
+      await getAxios(dispatch, deleteToasts).delete<IReport>(`/${report.id}`, { data: report });
+    },
+    [dispatch],
+  );
+
+  const addProjectReport = useCallback(
+    async (report: IReport) => {
+      const { data } = await getAxios(dispatch, addToasts).post<IReport>('', { data: report });
+      return data;
+    },
+    [dispatch],
+  );
+
+  const updateProjectReport = useCallback(
+    async (report: IReport) => {
+      const { data } = await getAxios(dispatch, updateToasts).put<IReport>(`/${report.id}`, report);
+      return data;
+    },
+    [dispatch],
+  );
+
+  return {
+    getProjectReports,
+    getProjectReportSnapshotsById,
+    getProjectReportSnapshots,
+    refreshProjectReportSnapshots,
+    deleteProjectReport,
+    addProjectReport,
+    updateProjectReport,
+  };
+};

--- a/frontend/src/features/splReports/hooks/useRouterReport.ts
+++ b/frontend/src/features/splReports/hooks/useRouterReport.ts
@@ -1,0 +1,59 @@
+import { IReport } from './../interfaces';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import React, { useState } from 'react';
+import _ from 'lodash';
+
+export const paramsToObject = (searchString: string) => {
+  const params = new URLSearchParams(searchString);
+  const obj: any = {};
+  for (const key of params.keys()) {
+    if (params.getAll(key).length > 1) {
+      obj[key] = params.getAll(key);
+    } else {
+      obj[key] = params.get(key);
+    }
+  }
+  return obj;
+};
+
+interface RouterFilterProps {
+  currentReport?: IReport;
+  setCurrentReport: (report: IReport) => void;
+  reports: IReport[];
+}
+
+/**
+ * Control the active report on the SPL reports page using url search params.
+ * NOTE: URLSearchParams not supported by IE.
+ */
+export const useRouterReport = ({
+  currentReport,
+  setCurrentReport,
+  reports,
+}: RouterFilterProps) => {
+  const history = useHistory();
+  const [originalSearch] = useState(history.location.search);
+  const dispatch = useDispatch();
+
+  //When this hook loads, override the value of the filter with the search params. Should run once as originalSearch should never change.
+  React.useEffect(() => {
+    if (reports?.length) {
+      const filterFromParams = paramsToObject(originalSearch);
+      if (filterFromParams.reportId) {
+        const report = _.find(reports, { id: filterFromParams.reportId });
+        report && setCurrentReport(report);
+      }
+    }
+  }, [originalSearch, reports, setCurrentReport]);
+
+  //If the filter ever changes, push those changes to the search params
+  React.useEffect(() => {
+    if (currentReport?.id) {
+      const params = new URLSearchParams({ reportId: `${currentReport?.id ?? ''}` });
+      history.push({ search: params.toString() });
+    }
+  }, [history, dispatch, currentReport]);
+
+  return;
+};

--- a/frontend/src/features/splReports/interfaces.ts
+++ b/frontend/src/features/splReports/interfaces.ts
@@ -1,0 +1,26 @@
+import { IProject } from './../projects/common/interfaces';
+export interface IReport {
+  id?: number;
+  name: string;
+  reportTypeId: number;
+  isFinal: boolean;
+  to: string;
+  from?: string;
+}
+
+export interface ISnapshot {
+  projectId: number;
+  project?: IProject;
+  snapshotOn: string;
+  netBook: number;
+  estimated: number;
+  assessed: number;
+  salesCost: number;
+  netProceeds: number;
+  baselineIntegrity: number;
+  programCost: number;
+  gainLoss: number;
+  ocgFinancialStatement: number;
+  interestComponent: number;
+  salesWithLeaseInPlace: boolean;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -20,6 +20,7 @@ import { ProjectListView, ProjectApprovalRequestListView } from 'features/projec
 import { LogoutPage } from 'features/account/Logout';
 import { ProjectRouter } from 'features/projects/common';
 import { ProjectDisposeView } from 'features/projects/dispose';
+import SplReportContainer from 'features/splReports/containers/SplReportContainer';
 
 const AppRouter: React.FC = () => {
   const getTitle = (page: string) => {
@@ -147,6 +148,14 @@ const AppRouter: React.FC = () => {
         layout={AuthLayout}
         claim={Claims.ADMIN_USERS}
         title={getTitle('Edit User')}
+      />
+      <AppRoute
+        protected
+        path="/splReports"
+        component={SplReportContainer}
+        layout={AuthLayout}
+        claim={Claims.REPORTS_SPL}
+        title={getTitle('Dispose Property')}
       />
       <AppRoute title="*" path="*" component={() => <Redirect to="/page-not-found" />} />
     </Switch>

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -178,3 +178,11 @@ export const formatDateFiscal = (date: string | undefined) => {
         .format('YYYY')}/${moment(date).format('YYYY')}`
     : '';
 };
+
+/**
+ * Get the current date time in the UTC timezone. This allows the frontend to create timestamps that are compatible with timestamps created by the API.
+ */
+export const generateUtcNowDateTime = () =>
+  moment(new Date())
+    .utc()
+    .format('YYYY-MM-DDTHH:mm:ss.SSSSSSS');


### PR DESCRIPTION
… restrict exporting reports and accessing spl reports.

This is the frontend part of PA-635 it contains:
1) a collapsing sidebar that allows a user to manage spl reports
2) a main view, where the parameters of the report can be changed, such as the title, date range, and final flag
3) a view-only table displaying all of the project snapshots and variance that belong to this report.
4) a hook that allows the active report to be controlled via the browser url and also pushes the current report to the url.
5) some permission changes and style changes to the existing report export process.