### PR TITLE
pa-1270 Fixing import property financials

### DIFF
--- a/backend/api/Areas/Tools/Controllers/ImportController.cs
+++ b/backend/api/Areas/Tools/Controllers/ImportController.cs
@@ -73,6 +73,29 @@ namespace Pims.Api.Areas.Tools.Controllers
             return new JsonResult(parcels);
         }
 
+        /// <summary>
+        /// POST - Update property financial values in the datasource.
+        /// If the property does not exist it will not be imported.
+        /// The financial values provided will overwrite existing data in the datasource.
+        /// </summary>
+        /// <param name="models">An array of property models.</param>
+        /// <returns>The properties added.</returns>
+        [HttpPost("properties/financials")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(IEnumerable<Model.ParcelModel>), 200)]
+        [ProducesResponseType(typeof(Pims.Api.Models.ErrorResponseModel), 400)]
+        [SwaggerOperation(Tags = new[] { "tools-import" })]
+        [HasPermission(Permissions.SystemAdmin)]
+        public IActionResult ImportPropertyFinancials([FromBody] Model.ImportPropertyModel[] models)
+        {
+            if (models.Count() > 100) return BadRequest("Must not submit more than 100 properties in a single request.");
+
+            var helper = new ImportPropertiesHelper(_pimsAdminService, _logger);
+            var entities = helper.UpdatePropertyFinancials(models);
+            var parcels = _mapper.Map<Model.ParcelModel[]>(entities);
+
+            return new JsonResult(parcels);
+        }
 
         /// <summary>
         /// POST - Add an array of new properties to the datasource.

--- a/backend/api/Areas/Tools/Helpers/ImportPropertiesHelper.cs
+++ b/backend/api/Areas/Tools/Helpers/ImportPropertiesHelper.cs
@@ -50,6 +50,104 @@ namespace Pims.Api.Areas.Tools.Helpers
 
         #region Methods
         /// <summary>
