### PR TITLE
pa-1256 Property List View Filter

### DIFF
--- a/frontend/src/assets/images/icon-business.svg
+++ b/frontend/src/assets/images/icon-business.svg
@@ -1,7 +1,29 @@
-<svg version="1.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="visible" preserveAspectRatio="none" viewBox="0 0 32 32" xml:space="preserve" y="0px" x="0px" id="Layer_1_1588194074809" width="30" height="30"><g transform="translate(1, 1)"><style type="text/css">
-	.st0_1588194074809{fill:none;stroke:#494949;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
-	.st1_1588194074809{fill:#494949;}
-	.st2_1588194074809{fill:none;stroke:#494949;stroke-miterlimit:10;}
-</style><polygon points="15,2.5 3,2.6 3,27.6 15,27.5" class="st0_1588194074809" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="5.5" x="10" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="9.5" x="10" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="13.5" x="10" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="5.5" x="6" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="9.5" x="6" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="13.5" x="6" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="17.4" x="10" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="17.4" x="6" vector-effect="non-scaling-stroke"/><polyline points="11.5,27.7 11.5,21.4 6.5,21.4 6.5,27.7" class="st2_1588194074809" vector-effect="non-scaling-stroke"/><polygon points="27,6.5 15,6.5 15,27.6 27,27.5" class="st0_1588194074809" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="9.5" x="22" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="13.5" x="22" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="9.5" x="18" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="13.5" x="18" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="17.4" x="22" vector-effect="non-scaling-stroke"/><rect height="2" width="2" class="st1_1588194074809" y="17.4" x="18" vector-effect="non-scaling-stroke"/><g>
-	<line y2="22.4" x2="27" y1="22.4" x1="15" class="st2_1588194074809" vector-effect="non-scaling-stroke"/>
-</g></g></svg>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="visible" preserveAspectRatio="none" viewBox="0 0 32 32" xml:space="preserve" y="0px" x="0px" id="Layer_1_1588194074809" width="30" height="30">
+  <g transform="translate(1, 1)">
+    <style type="text/css">
+	.st0_1588194074809{stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st1_1588194074809{}
+	.st2_1588194074809{stroke-miterlimit:10;}
+</style>
+    <polygon points="15,2.5 3,2.6 3,27.6 15,27.5" class="st0_1588194074809" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="5.5" x="10" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="9.5" x="10" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="13.5" x="10" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="5.5" x="6" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="9.5" x="6" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="13.5" x="6" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="17.4" x="10" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="17.4" x="6" vector-effect="non-scaling-stroke" />
+    <polyline points="11.5,27.7 11.5,21.4 6.5,21.4 6.5,27.7" class="st2_1588194074809" vector-effect="non-scaling-stroke" />
+    <polygon points="27,6.5 15,6.5 15,27.6 27,27.5" class="st0_1588194074809" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="9.5" x="22" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="13.5" x="22" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="9.5" x="18" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="13.5" x="18" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="17.4" x="22" vector-effect="non-scaling-stroke" />
+    <rect height="2" width="2" class="st1_1588194074809" y="17.4" x="18" vector-effect="non-scaling-stroke" />
+    <g>
+      <line y2="22.4" x2="27" y1="22.4" x1="15" class="st2_1588194074809" vector-effect="non-scaling-stroke" />
+    </g>
+  </g>
+</svg>

--- a/frontend/src/assets/images/icon-lot.svg
+++ b/frontend/src/assets/images/icon-lot.svg
@@ -1,4 +1,11 @@
-<svg version="1.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="visible" preserveAspectRatio="none" viewBox="0 0 32 32" xml:space="preserve" y="0px" x="0px" id="Layer_1_1588194077504" width="30" height="30"><g transform="translate(1, 1)"><style type="text/css">
-	.st0_1588194077504{fill:none;stroke:#494949;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
-	.st1_1588194077504{fill:none;stroke:#494949;stroke-miterlimit:10;}
-</style><polygon points="28,15 15,7.2 2,15 15,22.8" class="st0_1588194077504" vector-effect="non-scaling-stroke"/><line y2="11.1" x2="21.5" y1="18.9" x1="8.5" class="st1_1588194077504" vector-effect="non-scaling-stroke"/><line y2="18.9" x2="21.5" y1="11.1" x1="8.5" class="st1_1588194077504" vector-effect="non-scaling-stroke"/></g></svg>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="visible" preserveAspectRatio="none" viewBox="0 0 32 32" xml:space="preserve" y="0px" x="0px" id="Layer_1_1588194077504" width="30" height="30">
+  <g transform="translate(1, 1)">
+    <style type="text/css">
+	.st0_1588194077504{stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st1_1588194077504{stroke-miterlimit:10;}
+</style>
+    <polygon points="28,15 15,7.2 2,15 15,22.8" class="st0_1588194077504" vector-effect="non-scaling-stroke" />
+    <line y2="11.1" x2="21.5" y1="18.9" x1="8.5" class="st1_1588194077504" vector-effect="non-scaling-stroke" />
+    <line y2="18.9" x2="21.5" y1="11.1" x1="8.5" class="st1_1588194077504" vector-effect="non-scaling-stroke" />
+  </g>
+</svg>

--- a/frontend/src/buttons.scss
+++ b/frontend/src/buttons.scss
@@ -1,5 +1,38 @@
 @import './colors.scss';
 
+.svg {
+  fill: none;
+  stroke: #494949;
+}
+
+.svg-btn {
+  color: #494949;
+}
+
+.svg-btn:hover {
+  color: #3b99fc;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.svg-btn:hover svg {
+  fill: #3b99fc;
+  stroke: #fff;
+}
+
+.svg-btn.active {
+  color: #3b99fc;
+  border-bottom-style: solid;
+  border-bottom-color: #fcba19;
+  border-bottom-width: 1px;
+  background-color: transparent !important;
+}
+
+.svg-btn.active svg {
+  fill: #3b99fc;
+  stroke: #fff;
+}
+
 .btn {
   height: 44px;
 }

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -21,6 +21,7 @@ import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SELECTOR_OPTIONS } from './constants';
 import _ from 'lodash';
 import { Spinner, Collapse } from 'react-bootstrap';
 import { FaAngleDown, FaAngleRight } from 'react-icons/fa';
+import TooltipWrapper from 'components/common/TooltipWrapper';
 
 // these provide a way to inject custom CSS into table headers and cells
 const headerProps = <T extends object>(
@@ -277,7 +278,8 @@ const Table = <T extends object>(props: PropsWithChildren<TableProps<T>>): React
       return <div className="no-rows-message">{props.noRowsMessage || 'No rows to display'}</div>;
     }
 
-    const handleExpandClick = (data: T) => {
+    const handleExpandClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>, data: T) => {
+      e.preventDefault();
       let expanded = expandedRows;
       if (
         props.detailsPanel !== undefined &&
@@ -305,14 +307,19 @@ const Table = <T extends object>(props: PropsWithChildren<TableProps<T>>): React
               renderExpandRowStateButton(
                 props.detailsPanel && props.detailsPanel.checkExpanded(row.original, expandedRows),
                 'td',
-                () => handleExpandClick(row.original),
+                e => handleExpandClick(e, row.original),
               )}
+            {props.canRowExpand && !props.canRowExpand(row) ? (
+              <div className="td">
+                <div style={{ width: '20px' }}>&nbsp;</div>
+              </div>
+            ) : null}
             {/* Expansion button shown on every row by default */}
             {!props.canRowExpand &&
               renderExpandRowStateButton(
                 props.detailsPanel && props.detailsPanel.checkExpanded(row.original, expandedRows),
                 'td',
-                () => handleExpandClick(row.original),
+                e => handleExpandClick(e, row.original),
               )}
             {row.cells.map((cell: CellWithProps<T>) => {
               return (
@@ -350,7 +357,11 @@ const Table = <T extends object>(props: PropsWithChildren<TableProps<T>>): React
     );
   };
 
-  const renderExpandRowStateButton = (open?: boolean, className?: string, onClick?: () => void) => {
+  const renderExpandRowStateButton = (
+    open?: boolean,
+    className?: string,
+    onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void,
+  ) => {
     const detailsClosedIcon =
       props.detailsPanel && props.detailsPanel.icons?.closed ? (
         props.detailsPanel.icons?.closed
@@ -365,14 +376,17 @@ const Table = <T extends object>(props: PropsWithChildren<TableProps<T>>): React
       );
     return (
       props.detailsPanel && (
-        <div className={className} onClick={onClick}>
-          {open ? detailsOpenedIcon : detailsClosedIcon}
-        </div>
+        <TooltipWrapper toolTipId="expand-all-rows" toolTip={open ? 'Collapse Row' : 'Expand Row'}>
+          <div className={className + ' svg-btn'} onClick={onClick}>
+            {open ? detailsOpenedIcon : detailsClosedIcon}
+          </div>
+        </TooltipWrapper>
       )
     );
   };
 
-  const handleExpandAll = () => {
+  const handleExpandAll = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.preventDefault();
     let expanded = expandedRows.length !== props.data.length ? props.data : [];
     setExpandedRows(expanded);
     if (props.detailsPanel && props.detailsPanel.onExpand && expanded.length > 0) {

--- a/frontend/src/components/common/TooltipWrapper.tsx
+++ b/frontend/src/components/common/TooltipWrapper.tsx
@@ -1,9 +1,26 @@
 import * as React from 'react';
 import { Tooltip, OverlayTrigger, OverlayTriggerProps } from 'react-bootstrap';
 
+/**
+ * TooltipWrapper properties.
+ * @interface ITooltipWrapperProps
+ * @extends {Partial<OverlayTriggerProps>}
+ */
 interface ITooltipWrapperProps extends Partial<OverlayTriggerProps> {
-  toolTip?: string;
-  toolTipId: string;
+  /**
+   * The tooltip text to display when hovering over the component.
+   *
+   * @type {string}
+   * @memberof ITooltipWrapperProps
+   */
+  toolTip?: string; // TODO: Rename 'toolTip' with 'tooltip'
+  /**
+   * The tooltip element 'id'.
+   *
+   * @type {string}
+   * @memberof ITooltipWrapperProps
+   */
+  toolTipId: string; // TODO: Rename 'toolTipId' with 'tooltipId'
 }
 
 /**

--- a/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`Manage Users Component Snapshot matches 1`] = `
     </div>
   </form>
   <div
-    className="sc-fznWOq blcvyO container-fluid"
+    className="sc-fzolEj kuDfzp container-fluid"
   >
     <div
       className="table"

--- a/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
+++ b/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
@@ -806,6 +806,7 @@ exports[`Review Approve Step renders correctly 1`] = `
                     title="Click to view property details"
                   >
                     <svg
+                      className="svg"
                       title="Land"
                     >
                       icon-lot.svg

--- a/frontend/src/features/projects/common/__snapshots__/ProjectSummaryView.test.tsx.snap
+++ b/frontend/src/features/projects/common/__snapshots__/ProjectSummaryView.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`Review Summary View renders approved correctly 1`] = `
   className="ProjectSummaryView container-fluid"
 >
   <div
-    className="sc-fzqBZW loRQSX [object Object]-status"
+    className="sc-fzqNJr iZVvRm [object Object]-status"
   >
     <h5
-      className="sc-fzqNJr iyvzqf"
+      className="sc-fzoyAV iUdhUR"
     >
       Approved for Surplus Property Program
     </h5>
@@ -32,7 +32,7 @@ exports[`Review Summary View renders approved correctly 1`] = `
       />
     </svg>
     <h5
-      className="sc-fzqNJr iyvzqf"
+      className="sc-fzoyAV iUdhUR"
     >
       Approval Date: Unknown Date
     </h5>
@@ -797,7 +797,7 @@ exports[`Review Summary View renders approved correctly 1`] = `
       }
     />
     <div
-      className="sc-fzoLag iYjTex"
+      className="sc-fzoXzr chUPrj"
     >
       <button
         className="btn btn-warning"
@@ -830,10 +830,10 @@ exports[`Review Summary View renders denied correctly 1`] = `
   className="ProjectSummaryView container-fluid"
 >
   <div
-    className="sc-fzqBZW loRQSX [object Object]-status"
+    className="sc-fzqNJr iZVvRm [object Object]-status"
   >
     <h5
-      className="sc-fzqNJr iyvzqf"
+      className="sc-fzoyAV iUdhUR"
     >
       Submitted
     </h5>
@@ -857,7 +857,7 @@ exports[`Review Summary View renders denied correctly 1`] = `
       />
     </svg>
     <h5
-      className="sc-fzqNJr iyvzqf"
+      className="sc-fzoyAV iUdhUR"
     >
       test
     </h5>
@@ -1622,7 +1622,7 @@ exports[`Review Summary View renders denied correctly 1`] = `
       }
     />
     <div
-      className="sc-fzoLag iYjTex"
+      className="sc-fzoXzr chUPrj"
     >
       <button
         className="btn btn-warning"
@@ -1655,10 +1655,10 @@ exports[`Review Summary View renders submitted correctly 1`] = `
   className="ProjectSummaryView container-fluid"
 >
   <div
-    className="sc-fzqBZW loRQSX [object Object]-status"
+    className="sc-fzqNJr iZVvRm [object Object]-status"
   >
     <h5
-      className="sc-fzqNJr iyvzqf"
+      className="sc-fzoyAV iUdhUR"
     >
       Submitted
     </h5>
@@ -1682,7 +1682,7 @@ exports[`Review Summary View renders submitted correctly 1`] = `
       />
     </svg>
     <h5
-      className="sc-fzqNJr iyvzqf"
+      className="sc-fzoyAV iUdhUR"
     >
       In Review
     </h5>
@@ -2447,7 +2447,7 @@ exports[`Review Summary View renders submitted correctly 1`] = `
       }
     />
     <div
-      className="sc-fzoLag iYjTex"
+      className="sc-fzoXzr chUPrj"
     >
       <button
         className="btn btn-warning"

--- a/frontend/src/features/projects/common/components/columns.tsx
+++ b/frontend/src/features/projects/common/components/columns.tsx
@@ -259,7 +259,12 @@ export const getPropertyColumns = ({
       width: 60,
       clickable: true,
       Cell: ({ cell: { value } }: CellProps<IProperty, number>) => {
-        const icon = value === 0 ? <LandSvg title="Land" /> : <BuildingSvg title="Building" />;
+        const icon =
+          value === 0 ? (
+            <LandSvg title="Land" className="svg" />
+          ) : (
+            <BuildingSvg title="Building" className="svg" />
+          );
         return icon;
       },
     },
@@ -287,7 +292,12 @@ export const getAppraisedColumns = (project: IProject): any[] => [
     accessor: 'propertyTypeId',
     width: 60,
     Cell: ({ cell: { value } }: CellProps<IProperty, number>) => {
-      const icon = value === 0 ? <LandSvg title="Land" /> : <BuildingSvg title="Building" />;
+      const icon =
+        value === 0 ? (
+          <LandSvg title="Land" className="svg" />
+        ) : (
+          <BuildingSvg title="Building" className="svg" />
+        );
       return icon;
     },
   },

--- a/frontend/src/features/projects/common/forms/__snapshots__/UpdateInfoForm.test.tsx.snap
+++ b/frontend/src/features/projects/common/forms/__snapshots__/UpdateInfoForm.test.tsx.snap
@@ -953,6 +953,7 @@ exports[`Update Info Form Matches Snapshot 1`] = `
                   title="Click to view property details"
                 >
                   <svg
+                    className="svg"
                     title="Land"
                   >
                     icon-lot.svg

--- a/frontend/src/features/projects/dispose/__snapshots__/ProjectDisposeLayout.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/__snapshots__/ProjectDisposeLayout.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`dispose project draft step display stepper renders correctly based off 
     className="step-content container-fluid"
   >
     <div
-      className="sc-fzoLag iYjTex"
+      className="sc-fzoXzr chUPrj"
     >
       <button
         className="btn btn-primary"

--- a/frontend/src/features/projects/dispose/forms/__snapshots__/PropertyListViewSelect.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/forms/__snapshots__/PropertyListViewSelect.test.tsx.snap
@@ -940,6 +940,7 @@ exports[`Property List View Select renders correctly 1`] = `
               title="Click to view property details"
             >
               <svg
+                className="svg"
                 title="Land"
               >
                 icon-lot.svg

--- a/frontend/src/features/projects/erp/forms/__snapshots__/ExemptionEnhancedReferralCompleteForm.test.tsx.snap
+++ b/frontend/src/features/projects/erp/forms/__snapshots__/ExemptionEnhancedReferralCompleteForm.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`ExemptionEnhancedReferralCompleteForm renders successfully 1`] = `
           Proceed to SPL
         </button>
         <div
-          className="sc-fznWOq eRNTMe"
+          className="sc-fzolEj bHRNKN"
         >
           OR
         </div>

--- a/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
@@ -10,10 +10,10 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
     onSubmit={[Function]}
   >
     <div
-      className="sc-fzqBZW loRQSX default-status"
+      className="sc-fzqNJr iZVvRm default-status"
     >
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approved for Surplus Property Program
       </h5>
@@ -37,13 +37,13 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
         />
       </svg>
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approval Date 
       </h5>
     </div>
     <div
-      className="sc-fzoNJl KQqkE"
+      className="sc-fzoXWK bJauRU"
     >
       Approved for ERP
     </div>
@@ -1332,10 +1332,10 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
       }
     />
     <div
-      className="sc-fzpjYC efPzVu"
+      className="sc-fznxsB erKWrJ"
     />
     <div
-      className="sc-fzpjYC efPzVu"
+      className="sc-fznxsB erKWrJ"
     >
       <span>
         <button
@@ -1385,10 +1385,10 @@ exports[`ERP Approval Step renders correctly 1`] = `
     onSubmit={[Function]}
   >
     <div
-      className="sc-fzqBZW loRQSX default-status"
+      className="sc-fzqNJr iZVvRm default-status"
     >
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approved for Surplus Property Program
       </h5>
@@ -1412,13 +1412,13 @@ exports[`ERP Approval Step renders correctly 1`] = `
         />
       </svg>
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approval Date 
       </h5>
     </div>
     <div
-      className="sc-fzoNJl KQqkE"
+      className="sc-fzoXWK bJauRU"
     >
       Approved for ERP
     </div>
@@ -2093,7 +2093,7 @@ exports[`ERP Approval Step renders correctly 1`] = `
             </div>
           </div>
           <div
-            className="sc-fznMAR iJsJEt"
+            className="sc-fznWOq eRNTMe"
           >
             OR
           </div>
@@ -2150,7 +2150,7 @@ exports[`ERP Approval Step renders correctly 1`] = `
                 Proceed to SPL
               </button>
               <div
-                className="sc-fznMAR iJsJEt"
+                className="sc-fznWOq eRNTMe"
               >
                 OR
               </div>

--- a/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
@@ -8,10 +8,10 @@ exports[`GRE Transfer Step renders correctly 1`] = `
     className=""
   >
     <div
-      className="sc-fzqBZW loRQSX default-status"
+      className="sc-fzqNJr iZVvRm default-status"
     >
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approved for Surplus Property Program
       </h5>
@@ -35,13 +35,13 @@ exports[`GRE Transfer Step renders correctly 1`] = `
         />
       </svg>
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approval Date 
       </h5>
     </div>
     <div
-      className="sc-fzoXWK bJauRU"
+      className="sc-fzpmMD gopcyv"
     >
       Transferred within the Greater Revenue Entity
     </div>
@@ -658,6 +658,7 @@ exports[`GRE Transfer Step renders correctly 1`] = `
                   title="Click to view property details"
                 >
                   <svg
+                    className="svg"
                     title="Land"
                   >
                     icon-lot.svg

--- a/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
@@ -43,8 +43,12 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
           }
         >
           <div
-            className="th expander"
+            className="th expander svg-btn"
+            onBlur={[Function]}
             onClick={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
           >
             <svg
               color="black"
@@ -318,8 +322,12 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
             }
           >
             <div
-              className="td"
+              className="td svg-btn"
+              onBlur={[Function]}
               onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
             >
               <svg
                 color="black"
@@ -788,9 +796,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                         "boxSizing": "border-box",
                         "display": "flex",
                         "flex": "80 0 auto",
-                        "justifyContent": "flex-start",
+                        "justifyContent": "flex-end",
                         "minWidth": "80px",
-                        "textAlign": "left",
+                        "textAlign": "right",
                         "width": "7%",
                       }
                     }
@@ -809,9 +817,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                         "boxSizing": "border-box",
                         "display": "flex",
                         "flex": "80 0 auto",
-                        "justifyContent": "flex-start",
+                        "justifyContent": "flex-end",
                         "minWidth": "80px",
-                        "textAlign": "left",
+                        "textAlign": "right",
                         "width": "7%",
                       }
                     }
@@ -830,9 +838,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                         "boxSizing": "border-box",
                         "display": "flex",
                         "flex": "80 0 auto",
-                        "justifyContent": "flex-start",
+                        "justifyContent": "flex-end",
                         "minWidth": "80px",
-                        "textAlign": "left",
+                        "textAlign": "right",
                         "width": "7%",
                       }
                     }
@@ -872,9 +880,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                         "boxSizing": "border-box",
                         "display": "flex",
                         "flex": "65 0 auto",
-                        "justifyContent": "flex-start",
+                        "justifyContent": "flex-end",
                         "minWidth": "65px",
-                        "textAlign": "left",
+                        "textAlign": "right",
                         "width": "3.5%",
                       }
                     }
@@ -1101,9 +1109,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                           "boxSizing": "border-box",
                           "display": "flex",
                           "flex": "80 0 auto",
-                          "justifyContent": "flex-start",
+                          "justifyContent": "flex-end",
                           "minWidth": "80px",
-                          "textAlign": "left",
+                          "textAlign": "right",
                           "width": "7%",
                         }
                       }
@@ -1122,9 +1130,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                           "boxSizing": "border-box",
                           "display": "flex",
                           "flex": "80 0 auto",
-                          "justifyContent": "flex-start",
+                          "justifyContent": "flex-end",
                           "minWidth": "80px",
-                          "textAlign": "left",
+                          "textAlign": "right",
                           "width": "7%",
                         }
                       }
@@ -1143,9 +1151,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                           "boxSizing": "border-box",
                           "display": "flex",
                           "flex": "80 0 auto",
-                          "justifyContent": "flex-start",
+                          "justifyContent": "flex-end",
                           "minWidth": "80px",
-                          "textAlign": "left",
+                          "textAlign": "right",
                           "width": "7%",
                         }
                       }
@@ -1173,10 +1181,11 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                       title=""
                       width="3.5%"
                     >
-                      <img
-                        className=""
-                        src="icon-business.svg"
-                      />
+                      <svg
+                        className="svg"
+                      >
+                        icon-business.svg
+                      </svg>
                     </div>
                     <div
                       className="td"
@@ -1188,9 +1197,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                           "boxSizing": "border-box",
                           "display": "flex",
                           "flex": "65 0 auto",
-                          "justifyContent": "flex-start",
+                          "justifyContent": "flex-end",
                           "minWidth": "65px",
-                          "textAlign": "left",
+                          "textAlign": "right",
                           "width": "3.5%",
                         }
                       }

--- a/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
@@ -189,8 +189,12 @@ exports[`Project list view tests Matches snapshot 1`] = `
           }
         >
           <div
-            className="th expander"
+            className="th expander svg-btn"
+            onBlur={[Function]}
             onClick={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
           >
             <svg
               color="black"

--- a/frontend/src/features/projects/list/properties/Properties.tsx
+++ b/frontend/src/features/projects/list/properties/Properties.tsx
@@ -3,7 +3,7 @@ import { columns } from './columns';
 import { Table } from 'components/Table';
 import { IProperty } from '../../common';
 
-interface IProps {
+export interface IProps {
   data: IProperty[];
   hideHeaders?: boolean;
 }

--- a/frontend/src/features/projects/list/properties/index.ts
+++ b/frontend/src/features/projects/list/properties/index.ts
@@ -1,0 +1,2 @@
+export * from './Properties';
+export { columns } from './columns';

--- a/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
+++ b/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
@@ -10,10 +10,10 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
     onSubmit={[Function]}
   >
     <div
-      className="sc-fzqBZW loRQSX default-status"
+      className="sc-fzqNJr iZVvRm default-status"
     >
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approved for Surplus Property Program
       </h5>
@@ -37,13 +37,13 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
         />
       </svg>
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approval Date 2020-07-15
       </h5>
     </div>
     <div
-      className="sc-fznxKY hKlkDb"
+      className="sc-fznMAR DcCKH"
     >
       Approved for ERP
     </div>
@@ -1346,10 +1346,10 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
       }
     />
     <div
-      className="sc-fzpjYC efPzVu"
+      className="sc-fznxsB erKWrJ"
     />
     <div
-      className="sc-fzpjYC efPzVu"
+      className="sc-fznxsB erKWrJ"
     >
       <span>
         <button
@@ -1399,10 +1399,10 @@ exports[`SPL Approval Step renders correctly 1`] = `
     onSubmit={[Function]}
   >
     <div
-      className="sc-fzqBZW loRQSX default-status"
+      className="sc-fzqNJr iZVvRm default-status"
     >
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approved for Surplus Property Program
       </h5>
@@ -1426,13 +1426,13 @@ exports[`SPL Approval Step renders correctly 1`] = `
         />
       </svg>
       <h5
-        className="sc-fzqNJr iyvzqf"
+        className="sc-fzoyAV iUdhUR"
       >
         Approval Date 2020-07-15
       </h5>
     </div>
     <div
-      className="sc-fznxKY hKlkDb"
+      className="sc-fznMAR DcCKH"
     >
       Approved for ERP
     </div>

--- a/frontend/src/features/properties/components/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
@@ -212,10 +212,10 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
                   className="form-row"
                 >
                   <div
-                    className="sc-fzoNJl hgprTW form-group"
+                    className="sc-fzoXWK eNEiuy form-group"
                   >
                     <label
-                      className="sc-fzoXWK frIblo form-label"
+                      className="sc-fzpmMD hzPxsT form-label"
                     >
                       Location
                        
@@ -1623,7 +1623,7 @@ exports[`ParcelDetailForm ParcelDetailForm renders view-only correctly 1`] = `
           </div>
         </div>
         <div
-          className="sc-fznWOq doWHVH"
+          className="sc-fzolEj kYIodA"
         />
       </div>
     </form>

--- a/frontend/src/features/properties/components/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
@@ -73,10 +73,10 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
           className="form-row"
         >
           <div
-            className="sc-fznxKY keqzrd form-group"
+            className="sc-fznMAR eqswTV form-group"
           >
             <label
-              className="sc-fznMAR fzHbWr form-label"
+              className="sc-fznWOq dYJGRA form-label"
             >
               Location
                

--- a/frontend/src/features/properties/components/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
@@ -137,10 +137,10 @@ exports[`PagedBuildingForms functionality displays any pre-existing buildings 1`
               className="form-row"
             >
               <div
-                className="sc-fznxKY keqzrd form-group"
+                className="sc-fznMAR eqswTV form-group"
               >
                 <label
-                  className="sc-fznMAR fzHbWr form-label"
+                  className="sc-fznWOq dYJGRA form-label"
                 >
                   Location
                    

--- a/frontend/src/features/properties/list/FilterBar.test.tsx
+++ b/frontend/src/features/properties/list/FilterBar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { render, wait, fireEvent, cleanup } from '@testing-library/react';
-import FilterBar, { IFilterBarState } from './FilterBar';
+import FilterBar, { IFilterBarState, PropertyTypes } from './FilterBar';
 import * as MOCK from 'mocks/filterDataMock';
 import Axios from 'axios';
 
@@ -104,7 +104,7 @@ describe('FilterBar', () => {
       minLotSize: '1',
       maxLotSize: '3',
       parcelId: '',
-      propertyType: '',
+      propertyType: PropertyTypes.Land,
     });
   });
   it('loads list filter values if provided', () => {

--- a/frontend/src/features/properties/list/FilterBar.tsx
+++ b/frontend/src/features/properties/list/FilterBar.tsx
@@ -60,7 +60,12 @@ export interface IFilterBarState extends BasePropertyFilter {
   minLotSize: string;
   maxLotSize: string;
   parcelId?: string;
-  propertyType?: string;
+  propertyType?: PropertyTypes;
+}
+
+export enum PropertyTypes {
+  Land = 'Land',
+  Building = 'Building',
 }
 
 type FilterBarProps = {
@@ -81,7 +86,7 @@ const defaultFilterValues: IFilterBarState = {
   minLotSize: '',
   maxLotSize: '',
   parcelId: '',
-  propertyType: '',
+  propertyType: PropertyTypes.Land,
 };
 
 /**

--- a/frontend/src/features/properties/list/PropertyListView.scss
+++ b/frontend/src/features/properties/list/PropertyListView.scss
@@ -5,7 +5,7 @@ $filter-height: 76px;
 $contentheading-height: 60px;
 
 .PropertyListView {
-  background-color: var(--light);
+  background-color: #fff;
   display: flex;
   flex-direction: column;
   padding: 0;
@@ -40,6 +40,18 @@ $contentheading-height: 60px;
     display: flex;
     flex-direction: row;
     padding-bottom: 1rem;
+  }
+
+  .TableToolbar .menu {
+    display: flex;
+    flex-direction: row;
+    margin-left: 10px;
+    margin-top: auto;
+    margin-right: auto;
+  }
+
+  .TableToolbar .menu div {
+    margin-left: 10px;
   }
 
   .ScrollContainer {

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -1,5 +1,4 @@
 import './PropertyListView.scss';
-
 import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Container, Button } from 'react-bootstrap';
@@ -17,11 +16,23 @@ import { columns as cols } from './columns';
 import { Table } from 'components/Table';
 import service from '../service';
 import { FaFolderOpen, FaFolder } from 'react-icons/fa';
-import { Properties } from 'features/projects/list/properties';
+import { Buildings } from './buildings';
 import { useRouterFilter } from 'hooks/useRouterFilter';
+import { FaFileExcel, FaFileAlt } from 'react-icons/fa';
+import styled from 'styled-components';
+import TooltipWrapper from 'components/common/TooltipWrapper';
+import { ReactComponent as BuildingSvg } from 'assets/images/icon-business.svg';
+import { ReactComponent as LandSvg } from 'assets/images/icon-lot.svg';
+import { PropertyTypes } from './FilterBar';
 
 const getPropertyReportUrl = (filter: IPropertyFilter) =>
   `${ENVIRONMENT.apiUrl}/reports/properties?${filter ? queryString.stringify(filter) : ''}`;
+
+const FileIcon = styled(Button)`
+  background-color: #fff !important;
+  color: #003366 !important;
+  padding: 6px 5px;
+`;
 
 const initialQuery: IPropertyFilter = {
   page: 1,
@@ -110,6 +121,7 @@ const PropertyListView: React.FC = () => {
     classificationId: '',
     minLotSize: '',
     maxLotSize: '',
+    propertyType: PropertyTypes.Land,
   });
 
   const [pageSize, setPageSize] = useState(10);
@@ -218,6 +230,16 @@ const PropertyListView: React.FC = () => {
     }
   };
 
+  const changePropertyType = (type: PropertyTypes) => {
+    setPageIndex(0);
+    setFilter(state => {
+      return {
+        ...state,
+        propertyType: type,
+      };
+    });
+  };
+
   return (
     <Container fluid className="PropertyListView">
       <Container fluid className="filter-container border-bottom">
@@ -232,11 +254,45 @@ const PropertyListView: React.FC = () => {
       </Container>
       <div className="ScrollContainer">
         <Container fluid className="TableToolbar">
-          <h3 className="mr-auto">Results</h3>
-          <Button className="mr-2" onClick={() => fetch('excel')}>
-            Export as Excel
-          </Button>
-          <Button onClick={() => fetch('csv')}>Export as CSV</Button>
+          <h3>View Inventory</h3>
+          <div className="menu">
+            <div>
+              <TooltipWrapper toolTipId="show-parcels" toolTip="Show Parcels">
+                <div
+                  className={
+                    filter.propertyType === PropertyTypes.Land ? 'svg-btn active' : 'svg-btn'
+                  }
+                  onClick={() => changePropertyType(PropertyTypes.Land)}
+                >
+                  <LandSvg className="svg" />
+                  Parcels view
+                </div>
+              </TooltipWrapper>
+            </div>
+            <div>
+              <TooltipWrapper toolTipId="show-buildings" toolTip="Show Buildings">
+                <div
+                  className={
+                    filter.propertyType === PropertyTypes.Building ? 'svg-btn active' : 'svg-btn'
+                  }
+                  onClick={() => changePropertyType(PropertyTypes.Building)}
+                >
+                  <BuildingSvg className="svg" />
+                  Buildings view
+                </div>
+              </TooltipWrapper>
+            </div>
+          </div>
+          <TooltipWrapper toolTipId="export-to-excel" toolTip="Export to Excel">
+            <FileIcon>
+              <FaFileExcel size={36} onClick={() => fetch('excel')} />
+            </FileIcon>
+          </TooltipWrapper>
+          <TooltipWrapper toolTipId="export-to-excel" toolTip="Export to CSV">
+            <FileIcon>
+              <FaFileAlt size={36} onClick={() => fetch('csv')} />
+            </FileIcon>
+          </TooltipWrapper>
         </Container>
         <Table<IProperty>
           name="propertiesTable"
@@ -256,10 +312,13 @@ const PropertyListView: React.FC = () => {
           detailsPanel={{
             render: val => {
               if (expandData[val.id]) {
-                return <Properties hideHeaders={true} data={expandData[val.id]} />;
+                return <Buildings hideHeaders={true} data={expandData[val.id]} />;
               }
             },
-            icons: { open: <FaFolderOpen color="black" />, closed: <FaFolder color="black" /> },
+            icons: {
+              open: <FaFolderOpen color="black" size={20} />,
+              closed: <FaFolder color="black" size={20} />,
+            },
             checkExpanded: (row, state) => !!state.find(x => checkExpanded(x, row)),
             onExpand: loadBuildings,
             getRowId: row => row.id,

--- a/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
+++ b/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
@@ -255,26 +255,106 @@ Array [
       <div
         className="TableToolbar container-fluid"
       >
-        <h3
-          className="mr-auto"
-        >
-          Results
+        <h3>
+          View Inventory
         </h3>
+        <div
+          className="menu"
+        >
+          <div>
+            <div
+              className="svg-btn active"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+            >
+              <svg
+                className="svg"
+              >
+                icon-lot.svg
+              </svg>
+              Parcels view
+            </div>
+          </div>
+          <div>
+            <div
+              className="svg-btn"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+            >
+              <svg
+                className="svg"
+              >
+                icon-business.svg
+              </svg>
+              Buildings view
+            </div>
+          </div>
+        </div>
         <button
-          className="mr-2 btn btn-primary"
+          className="sc-fzolEj iTKQzA btn btn-primary"
           disabled={false}
-          onClick={[Function]}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
           type="button"
         >
-          Export as Excel
+          <svg
+            fill="currentColor"
+            height={36}
+            onClick={[Function]}
+            size={36}
+            stroke="currentColor"
+            strokeWidth="0"
+            style={
+              Object {
+                "color": undefined,
+              }
+            }
+            viewBox="0 0 384 512"
+            width={36}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm60.1 106.5L224 336l60.1 93.5c5.1 8-.6 18.5-10.1 18.5h-34.9c-4.4 0-8.5-2.4-10.6-6.3C208.9 405.5 192 373 192 373c-6.4 14.8-10 20-36.6 68.8-2.1 3.9-6.1 6.3-10.5 6.3H110c-9.5 0-15.2-10.5-10.1-18.5l60.3-93.5-60.3-93.5c-5.2-8 .6-18.5 10.1-18.5h34.8c4.4 0 8.5 2.4 10.6 6.3 26.1 48.8 20 33.6 36.6 68.5 0 0 6.1-11.7 36.6-68.5 2.1-3.9 6.2-6.3 10.6-6.3H274c9.5-.1 15.2 10.4 10.1 18.4zM384 121.9v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+            />
+          </svg>
         </button>
         <button
-          className="btn btn-primary"
+          className="sc-fzolEj iTKQzA btn btn-primary"
           disabled={false}
-          onClick={[Function]}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
           type="button"
         >
-          Export as CSV
+          <svg
+            fill="currentColor"
+            height={36}
+            onClick={[Function]}
+            size={36}
+            stroke="currentColor"
+            strokeWidth="0"
+            style={
+              Object {
+                "color": undefined,
+              }
+            }
+            viewBox="0 0 384 512"
+            width={36}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+            />
+          </svg>
         </button>
       </div>
       <div
@@ -301,13 +381,18 @@ Array [
             }
           >
             <div
-              className="th expander"
+              className="th expander svg-btn"
+              onBlur={[Function]}
               onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
             >
               <svg
                 color="black"
                 fill="currentColor"
-                height="1em"
+                height={20}
+                size={20}
                 stroke="currentColor"
                 strokeWidth="0"
                 style={
@@ -316,7 +401,7 @@ Array [
                   }
                 }
                 viewBox="0 0 576 512"
-                width="1em"
+                width={20}
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -418,6 +503,27 @@ Array [
                   "alignItems": "center",
                   "boxSizing": "border-box",
                   "display": "flex",
+                  "flex": "65 0 auto",
+                  "justifyContent": "flex-start",
+                  "minWidth": "65px",
+                  "textAlign": "left",
+                  "width": "3.5%",
+                }
+              }
+              width="3.5%"
+            >
+              Type
+            </div>
+            <div
+              className="th"
+              colSpan={1}
+              onClick={[Function]}
+              role="columnheader"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "boxSizing": "border-box",
+                  "display": "flex",
                   "flex": "160 0 auto",
                   "justifyContent": "flex-start",
                   "minWidth": "160px",
@@ -461,9 +567,9 @@ Array [
                   "boxSizing": "border-box",
                   "display": "flex",
                   "flex": "80 0 auto",
-                  "justifyContent": "flex-start",
+                  "justifyContent": "flex-end",
                   "minWidth": "80px",
-                  "textAlign": "left",
+                  "textAlign": "right",
                   "width": "7%",
                 }
               }
@@ -482,9 +588,9 @@ Array [
                   "boxSizing": "border-box",
                   "display": "flex",
                   "flex": "80 0 auto",
-                  "justifyContent": "flex-start",
+                  "justifyContent": "flex-end",
                   "minWidth": "80px",
-                  "textAlign": "left",
+                  "textAlign": "right",
                   "width": "7%",
                 }
               }
@@ -503,9 +609,9 @@ Array [
                   "boxSizing": "border-box",
                   "display": "flex",
                   "flex": "80 0 auto",
-                  "justifyContent": "flex-start",
+                  "justifyContent": "flex-end",
                   "minWidth": "80px",
-                  "textAlign": "left",
+                  "textAlign": "right",
                   "width": "7%",
                 }
               }
@@ -524,30 +630,9 @@ Array [
                   "boxSizing": "border-box",
                   "display": "flex",
                   "flex": "65 0 auto",
-                  "justifyContent": "flex-start",
+                  "justifyContent": "flex-end",
                   "minWidth": "65px",
-                  "textAlign": "left",
-                  "width": "3.5%",
-                }
-              }
-              width="3.5%"
-            >
-              Type
-            </div>
-            <div
-              className="th"
-              colSpan={1}
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "alignItems": "center",
-                  "boxSizing": "border-box",
-                  "display": "flex",
-                  "flex": "65 0 auto",
-                  "justifyContent": "flex-start",
-                  "minWidth": "65px",
-                  "textAlign": "left",
+                  "textAlign": "right",
                   "width": "3.5%",
                 }
               }

--- a/frontend/src/features/properties/list/buildings/Buildings.tsx
+++ b/frontend/src/features/properties/list/buildings/Buildings.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { columns } from './columns';
+import { Table } from 'components/Table';
+import { IProperty } from './IProperty';
+
+/**
+ * Buildings table component properties
+ * @interface IProps
+ */
+export interface IProps {
+  /** An array of properties. */
+  data: IProperty[];
+  /** Whether to hide the headers. */
+  hideHeaders?: boolean;
+}
+
+/**
+ * A table displaying a list of buildings.
+ * @param {IProps} props Component properties.
+ */
+export const Buildings: React.FC<IProps> = ({ data, hideHeaders }) => {
+  return (
+    <Table<IProperty>
+      hideHeaders={hideHeaders}
+      name="nestedPropertiesTable"
+      columns={columns}
+      data={data}
+      pageCount={1}
+      hideToolbar={true}
+    />
+  );
+};

--- a/frontend/src/features/properties/list/buildings/IProperty.ts
+++ b/frontend/src/features/properties/list/buildings/IProperty.ts
@@ -1,0 +1,71 @@
+/**
+ * IProperty interface represents the model used for searching properties.
+ */
+export interface IProperty {
+  id: number;
+  projectPropertyId?: number;
+  propertyTypeId: number;
+  propertyType: string;
+  pid: string;
+  pin?: number;
+  classificationId: number;
+  classification: string;
+  description: string;
+  projectNumber?: string;
+  latitude: number;
+  longitude: number;
+  isSensitive: boolean;
+  agencyId: number;
+  agency: string;
+  agencyCode: string;
+  subAgency?: string;
+  subAgencyCode?: string;
+
+  addressId: number;
+  address: string;
+  cityId: number;
+  city: string;
+  province: string;
+  postal: string;
+
+  // Financial Values
+  estimated: number;
+  estimatedFiscalYear?: number;
+  estimatedRowVersion?: string;
+  netBook: number;
+  netBookFiscalYear?: number;
+  netBookRowVersion?: string;
+
+  assessed: number;
+  assessedDate?: Date | string;
+  assessedFirm?: string;
+  assessedRowVersion?: string;
+  appraised: number;
+  appraisedDate?: Date | string;
+  appraisedFirm?: string;
+  appraisedRowVersion?: string;
+
+  // Parcel Properties
+  landArea: number;
+  landLegalDescription: string;
+  municipality?: string;
+  zoning?: string;
+  zoningPotential?: string;
+
+  // Building Properties
+  parcelId?: number;
+  localId?: string;
+  constructionTypeId?: number;
+  constructionType?: string;
+  predominateUseId?: number;
+  predominateUse?: string;
+  occupantTypeId?: number;
+  occupantType?: string;
+  floorCount?: number;
+  tenancy?: string;
+  occupantName?: string;
+  leaseExpiry?: Date | string;
+  transferLeaseOnSale?: boolean;
+  rentableArea?: number;
+  rowVersion?: string;
+}

--- a/frontend/src/features/properties/list/buildings/columns.tsx
+++ b/frontend/src/features/properties/list/buildings/columns.tsx
@@ -6,10 +6,9 @@ import { CellProps } from 'react-table';
 import { Link } from 'react-router-dom';
 import { formatMoney, formatNumber } from 'utils';
 import { ColumnWithProps } from 'components/Table';
-import { IProperty } from '../../common/interfaces';
+import { IProperty } from './IProperty';
 
 const MoneyCell = ({ cell: { value } }: CellProps<IProperty, number>) => formatMoney(value);
-
 const NumberCell = ({ cell: { value } }: CellProps<IProperty, number>) => formatNumber(value);
 
 // NOTE - There numbers below match the total number of columns ATM (13)
@@ -63,6 +62,16 @@ export const columns: ColumnWithProps<IProperty>[] = [
     minWidth: 80,
   },
   {
+    Header: 'Type',
+    accessor: 'propertyTypeId',
+    Cell: ({ cell: { value } }: CellProps<IProperty, number>) => {
+      return value === 0 ? <LandSvg className="svg" /> : <BuildingSvg className="svg" />;
+    },
+    responsive: true,
+    width: spacing.small,
+    minWidth: 65,
+  },
+  {
     Header: 'Street Address',
     accessor: 'address',
     align: 'left',
@@ -72,26 +81,10 @@ export const columns: ColumnWithProps<IProperty>[] = [
   },
   {
     Header: 'Location',
-    accessor: 'administrativeArea',
+    accessor: 'city',
     align: 'left',
     responsive: true,
     width: spacing.medium,
-    minWidth: 80,
-  },
-  {
-    Header: 'Zoning',
-    accessor: 'zoning',
-    align: 'left',
-    responsive: true,
-    width: spacing.small,
-    minWidth: 80,
-  },
-  {
-    Header: 'Zoning Potential',
-    accessor: 'zoningPotential',
-    align: 'left',
-    responsive: true,
-    width: spacing.small,
     minWidth: 80,
   },
   {
@@ -120,16 +113,6 @@ export const columns: ColumnWithProps<IProperty>[] = [
     responsive: true,
     width: spacing.medium,
     minWidth: 80,
-  },
-  {
-    Header: 'Type',
-    accessor: 'propertyTypeId',
-    Cell: ({ cell: { value } }: CellProps<IProperty, number>) => {
-      return value === 0 ? <LandSvg className="svg" /> : <BuildingSvg className="svg" />;
-    },
-    responsive: true,
-    width: spacing.small,
-    minWidth: 65,
   },
   {
     Header: 'Lot Size (in ha)',

--- a/frontend/src/features/properties/list/buildings/index.ts
+++ b/frontend/src/features/properties/list/buildings/index.ts
@@ -1,0 +1,5 @@
+import { IProperty as t } from './IProperty';
+
+export * from './Buildings';
+export { columns } from './columns';
+export type IProperty = t;

--- a/frontend/src/features/properties/list/columns.tsx
+++ b/frontend/src/features/properties/list/columns.tsx
@@ -1,9 +1,8 @@
-import BuildingSvg from 'assets/images/icon-business.svg';
-import LandSvg from 'assets/images/icon-lot.svg';
+import { ReactComponent as BuildingSvg } from 'assets/images/icon-business.svg';
+import { ReactComponent as LandSvg } from 'assets/images/icon-lot.svg';
 
 import React from 'react';
 import { CellProps } from 'react-table';
-import { Image } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { formatMoney, formatNumber } from 'utils';
 import { IProperty } from '.';
@@ -64,6 +63,16 @@ export const columns: ColumnWithProps<IProperty>[] = [
     minWidth: 80,
   },
   {
+    Header: 'Type',
+    accessor: 'propertyTypeId',
+    Cell: ({ cell: { value } }: CellProps<IProperty, number>) => {
+      return value === 0 ? <LandSvg className="svg" /> : <BuildingSvg className="svg" />;
+    },
+    responsive: true,
+    width: spacing.small,
+    minWidth: 65,
+  },
+  {
     Header: 'Street Address',
     accessor: 'address',
     align: 'left',
@@ -83,7 +92,7 @@ export const columns: ColumnWithProps<IProperty>[] = [
     Header: 'Assessed Value',
     accessor: 'assessed',
     Cell: MoneyCell,
-    align: 'left',
+    align: 'right',
     responsive: true,
     width: spacing.medium,
     minWidth: 80,
@@ -92,7 +101,7 @@ export const columns: ColumnWithProps<IProperty>[] = [
     Header: 'Netbook Value',
     accessor: 'netBook',
     Cell: MoneyCell,
-    align: 'left',
+    align: 'right',
     responsive: true,
     width: spacing.medium,
     minWidth: 80,
@@ -101,26 +110,16 @@ export const columns: ColumnWithProps<IProperty>[] = [
     Header: 'Estimated Value',
     accessor: 'estimated',
     Cell: MoneyCell,
-    align: 'left',
+    align: 'right',
     responsive: true,
     width: spacing.medium,
     minWidth: 80,
   },
   {
-    Header: 'Type',
-    accessor: 'propertyTypeId',
-    Cell: ({ cell: { value } }: CellProps<IProperty, number>) => {
-      const icon = value === 0 ? LandSvg : BuildingSvg;
-      return <Image src={icon} />;
-    },
-    responsive: true,
-    width: spacing.small,
-    minWidth: 65,
-  },
-  {
     Header: 'Lot Size (in ha)',
     accessor: 'landArea',
     Cell: NumberCell,
+    align: 'right',
     responsive: true,
     width: spacing.small,
     minWidth: 65,

--- a/frontend/src/features/splReports/containers/__snapshots__/SplReportContainer.test.tsx.snap
+++ b/frontend/src/features/splReports/containers/__snapshots__/SplReportContainer.test.tsx.snap
@@ -44,11 +44,11 @@ exports[`Spl Report Container basic data loading and display Displays project sn
           </div>
         </div><button disabled=\\"\\" type=\\"submit\\" class=\\"Button Button--disabled h-75 mr-auto btn btn-primary\\">
           <div class=\\"Button__value\\">Save</div>
-        </button><button type=\\"button\\" class=\\"Button sc-fznWOq dOxIWh btn btn-primary\\">
+        </button><button type=\\"button\\" class=\\"Button sc-fzolEj dJwQce btn btn-primary\\">
           <div class=\\"Button__value\\"><svg stroke=\\"currentColor\\" fill=\\"currentColor\\" stroke-width=\\"0\\" viewBox=\\"0 0 384 512\\" size=\\"36\\" height=\\"36\\" width=\\"36\\" xmlns=\\"http://www.w3.org/2000/svg\\">
               <path d=\\"M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm60.1 106.5L224 336l60.1 93.5c5.1 8-.6 18.5-10.1 18.5h-34.9c-4.4 0-8.5-2.4-10.6-6.3C208.9 405.5 192 373 192 373c-6.4 14.8-10 20-36.6 68.8-2.1 3.9-6.1 6.3-10.5 6.3H110c-9.5 0-15.2-10.5-10.1-18.5l60.3-93.5-60.3-93.5c-5.2-8 .6-18.5 10.1-18.5h34.8c4.4 0 8.5 2.4 10.6 6.3 26.1 48.8 20 33.6 36.6 68.5 0 0 6.1-11.7 36.6-68.5 2.1-3.9 6.2-6.3 10.6-6.3H274c9.5-.1 15.2 10.4 10.1 18.4zM384 121.9v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z\\"></path>
             </svg></div>
-        </button><button type=\\"button\\" class=\\"Button sc-fznWOq dOxIWh btn btn-primary\\">
+        </button><button type=\\"button\\" class=\\"Button sc-fzolEj dJwQce btn btn-primary\\">
           <div class=\\"Button__value\\"><svg stroke=\\"currentColor\\" fill=\\"currentColor\\" stroke-width=\\"0\\" viewBox=\\"0 0 384 512\\" size=\\"36\\" height=\\"36\\" width=\\"36\\" xmlns=\\"http://www.w3.org/2000/svg\\">
               <path d=\\"M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z\\"></path>
             </svg></div>
@@ -124,11 +124,11 @@ exports[`Spl Report Container basic data loading and display Matches snapshot 1`
           </div>
         </div><button disabled=\\"\\" type=\\"submit\\" class=\\"Button Button--disabled h-75 mr-auto btn btn-primary\\">
           <div class=\\"Button__value\\">Save</div>
-        </button><button type=\\"button\\" class=\\"Button sc-fznWOq dOxIWh btn btn-primary\\">
+        </button><button type=\\"button\\" class=\\"Button sc-fzolEj dJwQce btn btn-primary\\">
           <div class=\\"Button__value\\"><svg stroke=\\"currentColor\\" fill=\\"currentColor\\" stroke-width=\\"0\\" viewBox=\\"0 0 384 512\\" size=\\"36\\" height=\\"36\\" width=\\"36\\" xmlns=\\"http://www.w3.org/2000/svg\\">
               <path d=\\"M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm60.1 106.5L224 336l60.1 93.5c5.1 8-.6 18.5-10.1 18.5h-34.9c-4.4 0-8.5-2.4-10.6-6.3C208.9 405.5 192 373 192 373c-6.4 14.8-10 20-36.6 68.8-2.1 3.9-6.1 6.3-10.5 6.3H110c-9.5 0-15.2-10.5-10.1-18.5l60.3-93.5-60.3-93.5c-5.2-8 .6-18.5 10.1-18.5h34.8c4.4 0 8.5 2.4 10.6 6.3 26.1 48.8 20 33.6 36.6 68.5 0 0 6.1-11.7 36.6-68.5 2.1-3.9 6.2-6.3 10.6-6.3H274c9.5-.1 15.2 10.4 10.1 18.4zM384 121.9v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z\\"></path>
             </svg></div>
-        </button><button type=\\"button\\" class=\\"Button sc-fznWOq dOxIWh btn btn-primary\\">
+        </button><button type=\\"button\\" class=\\"Button sc-fzolEj dJwQce btn btn-primary\\">
           <div class=\\"Button__value\\"><svg stroke=\\"currentColor\\" fill=\\"currentColor\\" stroke-width=\\"0\\" viewBox=\\"0 0 384 512\\" size=\\"36\\" height=\\"36\\" width=\\"36\\" xmlns=\\"http://www.w3.org/2000/svg\\">
               <path d=\\"M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z\\"></path>
             </svg></div>


### PR DESCRIPTION
## Description

Updating **Property List View** to provide a filter to show either **Parcels** or **Buildings**.  The purpose is to remove the confusion about duplicate buildings.

[Story](https://pimsteam.atlassian.net/browse/PA-1256)
[UX Story](https://pimsteam.atlassian.net/browse/PA-1081)

[UX](https://preview.uxpin.com/bcfcebd6d46b70cc4030fc7ec0b363b72d9d2d99#/pages/133606919/simulate/no-panels)

## Known Issues

- Currently there is a bug when expanding some parcel rows.  It will open multiple rows, but the user can't collapse the ones above.  Need to debug and determine if this is an introduced issue, or an old one.
- There is no loading indicator when user clicks the parcels or buildings filter.

## To Do

- Rows should how expand when the text is longer.  It should replace with ellipses with tooltip. 
