### PR TITLE
Ensure that duplicate id/agencyId rows are not created in join table …

### DIFF
--- a/backend/dal/Migrations/v01.01.00/Up/PreUp/v01.01.02.sql
+++ b/backend/dal/Migrations/v01.01.00/Up/PreUp/v01.01.02.sql
@@ -4,12 +4,15 @@
   select @incorrectAgencyId = Id from Agencies where Code = 'BT'
 
   update Parcels set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Buildings set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update NotificationQueue set ToAgencyId = @correctAgencyId where ToAgencyId = @incorrectAgencyId
-  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Projects set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
+  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and UserId not in (select UserId from UserAgencies where AgencyId = @correctAgencyId)
+  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and ProjectId not in (select ProjectId from ProjectAgencyResponses where AgencyId = @correctAgencyId)
+  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and AccessRequestId not in (select AccessRequestId from AccessRequestAgencies where AgencyId = @correctAgencyId)
+  delete from UserAgencies where AgencyId = @incorrectAgencyId
+  delete from ProjectAgencyResponses where AgencyId = @incorrectAgencyId
+  delete from AccessRequestAgencies where AgencyId = @incorrectAgencyId
   delete from Agencies where id = @incorrectAgencyId
 
 
@@ -17,12 +20,15 @@
   select @incorrectAgencyId = Id from Agencies where Code = 'ICOB'
 
   update Parcels set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Buildings set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update NotificationQueue set ToAgencyId = @correctAgencyId where ToAgencyId = @incorrectAgencyId
-  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Projects set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
+  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and UserId not in (select UserId from UserAgencies where AgencyId = @correctAgencyId)
+  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and ProjectId not in (select ProjectId from ProjectAgencyResponses where AgencyId = @correctAgencyId)
+  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and AccessRequestId not in (select AccessRequestId from AccessRequestAgencies where AgencyId = @correctAgencyId)
+  delete from UserAgencies where AgencyId = @incorrectAgencyId
+  delete from ProjectAgencyResponses where AgencyId = @incorrectAgencyId
+  delete from AccessRequestAgencies where AgencyId = @incorrectAgencyId
   delete from Agencies where id = @incorrectAgencyId
 
 
@@ -30,12 +36,15 @@
   select @incorrectAgencyId = Id from Agencies where Code = 'CPB'
 
   update Parcels set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Buildings set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update NotificationQueue set ToAgencyId = @correctAgencyId where ToAgencyId = @incorrectAgencyId
-  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Projects set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
+  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and UserId not in (select UserId from UserAgencies where AgencyId = @correctAgencyId)
+  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and ProjectId not in (select ProjectId from ProjectAgencyResponses where AgencyId = @correctAgencyId)
+  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and AccessRequestId not in (select AccessRequestId from AccessRequestAgencies where AgencyId = @correctAgencyId)
+  delete from UserAgencies where AgencyId = @incorrectAgencyId
+  delete from ProjectAgencyResponses where AgencyId = @incorrectAgencyId
+  delete from AccessRequestAgencies where AgencyId = @incorrectAgencyId
   delete from Agencies where id = @incorrectAgencyId
 
 
@@ -43,12 +52,15 @@
   select @incorrectAgencyId = Id from Agencies where Code = 'ECUOA&'
 
   update Parcels set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Buildings set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update NotificationQueue set ToAgencyId = @correctAgencyId where ToAgencyId = @incorrectAgencyId
-  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Projects set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
+  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and UserId not in (select UserId from UserAgencies where AgencyId = @correctAgencyId)
+  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and ProjectId not in (select ProjectId from ProjectAgencyResponses where AgencyId = @correctAgencyId)
+  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and AccessRequestId not in (select AccessRequestId from AccessRequestAgencies where AgencyId = @correctAgencyId)
+  delete from UserAgencies where AgencyId = @incorrectAgencyId
+  delete from ProjectAgencyResponses where AgencyId = @incorrectAgencyId
+  delete from AccessRequestAgencies where AgencyId = @incorrectAgencyId
   delete from Agencies where id = @incorrectAgencyId
 
 
@@ -56,12 +68,15 @@
   select @incorrectAgencyId = Id from Agencies where Code = 'P&LMB'
 
   update Parcels set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Buildings set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update NotificationQueue set ToAgencyId = @correctAgencyId where ToAgencyId = @incorrectAgencyId
-  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Projects set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
+  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and UserId not in (select UserId from UserAgencies where AgencyId = @correctAgencyId)
+  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and ProjectId not in (select ProjectId from ProjectAgencyResponses where AgencyId = @correctAgencyId)
+  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and AccessRequestId not in (select AccessRequestId from AccessRequestAgencies where AgencyId = @correctAgencyId)
+  delete from UserAgencies where AgencyId = @incorrectAgencyId
+  delete from ProjectAgencyResponses where AgencyId = @incorrectAgencyId
+  delete from AccessRequestAgencies where AgencyId = @incorrectAgencyId
   delete from Agencies where id = @incorrectAgencyId
 
 
@@ -69,10 +84,13 @@
   select @incorrectAgencyId = Id from Agencies where Code = 'KPU'
 
   update Parcels set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Buildings set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update NotificationQueue set ToAgencyId = @correctAgencyId where ToAgencyId = @incorrectAgencyId
-  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
   update Projects set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
-  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId
+  update UserAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and UserId not in (select UserId from UserAgencies where AgencyId = @correctAgencyId)
+  update ProjectAgencyResponses set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and ProjectId not in (select ProjectId from ProjectAgencyResponses where AgencyId = @correctAgencyId)
+  update AccessRequestAgencies set AgencyId = @correctAgencyId where AgencyId = @incorrectAgencyId and AccessRequestId not in (select AccessRequestId from AccessRequestAgencies where AgencyId = @correctAgencyId)
+  delete from UserAgencies where AgencyId = @incorrectAgencyId
+  delete from ProjectAgencyResponses where AgencyId = @incorrectAgencyId
+  delete from AccessRequestAgencies where AgencyId = @incorrectAgencyId
   delete from Agencies where id = @incorrectAgencyId


### PR DESCRIPTION
…during migration.

more details:
updating join table such that the incorrect agency is set to the correct agency causes issues if the join table already has an entry for the correct agency.

This should fix this issue by only correcting join rows that don't have a matching row with a correct agency. After the updates we can safely delete any trailing join table rows pointing to the incorrect agency.