+        /// Update the specified property financials only.
+        /// This will only add new financial year values to existing properties.
+        /// All other property metadata will remain unchanged.
+        /// </summary>
+        /// <param name="properties"></param>
+        /// <returns></returns>
+        public IEnumerable<Entity.Parcel> UpdatePropertyFinancials(IEnumerable<Model.ImportPropertyModel> properties)
+        {
+            if (properties == null) throw new ArgumentNullException(nameof(properties));
+
+            var entities = new List<Entity.Parcel>();
+            foreach (var property in properties)
+            {
+                var parcelId = property.ParcelId ?? property.PID;
+                _logger.LogDebug($"Update property financials pid:{parcelId}, type:{property.PropertyType}, fiscal:{property.FiscalYear}, local:{property.LocalId}");
+
+                var validPid = int.TryParse(parcelId?.Replace("-", ""), out int pid);
+                if (!validPid) continue;
+
+                if (String.Compare(property.PropertyType, "Land") == 0)
+                {
+                    entities.Add(UpdateParcelFinancials(property, pid));
+                }
+                else if (String.Compare(property.PropertyType, "Building") == 0)
+                {
+                    UpdateBuildingFinancials(property, pid);
+                }
+            }
+
+            return entities;
+        }
+
+        /// <summary>
+        /// Check if the parcel exists, if it does then it will update the financials if there are newer values provided.
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="pid"></param>
+        /// <returns></returns>
+        private Entity.Parcel UpdateParcelFinancials(Model.ImportPropertyModel property, int pid)
+        {
+            var p_e = ExceptionHelper.HandleKeyNotFoundWithDefault(() => _pimsAdminService.Parcel.GetByPid(pid));
+            var evaluationDate = new DateTime(property.FiscalYear, 1, 1); // Defaulting to Jan 1st because SIS data doesn't have the actual date.
+
+            // Ignore properties that are not part of inventory.
+            if (p_e.Id == 0) return null;
+
+            // Add a new fiscal values for each year.
+            if (!p_e.Fiscals.Any(e => e.FiscalYear == property.FiscalYear))
+            {
+                p_e.Fiscals.Add(new Entity.ParcelFiscal(p_e, property.FiscalYear, Entity.FiscalKeys.NetBook, property.NetBook));
+            }
+
+            // Add a new evaluation if new.
+            if (!p_e.Evaluations.Any(e => e.Date == evaluationDate))
+            {
+                p_e.Evaluations.Add(new Entity.ParcelEvaluation(p_e, evaluationDate, Entity.EvaluationKeys.Assessed, property.Assessed));
+            }
+
+            _pimsAdminService.Parcel.UpdateFinancials(p_e);
+            _logger.LogDebug($"Updating parcel '{property.PID}'");
+
+            return p_e;
+        }
+
+        /// <summary>
+        /// Check if the building exists, if it does then it will update the financials if there are newer values provided.
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="pid"></param>
+        /// <returns></returns>
+        private Entity.Building UpdateBuildingFinancials(Model.ImportPropertyModel property, int pid)
+        {
+            var lid = property.LocalId;
+            var b_e = ExceptionHelper.HandleKeyNotFoundWithDefault(() => _pimsAdminService.Building.GetByPidAndLocalId(pid, lid));
+            var evaluationDate = new DateTime(property.FiscalYear, 1, 1); // Defaulting to Jan 1st because SIS data doesn't have the actual date.
+
+            // Ignore properties that are not part of inventory.
+            if (b_e.Id == 0) return null;
+
+            // Add a new fiscal values for each year.
+            if (!b_e.Fiscals.Any(e => e.FiscalYear == property.FiscalYear))
+            {
+                b_e.Fiscals.Add(new Entity.BuildingFiscal(b_e, property.FiscalYear, Entity.FiscalKeys.NetBook, property.NetBook));
+            }
+
+            // Add a new evaluation if new.
+            if (!b_e.Evaluations.Any(e => e.Date == evaluationDate))
+            {
+                b_e.Evaluations.Add(new Entity.BuildingEvaluation(b_e, evaluationDate, Entity.EvaluationKeys.Assessed, property.Assessed));
+            }
+
+            _pimsAdminService.Building.UpdateFinancials(b_e);
+            _logger.LogDebug($"Updating building '{property.PID}:{property.LocalId}'");
+
+            return b_e;
+        }
+
+        /// <summary>
         /// Adds or updates the property in the datasource.
         /// Determines if the property is a parcel or a building.
         /// Massages some of the data to align with expected values.
@@ -230,7 +328,7 @@ namespace Pims.Api.Areas.Tools.Helpers
             // Copy properties over to entity.
             p_e.PID = pid;
 
-            // Determine if the last evaluation or fiscal values are older than the one currently being imported.
+            // Determine if the last evaluation or fiscal values in the datasource are older than the one currently being imported.
             var fiscalNetBook = p_e.Fiscals.OrderByDescending(f => f.FiscalYear).FirstOrDefault(f => f.Key == Entity.FiscalKeys.NetBook && f.FiscalYear > fiscalYear);
             var evaluationAssessed = p_e.Evaluations.OrderByDescending(e => e.Date).FirstOrDefault(e => e.Key == Entity.EvaluationKeys.Assessed && e.Date > evaluationDate);
 

--- a/backend/dal/Services/Admin/Concrete/ParcelService.cs
+++ b/backend/dal/Services/Admin/Concrete/ParcelService.cs
@@ -336,38 +336,99 @@ namespace Pims.Dal.Services.Admin
         /// <summary>
         /// Update the specified parcel in the datasource.
         /// </summary>
-        /// <param name="entity"></param>
+        /// <param name="parcel"></param>
         /// <exception type="KeyNotFoundException">Entity does not exist in the datasource.</exception>
         /// <returns></returns>
-        public override void Update(Parcel entity)
+        public override void Update(Parcel parcel)
         {
-            entity.ThrowIfNull(nameof(entity));
-            entity.ThrowIfNotAllowedToEdit(nameof(entity), this.User, new[] { Permissions.SystemAdmin, Permissions.AgencyAdmin });
+            parcel.ThrowIfNull(nameof(parcel));
+            parcel.ThrowIfNotAllowedToEdit(nameof(parcel), this.User, new[] { Permissions.SystemAdmin, Permissions.AgencyAdmin });
 
-            var parcel = this.Context.Parcels.Find(entity.Id) ?? throw new KeyNotFoundException();
+            var originalParcel = this.Context.Parcels.Find(parcel.Id) ?? throw new KeyNotFoundException();
 
-            this.Context.Entry(parcel).CurrentValues.SetValues(entity);
+            var entry = this.Context.Entry(originalParcel);
+            entry.CurrentValues.SetValues(parcel);
+            entry.Collection(p => p.Evaluations).Load();
+            entry.Collection(p => p.Fiscals).Load();
 
-            this.Context.Parcels.ThrowIfNotUnique(entity);
+            this.Context.Parcels.ThrowIfNotUnique(parcel);
 
             // TODO: Update child properties appropriately.
-            base.Update(parcel);
+            foreach (var e in parcel.Evaluations)
+            {
+                // Only add an evaluation that does not exist.
+                if (!originalParcel.Evaluations.Any(pe => pe.Key == e.Key && pe.Date == e.Date))
+                {
+                    e.Parcel = originalParcel;
+                    this.Context.ParcelEvaluations.Add(e);
+                }
+            }
+
+            foreach (var f in parcel.Fiscals)
+            {
+                // Only add a fiscal that does not exist.
+                if (!originalParcel.Fiscals.Any(pf => pf.Key == f.Key && pf.FiscalYear == f.FiscalYear))
+                {
+                    f.Parcel = originalParcel;
+                    this.Context.ParcelFiscals.Add(f);
+                }
+            }
+
+            base.Update(originalParcel);
+        }
+
+        /// <summary>
+        /// Update the specified parcel financials in the datasource.
+        /// </summary>
+        /// <param name="parcel"></param>
+        public void UpdateFinancials(Parcel parcel)
+        {
+            parcel.ThrowIfNull(nameof(parcel));
+            parcel.ThrowIfNotAllowedToEdit(nameof(parcel), this.User, new[] { Permissions.SystemAdmin, Permissions.AgencyAdmin });
+
+            var originalParcel = this.Context.Parcels.Find(parcel.Id) ?? throw new KeyNotFoundException();
+
+            var entry = this.Context.Entry(originalParcel);
+            entry.Collection(p => p.Evaluations).Load();
+            entry.Collection(p => p.Fiscals).Load();
+
+            foreach (var e in parcel.Evaluations)
+            {
+                // Only add an evaluation that does not exist.
+                if (!originalParcel.Evaluations.Any(pe => pe.Key == e.Key && pe.Date == e.Date))
+                {
+                    e.Parcel = originalParcel;
+                    this.Context.ParcelEvaluations.Add(e);
+                }
+            }
+
+            foreach (var f in parcel.Fiscals)
+            {
+                // Only add a fiscal that does not exist.
+                if (!originalParcel.Fiscals.Any(pf => pf.Key == f.Key && pf.FiscalYear == f.FiscalYear))
+                {
+                    f.Parcel = originalParcel;
+                    this.Context.ParcelFiscals.Add(f);
+                }
+            }
+
+            base.Update(originalParcel);
         }
 
         /// <summary>
         /// Remove the specified parcel from the datasource.
         /// </summary>
         /// <exception type="KeyNotFoundException">Entity does not exist in the datasource.</exception>
-        /// <param name="entity"></param>
-        public override void Remove(Parcel entity)
+        /// <param name="parcel"></param>
+        public override void Remove(Parcel parcel)
         {
-            entity.ThrowIfNull(nameof(entity));
-            entity.ThrowIfNotAllowedToEdit(nameof(entity), this.User, new[] { Permissions.SystemAdmin, Permissions.AgencyAdmin });
+            parcel.ThrowIfNull(nameof(parcel));
+            parcel.ThrowIfNotAllowedToEdit(nameof(parcel), this.User, new[] { Permissions.SystemAdmin, Permissions.AgencyAdmin });
 
-            var parcel = this.Context.Parcels.Find(entity.Id) ?? throw new KeyNotFoundException();
+            var originalParcel = this.Context.Parcels.Find(parcel.Id) ?? throw new KeyNotFoundException();
 
-            this.Context.Entry(parcel).CurrentValues.SetValues(entity);
-            base.Remove(parcel);
+            this.Context.Entry(originalParcel).CurrentValues.SetValues(parcel);
+            base.Remove(originalParcel);
         }
         #endregion
     }

--- a/backend/dal/Services/Admin/IBuildingService.cs
+++ b/backend/dal/Services/Admin/IBuildingService.cs
@@ -14,5 +14,6 @@ namespace Pims.Dal.Services.Admin
         Building GetByLocalId(string localId);
         Building GetByPidAndLocalId(int pid, string localId);
         IEnumerable<Building> Add(IEnumerable<Building> buildings);
+        void UpdateFinancials(Building building);
     }
 }

--- a/backend/dal/Services/Admin/IParcelService.cs
+++ b/backend/dal/Services/Admin/IParcelService.cs
@@ -13,5 +13,6 @@ namespace Pims.Dal.Services.Admin
         Parcel Get(int id);
         Parcel GetByPid(int pid);
         IEnumerable<Parcel> Add(IEnumerable<Parcel> parcels);
+        void UpdateFinancials(Parcel parcel);
     }
 }

--- a/backend/tests/unit/dal/Services/Admin/BuildingServiceTest.cs
+++ b/backend/tests/unit/dal/Services/Admin/BuildingServiceTest.cs
@@ -1,0 +1,607 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Pims.Core.Comparers;
+using Pims.Core.Extensions;
+using Pims.Core.Test;
+using Pims.Dal.Entities.Models;
+using Pims.Dal.Exceptions;
+using Pims.Dal.Security;
+using Pims.Dal.Services.Admin;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Xunit;
+using Entity = Pims.Dal.Entities;
+
+namespace Pims.Dal.Test.Services.Admin
+{
+    [Trait("category", "unit")]
+    [Trait("category", "dal")]
+    [Trait("area", "admin")]
+    [Trait("group", "building")]
+    [ExcludeFromCodeCoverage]
+    public class BuildingServiceTest
+    {
+        #region Constructors
+        public BuildingServiceTest() { }
+        #endregion
+
+        #region Tests
+        #region Get Buildings
+        /// <summary>
+        /// User does not have 'property-view' claim.
+        /// </summary>
+        [Fact]
+        public void Get_Buildings_NotAuthorized()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission();
+            var filter = new BuildingFilter(50, 25, 50, 20);
+
+            var service = helper.CreateService<BuildingService>(user);
+
+            // Act
+            // Assert
+            Assert.Throws<NotAuthorizedException>(() =>
+                service.Get(1, 10, null));
+        }
+
+        [Fact]
+        public void Get_Buildings()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(21);
+            var buildings = init.CreateBuildings(parcel, 1, 20);
+            buildings.Next(0).Latitude = 50;
+            buildings.Next(0).Longitude = 25;
+            buildings.Next(1).Agency = init.Agencies.Find(3);
+            buildings.Next(1).AgencyId = 3;
+            buildings.Next(2).ClassificationId = 2;
+            buildings.Next(3).Description = "-DescriptionTest-";
+            buildings.Next(5).ProjectNumber = "ProjectNumber";
+            init.SaveChanges();
+
+            var service = helper.CreateService<BuildingService>(user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            var result = service.Get(1, 10, null);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<Paged<Entity.Building>>(result);
+            Assert.Equal(10, result.Items.Count());
+        }
+        #endregion
+
+        #region Get Building
+        /// <summary>
+        /// User does not have 'property-view' claim.
+        /// </summary>
+        [Fact]
+        public void Get_NotAuthorized()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission();
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            // Assert
+            Assert.Throws<NotAuthorizedException>(() =>
+                service.Get(1));
+        }
+
+        /// <summary>
+        /// Building does not exist.
+        /// </summary>
+        [Fact]
+        public void Get_KeyNotFound()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+
+            // Act
+            // Assert
+            Assert.Throws<KeyNotFoundException>(() =>
+                service.Get(12));
+        }
+
+        /// <summary>
+        /// Building found.
+        /// </summary>
+        [Fact]
+        public void Get()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+
+            // Act
+            var result = service.Get(2);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(building, result, new ShallowPropertyCompare());
+        }
+
+        /// <summary>
+        /// Sensitive building found.
+        /// </summary>
+        [Fact]
+        public void Get_Sensitive()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin, Permissions.SensitiveView).AddAgency(1);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            building.IsSensitive = true;
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+
+            // Act
+            var result = service.Get(2);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(building, result, new ShallowPropertyCompare());
+            Assert.True(result.IsSensitive);
+        }
+        #endregion
+
+        #region Delete Building
+        /// <summary>
+        /// Argument cannot be null.
+        /// </summary>
+        [Fact]
+        public void Remove_ArgumentNull()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission();
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+
+            // Act
+            // Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                service.Remove(null));
+        }
+
+        /// <summary>
+        /// User does not have 'property-delete' claim.
+        /// </summary>
+        [Fact]
+        public void Remove_NotAuthorized()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission();
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+
+            // Act
+            // Assert
+            Assert.Throws<NotAuthorizedException>(() =>
+                service.Remove(building));
+        }
+
+        /// <summary>
+        /// Building does not exist.
+        /// </summary>
+        [Fact]
+        public void Remove_KeyNotFound()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin, Permissions.PropertyDelete, Permissions.AdminProperties);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            var find = EntityHelper.CreateBuilding(parcel, 3);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+
+            // Act
+            // Assert
+            Assert.Throws<KeyNotFoundException>(() =>
+                service.Remove(find));
+        }
+
+        /// <summary>
+        /// Building found.
+        /// </summary>
+        [Fact]
+        public void Remove_SystemAdmin()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin, Permissions.PropertyDelete, Permissions.AdminProperties).AddAgency(1);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            service.Remove(building);
+
+            // Assert
+            Assert.Equal(EntityState.Detached, context.Entry(building).State);
+        }
+
+        /// <summary>
+        /// Sensitive building found.
+        /// </summary>
+        [Fact]
+        public void Remove_Sensitive()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin, Permissions.PropertyDelete, Permissions.AdminProperties).AddAgency(1);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            building.IsSensitive = true;
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>(user);
+            var context = helper.GetService<PimsContext>();
+
+            // Act
+            service.Remove(building);
+
+            // Assert
+            Assert.Equal(EntityState.Detached, context.Entry(building).State);
+            Assert.True(building.IsSensitive);
+        }
+        #endregion
+
+        #region Update Building
+        [Fact]
+        public void UpdateBuilding_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var options = Options.Create<PimsOptions>(new PimsOptions());
+            var service = helper.CreateService<BuildingService>(options);
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            updateBuilding.Name = newName;
+
+            // Act
+            service.Update(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(newName);
+        }
+
+        [Fact]
+        public void UpdateBuildingWithNewFiscals_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var options = Options.Create<PimsOptions>(new PimsOptions());
+            var service = helper.CreateService<BuildingService>(options);
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            EntityHelper.CreateFiscals(updateBuilding, new[] { 2018, 2019 }, Entity.FiscalKeys.NetBook, 5000);
+            updateBuilding.Name = newName;
+
+            // Act
+            service.Update(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(newName);
+            building.Fiscals.Should().HaveCount(2);
+            building.Fiscals.Sum(f => f.Value).Should().Be(10000);
+        }
+
+        [Fact]
+        public void UpdateBuildingWithFiscals_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.CreateFiscals(building, new[] { 2017, 2018 }, Entity.FiscalKeys.NetBook, 2000);
+            init.AddAndSaveChanges(building);
+
+            var options = Options.Create<PimsOptions>(new PimsOptions());
+            var service = helper.CreateService<BuildingService>(options);
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            EntityHelper.CreateFiscals(updateBuilding, new[] { 2018, 2019 }, Entity.FiscalKeys.NetBook, 5000);
+            updateBuilding.Name = newName;
+
+            // Act
+            service.Update(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(newName);
+            building.Fiscals.Should().HaveCount(3);
+            building.Fiscals.Sum(f => f.Value).Should().Be(9000);
+        }
+
+        [Fact]
+        public void UpdateBuildingWithNewEvaluations_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.AddAndSaveChanges(building);
+
+            var options = Options.Create<PimsOptions>(new PimsOptions());
+            var service = helper.CreateService<BuildingService>(options);
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            EntityHelper.CreateEvaluations(updateBuilding, new DateTime(2018, 1, 1), 2, Entity.EvaluationKeys.Assessed, 5000);
+            updateBuilding.Name = newName;
+
+            // Act
+            service.Update(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(newName);
+            building.Evaluations.Should().HaveCount(2);
+            building.Evaluations.Sum(f => f.Value).Should().Be(10000);
+        }
+
+        [Fact]
+        public void UpdateBuildingWithEvaluations_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            init.CreateEvaluations(building, new DateTime(2017, 1, 1), 2, Entity.EvaluationKeys.Assessed, 2000);
+            init.AddAndSaveChanges(building);
+
+            var options = Options.Create<PimsOptions>(new PimsOptions());
+            var service = helper.CreateService<BuildingService>(options);
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            EntityHelper.CreateEvaluations(updateBuilding, new DateTime(2018, 1, 1), 2, Entity.EvaluationKeys.Assessed, 5000);
+            updateBuilding.Name = newName;
+
+            // Act
+            service.Update(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(newName);
+            building.Evaluations.Should().HaveCount(3);
+            building.Evaluations.Sum(f => f.Value).Should().Be(9000);
+        }
+        #endregion
+
+        #region Update Building Financials
+        [Fact]
+        public void UpdateBuildingFinancials_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            var originalName = "original";
+            building.Name = originalName;
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>();
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            updateBuilding.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(originalName);
+        }
+
+        [Fact]
+        public void UpdateBuildingFinancialsWithNewFiscals_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            var originalName = "original";
+            building.Name = originalName;
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>();
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            EntityHelper.CreateFiscals(updateBuilding, new[] { 2018, 2019 }, Entity.FiscalKeys.NetBook, 5000);
+            updateBuilding.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(originalName);
+            building.Fiscals.Should().HaveCount(2);
+            building.Fiscals.Sum(f => f.Value).Should().Be(10000);
+        }
+
+        [Fact]
+        public void UpdateBuildingFinancialsWithFiscals_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            var originalName = "original";
+            building.Name = originalName;
+            init.CreateFiscals(building, new[] { 2017, 2018 }, Entity.FiscalKeys.NetBook, 2000);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>();
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            EntityHelper.CreateFiscals(updateBuilding, new[] { 2018, 2019 }, Entity.FiscalKeys.NetBook, 5000);
+            updateBuilding.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(originalName);
+            building.Fiscals.Should().HaveCount(3);
+            building.Fiscals.Sum(f => f.Value).Should().Be(9000);
+        }
+
+        [Fact]
+        public void UpdateBuildingFinancialsWithNewEvaluations_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            var originalName = "original";
+            building.Name = originalName;
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>();
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            EntityHelper.CreateEvaluations(updateBuilding, new DateTime(2018, 1, 1), 2, Entity.EvaluationKeys.Assessed, 5000);
+            updateBuilding.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(originalName);
+            building.Evaluations.Should().HaveCount(2);
+            building.Evaluations.Sum(f => f.Value).Should().Be(10000);
+        }
+
+        [Fact]
+        public void UpdateBuildingFinancialsWithEvaluations_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+
+            using var init = helper.InitializeDatabase(user);
+            var parcel = init.CreateParcel(1);
+            var building = init.CreateBuilding(parcel, 2);
+            var originalName = "original";
+            building.Name = originalName;
+            init.CreateEvaluations(building, new DateTime(2017, 1, 1), 2, Entity.EvaluationKeys.Assessed, 2000);
+            init.AddAndSaveChanges(building);
+
+            var service = helper.CreateService<BuildingService>();
+
+            var updateBuilding = EntityHelper.CreateBuilding(parcel, 2);
+            var newName = "testing name is updated";
+            EntityHelper.CreateEvaluations(updateBuilding, new DateTime(2018, 1, 1), 2, Entity.EvaluationKeys.Assessed, 5000);
+            updateBuilding.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateBuilding);
+
+            // Assert
+            building.Name.Should().Be(originalName);
+            building.Evaluations.Should().HaveCount(3);
+            building.Evaluations.Sum(f => f.Value).Should().Be(9000);
+        }
+        #endregion
+        #endregion
+    }
+}

--- a/backend/tests/unit/dal/Services/Admin/ParcelServiceTest.cs
+++ b/backend/tests/unit/dal/Services/Admin/ParcelServiceTest.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Pims.Core.Comparers;
 using Pims.Core.Extensions;
@@ -318,6 +319,268 @@ namespace Pims.Dal.Test.Services.Admin
             // Assert
             Assert.Equal(EntityState.Detached, context.Entry(parcel).State);
             Assert.True(parcel.IsSensitive);
+        }
+        #endregion
+
+        #region Update Parcel
+        [Fact]
+        public void UpdateParcel_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            updateParcel.Name = newName;
+
+            // Act
+            service.Update(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(newName);
+        }
+
+        [Fact]
+        public void UpdateParcelWithNewFiscals_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            EntityHelper.CreateFiscals(updateParcel, new[] { 2018, 2019 }, Entity.FiscalKeys.NetBook, 5000);
+            updateParcel.Name = newName;
+
+            // Act
+            service.Update(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(newName);
+            parcel.Fiscals.Should().HaveCount(2);
+            parcel.Fiscals.Sum(f => f.Value).Should().Be(10000);
+        }
+
+        [Fact]
+        public void UpdateParcelWithFiscals_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            EntityHelper.CreateFiscals(parcel, new[] { 2017, 2018 }, Entity.FiscalKeys.NetBook, 2000);
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            EntityHelper.CreateFiscals(updateParcel, new[] { 2018, 2019 }, Entity.FiscalKeys.NetBook, 5000);
+            updateParcel.Name = newName;
+
+            // Act
+            service.Update(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(newName);
+            parcel.Fiscals.Should().HaveCount(3);
+            parcel.Fiscals.Sum(f => f.Value).Should().Be(9000);
+        }
+
+        [Fact]
+        public void UpdateParcelWithNewEvaluations_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            EntityHelper.CreateEvaluations(updateParcel, new DateTime(2018, 1, 1), 2, Entity.EvaluationKeys.Assessed, 5000);
+            updateParcel.Name = newName;
+
+            // Act
+            service.Update(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(newName);
+            parcel.Evaluations.Should().HaveCount(2);
+            parcel.Evaluations.Sum(f => f.Value).Should().Be(10000);
+        }
+
+        [Fact]
+        public void UpdateParcelWithEvaluations_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            EntityHelper.CreateEvaluations(parcel, new DateTime(2017, 1, 1), 2, Entity.EvaluationKeys.Assessed, 2000);
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            EntityHelper.CreateEvaluations(updateParcel, new DateTime(2018, 1, 1), 2, Entity.EvaluationKeys.Assessed, 5000);
+            updateParcel.Name = newName;
+
+            // Act
+            service.Update(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(newName);
+            parcel.Evaluations.Should().HaveCount(3);
+            parcel.Evaluations.Sum(f => f.Value).Should().Be(9000);
+        }
+        #endregion
+
+        #region Update Parcel Financials
+        [Fact]
+        public void UpdateParcelFinancials_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var originalName = "original";
+            parcel.Name = originalName;
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            updateParcel.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(originalName);
+        }
+
+        [Fact]
+        public void UpdateParcelFinancialsWithNewFiscals_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var originalName = "original";
+            parcel.Name = originalName;
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            EntityHelper.CreateFiscals(updateParcel, new[] { 2018, 2019 }, Entity.FiscalKeys.NetBook, 5000);
+            updateParcel.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(originalName);
+            parcel.Fiscals.Should().HaveCount(2);
+            parcel.Fiscals.Sum(f => f.Value).Should().Be(10000);
+        }
+
+        [Fact]
+        public void UpdateParcelFinancialsWithFiscals_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var originalName = "original";
+            parcel.Name = originalName;
+            EntityHelper.CreateFiscals(parcel, new[] { 2017, 2018 }, Entity.FiscalKeys.NetBook, 2000);
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            EntityHelper.CreateFiscals(updateParcel, new[] { 2018, 2019 }, Entity.FiscalKeys.NetBook, 5000);
+            updateParcel.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(originalName);
+            parcel.Fiscals.Should().HaveCount(3);
+            parcel.Fiscals.Sum(f => f.Value).Should().Be(9000);
+        }
+
+        [Fact]
+        public void UpdateParcelFinancialsWithNewEvaluations_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var originalName = "original";
+            parcel.Name = originalName;
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            EntityHelper.CreateEvaluations(updateParcel, new DateTime(2018, 1, 1), 2, Entity.EvaluationKeys.Assessed, 5000);
+            updateParcel.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(originalName);
+            parcel.Evaluations.Should().HaveCount(2);
+            parcel.Evaluations.Sum(f => f.Value).Should().Be(10000);
+        }
+
+        [Fact]
+        public void UpdateParcelFinancialsWithEvaluations_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.SystemAdmin);
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var originalName = "original";
+            parcel.Name = originalName;
+            EntityHelper.CreateEvaluations(parcel, new DateTime(2017, 1, 1), 2, Entity.EvaluationKeys.Assessed, 2000);
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(parcel);
+
+            var service = helper.CreateService<ParcelService>();
+
+            var updateParcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var newName = "testing name is updated";
+            EntityHelper.CreateEvaluations(updateParcel, new DateTime(2018, 1, 1), 2, Entity.EvaluationKeys.Assessed, 5000);
+            updateParcel.Name = newName;
+
+            // Act
+            service.UpdateFinancials(updateParcel);
+
+            // Assert
+            parcel.Name.Should().Be(originalName);
+            parcel.Evaluations.Should().HaveCount(3);
+            parcel.Evaluations.Sum(f => f.Value).Should().Be(9000);
         }
         #endregion
         #endregion


### PR DESCRIPTION
## Description

Previously financials values for each each year were being ignored during import.  This update corrects this issue.  Additionally a new endpoint has been created to support only updating property financial values (`/api/tools/import/properties/financials`).  This new endpoint will allow us to rerun the import without overwriting any changes made to inventory in production.