### PR TITLE
PA-106, 1203

### DIFF
--- a/backend/api/Areas/Admin/Controllers/AgencyController.cs
+++ b/backend/api/Areas/Admin/Controllers/AgencyController.cs
@@ -6,6 +6,7 @@ using Pims.Dal.Services.Admin;
 using Swashbuckle.AspNetCore.Annotations;
 using Entity = Pims.Dal.Entities;
 using Model = Pims.Api.Areas.Admin.Models.Agency;
+using EModel = Pims.Dal.Entities.Models;
 
 namespace Pims.Api.Areas.Admin.Controllers
 {
@@ -68,6 +69,23 @@ namespace Pims.Api.Areas.Admin.Controllers
         {
             var agency = _pimsAdminService.Agency.Get(id);
             return new JsonResult(_mapper.Map<Model.AgencyModel>(agency));
+        }
+
+        /// <summary>
+        /// GET - Returns a paged array of agencies from the datasource.
+        /// </summary>
+        /// <param name="filter"></param>
+        /// <returns>Paged object with an array of agencies.</returns>
+        [HttpPost("filter")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(Api.Models.PageModel<Model.AgencyModel>), 200)]
+        [ProducesResponseType(typeof(Api.Models.ErrorResponseModel), 400)]
+        [SwaggerOperation(Tags = new[] { "admin-agency" })]
+        public IActionResult GetAgencies(EModel.AgencyFilter filter)
+        {
+            var page = _pimsAdminService.Agency.Get(filter);
+            var result = _mapper.Map<Api.Models.PageModel<Model.AgencyModel>>(page);
+            return new JsonResult(result);
         }
 
         /// <summary>

--- a/backend/api/Areas/Admin/Mapping/Agency/AgencyMap.cs
+++ b/backend/api/Areas/Admin/Mapping/Agency/AgencyMap.cs
@@ -10,11 +10,15 @@ namespace Pims.Api.Areas.Admin.Mapping.Agency
         {
             config.NewConfig<Entity.Agency, Model.AgencyModel>()
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.Email, src => src.Email)
+                .Map(dest => dest.SendEmail, src => src.SendEmail)
                 .Map(dest => dest.ParentId, src => src.ParentId)
                 .Inherits<Entity.CodeEntity<int>, Api.Models.CodeModel<int>>();
 
             config.NewConfig<Model.AgencyModel, Entity.Agency>()
                 .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.Email, src => src.Email)
+                .Map(dest => dest.SendEmail, src => src.SendEmail)
                 .Map(dest => dest.ParentId, src => src.ParentId)
                 .Inherits<Api.Models.CodeModel<int>, Entity.CodeEntity<int>>();
         }

--- a/backend/api/Areas/Admin/Models/Agency/AgencyModel.cs
+++ b/backend/api/Areas/Admin/Models/Agency/AgencyModel.cs
@@ -11,6 +11,11 @@ namespace Pims.Api.Areas.Admin.Models.Agency
         /// </summary>
         /// <value></value>
         public string Description { get; set; }
+
+        public string Email { get; set; }
+
+        public string SendEmail { get; set; }
+        
         #endregion
     }
 }

--- a/backend/dal/Services/Admin/IAgencyService.cs
+++ b/backend/dal/Services/Admin/IAgencyService.cs
@@ -1,4 +1,5 @@
 using Pims.Dal.Entities;
+using Pims.Dal.Entities.Models;
 using System.Collections.Generic;
 
 namespace Pims.Dal.Services.Admin
@@ -10,5 +11,7 @@ namespace Pims.Dal.Services.Admin
     {
         IEnumerable<Agency> GetAll();
         Agency Get(int id);
+        Paged<Agency> Get(int page, int quantity);
+        Paged<Agency> Get(AgencyFilter filter);
     }
 }

--- a/backend/entities/Models/AgencyFilter.cs
+++ b/backend/entities/Models/AgencyFilter.cs
@@ -1,0 +1,112 @@
+using Pims.Core.Extensions;
+using System;
+using System.Collections.Generic;
+
+namespace Pims.Dal.Entities.Models
+{
+    /// <summary>
+    /// AgencyFilter class, provides a model for filtering agencies.
+    /// </summary>
+    public class AgencyFilter
+    {
+        #region Properties
+        /// <summary>
+        /// get/set - The page number.
+        /// </summary>
+        /// <value></value>
+        public int Page { get; set; } = 1;
+
+        /// <summary>
+        /// get/set - The quantity to return in each page.
+        /// </summary>
+        /// <value></value>
+        public int Quantity { get; set; } = 10;
+
+        /// <summary>
+        /// get/set - The name of the agency.
+        /// </summary>
+        /// <value></value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// get/set - The parent id of given agency.
+        /// </summary>
+        /// <value></value>
+        public int ParentId { get; set; }
+
+        /// <summary>
+        /// get/set - account status
+        /// </summary>
+        /// <value></value>
+        public bool? IsDisabled { get; set; }
+
+        /// <summary>
+        /// get/set - The agency ID
+        /// </summary>
+        /// <value></value>
+        public int? Id { get; set; }
+
+        /// <summary>
+        /// get/set - An array of sorting conditions (i.e. FirstName desc, LastName asc)
+        /// </summary>
+        /// <value></value>
+        public string[] Sort { get; set; }
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Creates a new instance of a AgencyFilter class.
+        /// </summary>
+        public AgencyFilter() { }
+
+        /// <summary>
+        /// Creates a new instance of a AgencyFilter class, initializes it with the specified arguments.
+        /// </summary>
+        /// <param name="page"></param>
+        /// <param name="quantity"></param>
+        public AgencyFilter(int page, int quantity)
+        {
+            this.Page = page;
+            this.Quantity = quantity;
+        }
+
+        /// <summary>
+        /// Creates a new instance of a AgencyFilter class, initializes it with the specified arguments.
+        /// </summary>
+        /// <param name="page"></param>
+        /// <param name="quantity"></param>
+        /// <param name="name"></param>
+        /// <param name="description"></param>
+        /// <param name="parentId"></param>
+        /// <param name="isDisabled"></param>
+        /// <param name="sort"></param>
+        /// <returns></returns>
+        public AgencyFilter(int page, int quantity, int id, String name, string description, int parentId, bool? isDisabled, string[] sort) : this(page, quantity)
+        {
+            this.Name = name;
+            this.ParentId = parentId;
+            this.IsDisabled = isDisabled;
+            this.Sort = sort;
+            this.Id = id;
+        }
+
+        /// <summary>
+        /// Creates a new instance of a AgencyFilter class, initializes it with the specified arguments.
+        /// Extracts the properties from the query string to generate the filter.
+        /// </summary>
+        /// <param name="query"></param>
+        public AgencyFilter(Dictionary<string, Microsoft.Extensions.Primitives.StringValues> query)
+        {
+            // We want case-insensitive query parameter properties.
+            var filter = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(query, StringComparer.OrdinalIgnoreCase);
+            this.Page = filter.GetIntValue(nameof(this.Page), 1);
+            this.Quantity = filter.GetIntValue(nameof(this.Quantity), 10);
+            this.Name = filter.GetStringValue(nameof(this.Name));
+            this.ParentId = filter.GetIntValue(nameof(this.ParentId));
+            this.IsDisabled = filter.GetValue<bool?>(nameof(this.IsDisabled));
+            this.Id = filter.GetIntValue(nameof(this.Id));
+            this.Sort = filter.GetStringArrayValue(nameof(this.Sort));
+        }
+        #endregion
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19966,6 +19966,7 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -20003,6 +20004,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -20011,6 +20013,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -20061,6 +20064,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -20134,6 +20138,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/frontend/src/actionCreators/agencyActionCreator.ts
+++ b/frontend/src/actionCreators/agencyActionCreator.ts
@@ -1,0 +1,97 @@
+import { showLoading, hideLoading } from 'react-redux-loading-bar';
+import { request, success, error } from 'actions/genericActions';
+import * as actionTypes from 'constants/actionTypes';
+import * as adminActions from 'actions/adminActions';
+import * as API from 'constants/API';
+import { ENVIRONMENT } from 'constants/environment';
+import CustomAxios, { LifecycleToasts } from 'customAxios';
+import { AxiosResponse, AxiosError } from 'axios';
+import { IAddAgency, IAgency, IAgencyDetail } from 'interfaces';
+import { handleAxiosResponse } from 'utils';
+import * as pimsToasts from 'constants/toasts';
+
+export const getAgenciesAction = (params: API.IPaginateParams) => (dispatch: Function) => {
+  dispatch(request(actionTypes.GET_AGENCIES));
+  dispatch(showLoading());
+  return CustomAxios()
+    .post(ENVIRONMENT.apiUrl + API.POST_AGENCIES(), params)
+    .then((response: AxiosResponse) => {
+      dispatch(success(actionTypes.GET_AGENCIES, response.status));
+      dispatch(adminActions.storeAgencies(response.data));
+      dispatch(hideLoading());
+    })
+    .catch((axiosError: AxiosError) =>
+      dispatch(error(actionTypes.GET_AGENCIES, axiosError?.response?.status, axiosError)),
+    )
+    .finally(() => dispatch(hideLoading()));
+};
+
+export const fetchAgencyDetail = (id: API.IAgencyDetailParams) => (dispatch: Function) => {
+  dispatch(request(actionTypes.GET_AGENCY_DETAILS));
+  dispatch(showLoading());
+  return CustomAxios()
+    .get(ENVIRONMENT.apiUrl + API.AGENCY_DETAIL(id))
+    .then((response: AxiosResponse) => {
+      dispatch(success(actionTypes.GET_AGENCY_DETAILS));
+      dispatch(adminActions.storeAgencyDetails(response.data));
+      dispatch(hideLoading());
+    })
+    .catch(() => dispatch(error(actionTypes.GET_AGENCY_DETAILS)))
+    .finally(() => dispatch(hideLoading()));
+};
+
+const agencyToasts: LifecycleToasts = {
+  loadingToast: pimsToasts.agency.AGENCY_UPDATING,
+  successToast: pimsToasts.agency.AGENCY_UPDATED,
+  errorToast: pimsToasts.agency.AGENCY_ERROR,
+};
+
+export const getUpdateAgencyAction = (
+  id: API.IAgencyDetailParams,
+  updatedAgency: IAgencyDetail,
+) => (dispatch: Function) => {
+  const axiosPromise = CustomAxios({ lifecycleToasts: agencyToasts })
+    .put(ENVIRONMENT.apiUrl + API.AGENCY_DETAIL(id), updatedAgency)
+    .then((response: AxiosResponse) => {
+      dispatch(adminActions.updateAgency(response.data));
+      return Promise.resolve(response);
+    });
+  return handleAxiosResponse(
+    dispatch,
+    actionTypes.PUT_AGENCY_DETAILS,
+    axiosPromise,
+  ).catch(() => {});
+};
+
+export const createAgency = (agency: IAddAgency) => async (dispatch: Function) => {
+  dispatch(request(actionTypes.ADD_AGENCY));
+  dispatch(showLoading());
+  try {
+    const { data, status } = await CustomAxios().post(
+      ENVIRONMENT.apiUrl + API.AGENCY_ROOT(),
+      agency,
+    );
+    dispatch(success(actionTypes.ADD_PARCEL, status));
+    dispatch(hideLoading());
+    return data;
+  } catch (axiosError) {
+    dispatch(error(actionTypes.ADD_AGENCY, axiosError?.response?.status, axiosError));
+    dispatch(hideLoading());
+    throw Error(axiosError.response?.data.details);
+  }
+};
+
+export const deleteAgency = (agency: IAgency) => async (dispatch: Function) => {
+  dispatch(request(actionTypes.DELETE_AGENCY));
+  dispatch(showLoading());
+  return await CustomAxios()
+    .delete(ENVIRONMENT.apiUrl + API.AGENCY_ROOT() + `${agency.id}`, { data: agency })
+    .then((response: AxiosResponse) => {
+      dispatch(success(actionTypes.DELETE_AGENCY, response.status));
+      dispatch(hideLoading());
+    })
+    .catch((axiosError: AxiosError) => {
+      dispatch(error(actionTypes.DELETE_AGENCY, axiosError?.response?.status, axiosError));
+    })
+    .finally(() => dispatch(hideLoading()));
+};

--- a/frontend/src/actions/adminActions.ts
+++ b/frontend/src/actions/adminActions.ts
@@ -1,5 +1,14 @@
 import * as ActionTypes from 'constants/actionTypes';
-import { IPagedItems, IUser, IUserDetails, IAgency, IRole, IUsersFilter } from 'interfaces';
+import {
+  IPagedItems,
+  IUser,
+  IUserDetails,
+  IAgency,
+  IRole,
+  IUsersFilter,
+  IAgencyRecord,
+  IAgencyDetail,
+} from 'interfaces';
 import { IUserRecord } from 'features/admin/users/interfaces/IUserRecord';
 import { TableSort } from 'components/Table/TableSort';
 
@@ -82,6 +91,62 @@ export const getUsersPageIndexAction = (pageIndex: number): IUpdateUsersPageInde
 
 export const getUsersSortAction = (sort: TableSort<IUserRecord>): ISortUsersAction => ({
   type: ActionTypes.SORT_USERS,
+  sort,
+});
+
+// agency admin
+export interface IStoreAgencyDetail {
+  type: typeof ActionTypes.STORE_AGENCY_DETAILS;
+  agencyDetail: IAgency;
+}
+
+export interface IStoreAgencyAction {
+  type: typeof ActionTypes.STORE_AGENCY_RESULTS;
+  pagedAgencies: IPagedItems<IAgency>;
+}
+
+export interface IAgencyPaginationAction {
+  type: typeof ActionTypes.STORE_AGENCY_RESULTS;
+  pagedAgencies: IPagedItems<IAgency>;
+}
+
+export interface IGetAgencyAction {
+  type: typeof ActionTypes.GET_AGENCY;
+  pagedAgency: IAgency;
+}
+
+export interface IUpdateAgencyAction {
+  type: typeof ActionTypes.UPDATE_AGENCY;
+  agency: IAgency;
+}
+
+export interface ISortAgenciesAction {
+  type: typeof ActionTypes.SORT_AGENCIES;
+  sort: TableSort<IAgencyDetail>;
+}
+
+export const storeAgencyDetails = (agencyDetail: IAgency) => ({
+  type: ActionTypes.STORE_AGENCY_DETAILS,
+  agencyDetail: agencyDetail,
+});
+
+export const storeAgencies = (apiData: IPagedItems<IAgency>) => ({
+  type: ActionTypes.STORE_AGENCY_RESULTS,
+  pagedAgencies: { ...apiData, pageIndex: apiData.page - 1 },
+});
+
+export const updateAgency = (agency: IAgencyDetail): IUpdateAgencyAction => ({
+  type: ActionTypes.UPDATE_AGENCY,
+  agency,
+});
+
+export const setAgenciesPageSize = (size: number) => ({
+  type: ActionTypes.SET_AGENCIES_PAGE_SIZE,
+  size,
+});
+
+export const getAgenciesSortAction = (sort: TableSort<IAgencyRecord>): ISortAgenciesAction => ({
+  type: ActionTypes.SORT_AGENCIES,
   sort,
 });
 

--- a/frontend/src/components/SearchBar/FilterBar.scss
+++ b/frontend/src/components/SearchBar/FilterBar.scss
@@ -1,5 +1,4 @@
 @import '../../fonts.scss';
-
 .search-bar {
   padding: 12px;
   background-color: #f2f2f2;
@@ -8,5 +7,12 @@
       padding: 0;
       margin: 0;
     }
+  }
+  .vl {
+    border-left: 6px solid #666666;
+    height: 40px;
+    margin-left: 1%;
+    margin-right: 1%;
+    border-width: 1px;
   }
 }

--- a/frontend/src/components/SearchBar/FilterBar.tsx
+++ b/frontend/src/components/SearchBar/FilterBar.tsx
@@ -6,10 +6,24 @@ import { Formik } from 'formik';
 import { Form } from 'components/common/form';
 import ResetButton from 'components/common/form/ResetButton';
 import SearchButton from 'components/common/form/SearchButton';
+import PlusButton from 'components/common/form/PlusButton';
 
 interface IProps<T extends object = {}> {
   initialValues: T;
   onChange: (value: any) => void;
+  /** controls the className of the search button */
+  searchClassName?: string;
+  /** determine whether to hide the reset button */
+  hideReset?: boolean;
+  /** determine whether the plus button is needed for this filter bar */
+  plusButton?: boolean;
+  /** make a heading for this fitler bar */
+  filterBarHeading?: string;
+  /** if the filter bar is enabled to add a new entity control what happens on click */
+  handleAdd?: (value: any) => void;
+  /** the two probs below are for controlling the tool tip for the plust button */
+  toolTipAddId?: string;
+  toolTipAddText?: string;
 }
 
 const FilterBar = <T extends object = {}>(props: PropsWithChildren<IProps<T>>) => {
@@ -30,13 +44,31 @@ const FilterBar = <T extends object = {}>(props: PropsWithChildren<IProps<T>>) =
       {({ isSubmitting, handleReset }) => (
         <Form>
           <Form.Row className="search-bar">
+            <h3 className="filterBarHeading">{props.filterBarHeading}</h3>
             {props.children}
             <Col className="bar-item flex-grow-0">
-              <SearchButton disabled={isSubmitting} />
+              <SearchButton
+                className={props.searchClassName ? props.searchClassName : 'bg-warning'}
+                disabled={isSubmitting}
+              />
             </Col>
-            <Col className="bar-item flex-grow-0">
-              <ResetButton disabled={isSubmitting} onClick={handleReset} />
-            </Col>
+            {!props.hideReset && (
+              <Col className="bar-item flex-grow-0">
+                <ResetButton disabled={isSubmitting} onClick={handleReset} />
+              </Col>
+            )}
+            {props.plusButton && (
+              <>
+                <div className="vl"></div>
+                <Col className="bar-item flex-grow-0 plus-button">
+                  <PlusButton
+                    onClick={props.handleAdd}
+                    toolTipId={props.toolTipAddId!}
+                    toolTipText={props.toolTipAddText!}
+                  />
+                </Col>
+              </>
+            )}
           </Form.Row>
         </Form>
       )}

--- a/frontend/src/components/SearchBar/__snapshots__/FilterBar.test.tsx.snap
+++ b/frontend/src/components/SearchBar/__snapshots__/FilterBar.test.tsx.snap
@@ -10,11 +10,14 @@ exports[`Filter Bar Snapshot matches 1`] = `
     <div
       className="search-bar form-row"
     >
+      <h3
+        className="filterBarHeading"
+      />
       <div
         className="bar-item flex-grow-0 col"
       >
         <button
-          className="Button Button--icon-only btn btn-warning"
+          className="Button Button--icon-only bg-warning btn btn-primary"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}

--- a/frontend/src/components/common/form/AutoCompleteText.scss
+++ b/frontend/src/components/common/form/AutoCompleteText.scss
@@ -1,9 +1,16 @@
 @import '../../../styles.scss';
-
 .AutoCompleteText {
   width: 300px;
   font-size: 14px;
   position: relative;
+  .input-area {
+    display: flex;
+    .form-label {
+      display: inline-block;
+      align-self: flex-end;
+      width: 250px;
+    }
+  }
 }
 
 .AutoCompleteText form.Control {

--- a/frontend/src/components/common/form/AutoCompleteText.tsx
+++ b/frontend/src/components/common/form/AutoCompleteText.tsx
@@ -17,6 +17,7 @@ export type IAutoCompleteProps = {
   /** to determine whether to show the code or label defaults to label*/
   getValueDisplay?: (value: any) => string;
   agencyType?: 'parent' | 'child';
+  label?: string;
 };
 
 export const AutoCompleteText: React.FC<IAutoCompleteProps> = ({
@@ -28,6 +29,7 @@ export const AutoCompleteText: React.FC<IAutoCompleteProps> = ({
   required,
   getValueDisplay,
   agencyType,
+  label,
 }) => {
   const { values, setFieldValue, errors, touched } = useFormikContext<any>();
   const [suggestions, setSuggestions] = useState<SelectOptions>([]);
@@ -110,16 +112,19 @@ export const AutoCompleteText: React.FC<IAutoCompleteProps> = ({
     // autoComplete will have different value depending on form. eg) 'new-password' is needed to override chrome's address suggestions etc.
     <div className="AutoCompleteText">
       <Form.Group controlId={`input-${field}`}>
-        <Form.Control
-          autoComplete={autoSetting}
-          name={field}
-          value={text}
-          isInvalid={!!touch && !!error}
-          onChange={onTextChanged}
-          placeholder={placeholder}
-          disabled={disabled}
-          required={required}
-        />
+        <div className="input-area">
+          {label && <Form.Label>{label}</Form.Label>}
+          <Form.Control
+            autoComplete={autoSetting}
+            name={field}
+            value={text}
+            isInvalid={!!touch && !!error}
+            onChange={onTextChanged}
+            placeholder={placeholder}
+            disabled={disabled}
+            required={required}
+          />
+        </div>
         {renderSuggestions()}
         <DisplayError field={field} />
       </Form.Group>

--- a/frontend/src/components/common/form/Check.tsx
+++ b/frontend/src/components/common/form/Check.tsx
@@ -4,6 +4,7 @@ import { Form, FormCheckProps } from 'react-bootstrap';
 import { useFormikContext, getIn } from 'formik';
 import { DisplayError } from './DisplayError';
 import classNames from 'classnames';
+import TooltipIcon from '../TooltipIcon';
 
 type RequiredAttributes = {
   /** The field name */
@@ -35,6 +36,10 @@ type OptionalAttributes = {
   radioLabelOne?: string;
   /** label of the second radio button */
   radioLabelTwo?: string;
+  /** Optional tool tip message to add to checkbox */
+  toolTip?: string;
+  /** id for tooltip */
+  toolTipId?: string;
 };
 
 // only "field" is required for <Check>, the rest are optional
@@ -57,6 +62,8 @@ export const Check: React.FC<CheckProps> = ({
   custom,
   radioLabelOne,
   radioLabelTwo,
+  toolTip,
+  toolTipId,
   ...rest
 }) => {
   const { values, setFieldValue, errors, touched } = useFormikContext();
@@ -74,6 +81,7 @@ export const Check: React.FC<CheckProps> = ({
           <Form.Label>
             {label}
             {!!required && <span className="required">*</span>}
+            {!!toolTip && <TooltipIcon toolTipId={toolTipId!} toolTip={toolTip} />}
           </Form.Label>
         )}
         <>

--- a/frontend/src/components/common/form/PlusButton.tsx
+++ b/frontend/src/components/common/form/PlusButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import TooltipWrapper from '../TooltipWrapper';
+import { FaPlus } from 'react-icons/fa';
+import { Button, ButtonProps } from '.';
+
+interface IPlusButtonProps extends ButtonProps {
+  /** set the text of the tooltip that appears on hover of the plus button */
+  toolTipText: string;
+  /** set the id of the tool tip use for on hover of the plus buttons */
+  toolTipId: string;
+}
+
+/**
+ * PlusButton displaying a plus button, used to add new items.
+ * @param param0
+ */
+const PlusButton: React.FC<IPlusButtonProps> = ({ ...props }) => {
+  return (
+    <TooltipWrapper toolTipId={props.toolTipId} toolTip={props.toolTipText}>
+      <Button className="bg-success" {...props} icon={<FaPlus size={20} />} />
+    </TooltipWrapper>
+  );
+};
+
+export default PlusButton;

--- a/frontend/src/components/common/form/SearchButton.tsx
+++ b/frontend/src/components/common/form/SearchButton.tsx
@@ -10,7 +10,12 @@ import { Button, ButtonProps } from '.';
 const SearchButton: React.FC<ButtonProps> = ({ ...props }) => {
   return (
     <TooltipWrapper toolTipId="map-filter-search-tooltip" toolTip="Search">
-      <Button type="submit" variant="warning" {...props} icon={<FaSearch size={20} />} />
+      <Button
+        type="submit"
+        className={props.className ?? 'bg-warning'}
+        {...props}
+        icon={<FaSearch size={20} />}
+      />
     </TooltipWrapper>
   );
 };

--- a/frontend/src/components/common/form/__snapshots__/AutoCompleteText.test.tsx.snap
+++ b/frontend/src/components/common/form/__snapshots__/AutoCompleteText.test.tsx.snap
@@ -12,13 +12,17 @@ exports[`Auto Complete Text component renders correctly 1`] = `
     <div
       className="form-group"
     >
-      <input
-        className="form-control"
-        id="input-city"
-        name="city"
-        onChange={[Function]}
-        value=""
-      />
+      <div
+        className="input-area"
+      >
+        <input
+          className="form-control"
+          id="input-city"
+          name="city"
+          onChange={[Function]}
+          value=""
+        />
+      </div>
     </div>
   </div>
 </form>

--- a/frontend/src/components/layout/AppNavBar/AppNavBar.tsx
+++ b/frontend/src/components/layout/AppNavBar/AppNavBar.tsx
@@ -126,6 +126,7 @@ function AdminDropdown() {
       <NavDropdown.Item onClick={() => history.push('/admin/access/requests')}>
         Access Requests
       </NavDropdown.Item>
+      <NavDropdown.Item onClick={() => history.push('/admin/agencies')}>Agencies</NavDropdown.Item>
     </NavDropdown>
   ) : null;
 }

--- a/frontend/src/components/maps/__snapshots__/MapFilterBar.test.tsx.snap
+++ b/frontend/src/components/maps/__snapshots__/MapFilterBar.test.tsx.snap
@@ -84,15 +84,19 @@ exports[`MapFilterBar renders correctly 1`] = `
         <div
           className="form-group"
         >
-          <input
-            autoComplete="off"
-            className="form-control"
-            id="input-agencies"
-            name="agencies"
-            onChange={[Function]}
-            placeholder="Enter an agency"
-            value=""
-          />
+          <div
+            className="input-area"
+          >
+            <input
+              autoComplete="off"
+              className="form-control"
+              id="input-agencies"
+              name="agencies"
+              onChange={[Function]}
+              placeholder="Enter an agency"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -187,7 +191,7 @@ exports[`MapFilterBar renders correctly 1`] = `
       className="bar-item flex-grow-0 col"
     >
       <button
-        className="Button Button--icon-only btn btn-warning"
+        className="Button Button--icon-only bg-warning btn btn-primary"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}

--- a/frontend/src/constants/API.ts
+++ b/frontend/src/constants/API.ts
@@ -20,6 +20,12 @@ export interface IGetUsersParams extends IPaginateParams {
   position?: string;
 }
 
+export interface IGetAgenciesParams extends IPaginateParams {
+  name?: string;
+  description?: string;
+  isDisabled?: boolean;
+}
+
 export interface IPaginateAccessRequests extends IPaginateParams {
   status?: AccessRequestStatus | null;
 }
@@ -55,6 +61,13 @@ export const PARCEL_ROOT = `/properties/parcels`;
 export interface IUserDetailParams {
   id: string;
 }
+
+export interface IAgencyDetailParams {
+  id: string;
+}
+
+export const AGENCY_ROOT = () => `/admin/agencies/`;
+export const AGENCY_DETAIL = (params: IAgencyDetailParams) => `/admin/agencies/${params.id}`;
 export const USER_DETAIL = (params: IUserDetailParams) => `/admin/users/${params.id}`;
 export const KEYCLOAK_USER_UPDATE = (params: IUserDetailParams) => `/keycloak/users/${params.id}`;
 
@@ -75,6 +88,9 @@ export const PROPERTY_CLASSIFICATION_CODE_SET_NAME = 'PropertyClassification';
 export const CONSTRUCTION_CODE_SET_NAME = 'BuildingConstructionType';
 export const PREDOMINATE_USE_CODE_SET_NAME = 'BuildingPredominateUse';
 export const OCCUPANT_TYPE_CODE_SET_NAME = 'BuildingOccupantType';
+
+// Agencies
+export const POST_AGENCIES = () => `/admin/agencies/filter`; // get paged list of agencies
 
 // Auth Service
 export const ACTIVATE_USER = () => `/auth/activate`; // get filtered properties or all if not specified.

--- a/frontend/src/constants/actionTypes.ts
+++ b/frontend/src/constants/actionTypes.ts
@@ -21,6 +21,21 @@ export const DELETE_PARCEL = 'DELETE_PARCEL';
 export const STORE_LOOKUP_CODE_RESULTS = 'STORE_LOOKUP_CODE_RESULTS';
 export const GET_LOOKUP_CODES = 'lookupCodes';
 
+// Agencies
+export const STORE_AGENCY_RESULTS = 'STORE_AGENCY_RESULTS';
+export const STORE_AGENCY_DETAILS = 'STORE_AGENCY_DETAILS';
+export const GET_AGENCIES = 'agencies';
+export const GET_AGENCY = 'GET_AGENCY';
+export const UPDATE_AGENCY = 'UPDATE_USER';
+export const SORT_AGENCIES = 'SORT_AGENCIES';
+export const FILTER_AGENCIES = 'FILTER_AGENCIES';
+export const SET_AGENCIES_PAGE_SIZE = 'SET_AGENCIES_PAGE_SIZE';
+export const SET_AGENCIES_PAGE_INDEX = 'SET_AGENCIES_PAGE_INDEX';
+export const GET_AGENCY_DETAILS = 'GET_AGENCY_DETAILS';
+export const PUT_AGENCY_DETAILS = 'PUT_AGENCY_DETAILS';
+export const ADD_AGENCY = 'ADD_AGENCY';
+export const DELETE_AGENCY = 'DELETE_AGENCY';
+
 // access requests
 export const STORE_ACCESS_REQUESTS = 'STORE_ACCESS_REQUESTS';
 export const ADD_REQUEST_ACCESS = 'addRequestAccess';

--- a/frontend/src/constants/reducerTypes.ts
+++ b/frontend/src/constants/reducerTypes.ts
@@ -12,6 +12,10 @@ export const ACCESS_REQUEST = 'accessRequest';
 // Users
 export const USERS = 'users';
 
+// Agencies
+export const AGENCIES = 'agencies';
+export const GET_AGENCY_DETAIL = 'GET_AGENCY_DETAIL';
+
 export const NETWORK = 'network';
 
 export const APP_ERRORS = 'appErrors';

--- a/frontend/src/constants/toasts.ts
+++ b/frontend/src/constants/toasts.ts
@@ -69,3 +69,20 @@ export const parcel = {
   PARCEL_DELETING_ERROR_TOAST_ID,
   PARCEL_DELETING_ERROR,
 };
+
+/** These toasts are used by the update agency api */
+const AGENCY_UPDATING_TOAST_ID = 'UPDATING_AGENCY';
+const AGENCY_UPDATING = () =>
+  toast.dark('Updating Agency...', { toastId: AGENCY_UPDATING_TOAST_ID });
+const AGENCY_UPDATED_TOAST_ID = 'AGENCY_UPDATED';
+const AGENCY_UPDATED = () => toast.dark('Agency updated', { toastId: AGENCY_UPDATED_TOAST_ID });
+const AGENCY_ERROR_TOAST_ID = 'AGENCY_ERROR';
+const AGENCY_ERROR = () => toast.error('Failed to update Agency', { toastId: USER_ERROR_TOAST_ID });
+export const agency = {
+  AGENCY_UPDATING_TOAST_ID,
+  AGENCY_UPDATING,
+  AGENCY_UPDATED_TOAST_ID,
+  AGENCY_UPDATED,
+  AGENCY_ERROR_TOAST_ID,
+  AGENCY_ERROR,
+};

--- a/frontend/src/features/admin/agencies/AgencyFilterBar.tsx
+++ b/frontend/src/features/admin/agencies/AgencyFilterBar.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import FilterBar from 'components/SearchBar/FilterBar';
+import { Col } from 'react-bootstrap';
+import { AutoCompleteText } from 'components/common/form';
+import { IAgencyFilter } from 'interfaces';
+import useCodeLookups from 'hooks/useLookupCodes';
+
+interface IProps {
+  value: IAgencyFilter;
+  onChange: (value: IAgencyFilter) => void;
+  handleAdd: (value: any) => void;
+}
+
+export const AgencyFilterBar: React.FC<IProps> = ({ value, onChange, handleAdd }) => {
+  const lookupCodes = useCodeLookups();
+  const agencyOptions = lookupCodes.getOptionsByType('Agency');
+
+  return (
+    <FilterBar<IAgencyFilter>
+      initialValues={value}
+      onChange={onChange}
+      searchClassName="bg-primary"
+      plusButton={true}
+      filterBarHeading="Agencies"
+      handleAdd={handleAdd}
+      toolTipAddId="agency-filter-add"
+      toolTipAddText="Add a new Agency"
+    >
+      <Col className="d-item">
+        {/* TODO: Swap out with new auto complete after grouping complete*/}
+        <AutoCompleteText
+          autoSetting="off"
+          field="id"
+          options={agencyOptions!}
+          placeholder="Enter an agency"
+          label="Search by Name: "
+        />
+      </Col>
+    </FilterBar>
+  );
+};

--- a/frontend/src/features/admin/agencies/EditAgencyPage.scss
+++ b/frontend/src/features/admin/agencies/EditAgencyPage.scss
@@ -1,0 +1,32 @@
+@import '../../../variables';
+.navBar {
+  font-weight: 700;
+  text-align: left;
+}
+
+.required {
+  color: red;
+  font-weight: 700;
+}
+
+.agency-edit-form-container {
+  justify-content: center;
+  margin-top: 20px;
+  margin-bottom: $footer-height;
+  .agencyInfo {
+    .label,
+    .form-label {
+      float: left;
+    }
+    .buttons {
+      .cancelSave {
+        margin-top: 100px;
+      }
+    }
+    .checkboxes {
+      margin-top: 10px;
+      float: left;
+      margin-bottom: 10px;
+    }
+  }
+}

--- a/frontend/src/features/admin/agencies/EditAgencyPage.tsx
+++ b/frontend/src/features/admin/agencies/EditAgencyPage.tsx
@@ -1,0 +1,213 @@
+import React, { useEffect, useState } from 'react';
+import { Navbar, Container, Row, ButtonToolbar, Button } from 'react-bootstrap';
+import { Check, Form, Input, Select, SelectOption } from '../../../components/common/form';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'reducers/rootReducer';
+import { IAgencyDetail } from 'interfaces';
+import { Formik } from 'formik';
+import * as API from 'constants/API';
+import './EditAgencyPage.scss';
+import { useHistory } from 'react-router-dom';
+import useCodeLookups from 'hooks/useLookupCodes';
+import { ILookupCode } from 'actions/lookupActions';
+import {
+  createAgency,
+  deleteAgency,
+  fetchAgencyDetail,
+  getUpdateAgencyAction,
+} from 'actionCreators/agencyActionCreator';
+import { FaArrowAltCircleLeft } from 'react-icons/fa';
+import GenericModal from 'components/common/GenericModal';
+
+interface IEditAgencyPageProps {
+  /** id prop to identify which agency to edit */
+  id: number;
+  match?: any;
+}
+
+/** This page is used to either add a new agency or edit the and agency's details */
+const EditAgencyPage = (props: IEditAgencyPageProps) => {
+  const agencyId = props?.match?.params?.id || props.id;
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const newAgency = history.location.pathname.includes('/new');
+  const [showDelete, setShowDelete] = useState(false);
+  useEffect(() => {
+    if (!newAgency) {
+      dispatch(fetchAgencyDetail({ id: agencyId }));
+    }
+  }, [dispatch, agencyId, newAgency]);
+
+  const { getByType } = useCodeLookups();
+  const agencies = getByType(API.AGENCY_CODE_SET_NAME);
+
+  const agency = useSelector<RootState, IAgencyDetail>(
+    state => state.GET_AGENCY_DETAIL as IAgencyDetail,
+  );
+  const mapLookupCode = (code: ILookupCode): SelectOption => ({
+    label: code.name,
+    value: code.id.toString(),
+    selected: !!agency.parentId,
+  });
+  //
+  const selectAgencies = agencies.map(c => mapLookupCode(c));
+
+  const checkAgencies = (
+    <Select
+      label="Parent Agency - If applicable"
+      field="parentId"
+      data-testid="agency"
+      options={selectAgencies}
+      placeholder={newAgency ? 'Please select if applicable' : undefined}
+    />
+  );
+
+  const goBack = () => {
+    history.push('/admin/agencies');
+  };
+
+  const newValues: any = {
+    code: '',
+    name: '',
+    description: '',
+    isDisabled: false,
+    sendEmail: true,
+    email: '',
+    rowVersion: '',
+  };
+
+  const initialValues: IAgencyDetail = {
+    ...agency,
+  };
+
+  return (
+    <div>
+      {showDelete && <DeleteModal {...{ showDelete, setShowDelete, history, dispatch, agency }} />}
+      <Navbar className="navBar" expand="sm" variant="light" bg="light">
+        <Navbar.Brand href="#">
+          {' '}
+          <FaArrowAltCircleLeft onClick={goBack} size={20} /> Agency Information
+        </Navbar.Brand>
+      </Navbar>
+      <Container fluid={true}>
+        <Row className="agency-edit-form-container">
+          <Formik
+            enableReinitialize
+            initialValues={newAgency ? newValues : initialValues}
+            onSubmit={async (values, { setSubmitting, setStatus }) => {
+              try {
+                if (!newAgency) {
+                  dispatch(
+                    getUpdateAgencyAction(
+                      { id: agencyId },
+                      {
+                        id: agency.id,
+                        name: values.name,
+                        code: values.code,
+                        email: values.email,
+                        isDisabled: values.isDisabled,
+                        sendEmail: values.sendEmail,
+                        parentId: Number(values.parentId),
+                        description: values.description,
+                        rowVersion: values.rowVersion,
+                      },
+                    ),
+                  );
+                } else {
+                  const data = await createAgency({
+                    name: values.name,
+                    code: values.code,
+                    email: values.email,
+                    isDisabled: values.isDisabled,
+                    sendEmail: values.sendEmail,
+                    parentId: Number(values.parentId),
+                    description: values.description,
+                  })(dispatch);
+                  history.replace(`/admin/agency/${data.id}`);
+                }
+              } catch (error) {
+                const msg: string =
+                  error?.response?.data?.error ?? 'Error saving property data, please try again.';
+                setStatus({ msg });
+              } finally {
+                setSubmitting(false);
+              }
+            }}
+          >
+            {props => (
+              <Form className="agencyInfo">
+                <Input label="Agency" required field="name" value={props.values.name} type="text" />
+                <Input
+                  label="Short Name (Code)"
+                  field="code"
+                  value={props.values.code}
+                  type="text"
+                />
+                {checkAgencies}
+                <Input label="Description" field="description" type="text" />
+                <Input label="Agency e-mail address" field="email" type="text" />
+
+                <Form.Group className="checkboxes">
+                  <Check
+                    toolTip="Toggle to change Agency status and click Save"
+                    toolTipId="is-disabled-tooltip"
+                    field="isDisabled"
+                    label="Is Disabled?"
+                  />
+                  <Check
+                    toolTip="Toggle to change whether to send an email and click Save"
+                    toolTipId="email-tooltip"
+                    field="sendEmail"
+                    label="Send email?"
+                  />
+                </Form.Group>
+
+                <hr></hr>
+                <Row className="buttons">
+                  <ButtonToolbar className="cancelSave">
+                    {!newAgency ? (
+                      <Button
+                        className="bg-danger mr-5"
+                        type="button"
+                        onClick={() => setShowDelete(true)}
+                      >
+                        Delete Agency
+                      </Button>
+                    ) : (
+                      <Button className="bg-danger mr-5" type="button" onClick={() => goBack()}>
+                        Cancel
+                      </Button>
+                    )}
+
+                    <Button className="mr-5" type="submit">
+                      {newAgency ? 'Save' : 'Save Changes'}
+                    </Button>
+                  </ButtonToolbar>
+                </Row>
+              </Form>
+            )}
+          </Formik>
+        </Row>
+      </Container>
+    </div>
+  );
+};
+
+export default EditAgencyPage;
+
+const DeleteModal = ({ showDelete, setShowDelete, history, dispatch, agency }: any) => (
+  <GenericModal
+    message="Are you sure you want to permanently delete the agency?"
+    cancelButtonText="Cancel"
+    okButtonText="Delete"
+    display={showDelete}
+    handleOk={() => {
+      dispatch(deleteAgency(agency)).then(() => {
+        history.push('/admin/agencies');
+      });
+    }}
+    handleCancel={() => {
+      setShowDelete(false);
+    }}
+  />
+);

--- a/frontend/src/features/admin/agencies/ManageAgencies.scss
+++ b/frontend/src/features/admin/agencies/ManageAgencies.scss
@@ -1,0 +1,36 @@
+$header-height: 72px;
+$footer-height: 46px;
+$navbar-height: 45px;
+$filter-height: 76px;
+$contentheading-height: 60px;
+.ManageAgencies {
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  .agency-toolbar {
+    padding: 0;
+    background-color: var(--light);
+    .search-bar {
+      .filterBarHeading {
+        margin-left: 500px;
+        margin-right: 100px;
+      }
+      .plus-button {
+        margin-right: 600px;
+      }
+    }
+  }
+  .table-section {
+    margin-left: 15%;
+    margin-right: 15%;
+    padding: 1rem 2rem;
+    // display: flex;
+    max-height: calc(
+      100vh - #{$header-height} - #{$navbar-height} - #{$filter-height} - #{$footer-height}
+    );
+    table {
+      background-color: white;
+    }
+  }
+}

--- a/frontend/src/features/admin/agencies/ManageAgencies.tsx
+++ b/frontend/src/features/admin/agencies/ManageAgencies.tsx
@@ -1,0 +1,112 @@
+import './ManageAgencies.scss';
+import React, { useMemo, useCallback, useState } from 'react';
+import { Container } from 'react-bootstrap';
+import { Table } from 'components/Table';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'reducers/rootReducer';
+import { columnDefinitions } from '../constants';
+import { IAgenciesState } from 'reducers/agencyReducer';
+import { IAgency, IAgencyDetail, IAgencyFilter, IAgencyRecord, IPagedItems } from 'interfaces';
+import { getAgenciesAction } from 'actionCreators/agencyActionCreator';
+import { toFilteredApiPaginateParams } from 'utils/CommonFunctions';
+import { TableSort } from 'components/Table/TableSort';
+import { IGenericNetworkAction } from 'actions/genericActions';
+import * as actionTypes from 'constants/actionTypes';
+import { generateSortCriteria } from 'utils';
+import { AgencyFilterBar } from './AgencyFilterBar';
+import useCodeLookups from 'hooks/useLookupCodes';
+import { useHistory } from 'react-router-dom';
+
+const ManageAgencies: React.FC<any> = ({ filterable, title, mode }) => {
+  const columns = useMemo(() => columnDefinitions, []);
+  const dispatch = useDispatch();
+  const [filter, setFilter] = useState<IAgencyFilter>({});
+  const lookupCodes = useCodeLookups();
+  const agencyLookupCodes = lookupCodes.getByType('Agency');
+  const history = useHistory();
+
+  const pagedAgencies = useSelector<RootState, IPagedItems<IAgency>>(state => {
+    return (state.agencies as IAgenciesState).pagedAgencies;
+  });
+
+  const pageSize = useSelector<RootState, number>(state => {
+    return (state.agencies as IAgenciesState).rowsPerPage;
+  });
+
+  const pageIndex = useSelector<RootState, number>(state => {
+    return (state.agencies as IAgenciesState).pageIndex;
+  });
+
+  const sort = useSelector<RootState, TableSort<IAgencyDetail>>(state => {
+    return (state.agencies as IAgenciesState).sort;
+  });
+
+  const agencies = useSelector<RootState, IGenericNetworkAction>(
+    state => (state.network as any)[actionTypes.GET_AGENCIES] as IGenericNetworkAction,
+  );
+
+  const onRowClick = (row: IAgencyRecord) => {
+    history.push(`/admin/agency/${row.id}`);
+  };
+
+  let agencyList = pagedAgencies.items.map(
+    (a: IAgency): IAgencyRecord => ({
+      name: a.name,
+      code: a.code,
+      description: a.description,
+      parentId: a.parentId,
+      id: a.id,
+      parent: agencyLookupCodes.find(x => x.id === a.parentId)?.name,
+    }),
+  );
+
+  const onRequestData = useCallback(
+    ({ pageIndex }) => {
+      dispatch(
+        getAgenciesAction(
+          toFilteredApiPaginateParams<IAgencyFilter>(
+            pageIndex,
+            pageSize,
+            sort && sort.column && sort.direction
+              ? [generateSortCriteria(sort.column, sort.direction)]
+              : undefined,
+            filter,
+          ),
+        ),
+      );
+    },
+    [dispatch, filter, pageSize, sort],
+  );
+
+  return (
+    <Container fluid className="ManageAgencies">
+      <Container fluid className="agency-toolbar">
+        <AgencyFilterBar
+          value={filter}
+          onChange={value => {
+            setFilter({ ...value });
+          }}
+          handleAdd={() => {
+            history.push('/admin/agency/new');
+          }}
+        />
+      </Container>
+      <div className="table-section">
+        <Table<IAgencyRecord>
+          name="agenciesTable"
+          columns={columns}
+          pageIndex={pageIndex}
+          data={agencyList}
+          onRowClick={onRowClick}
+          onRequestData={onRequestData}
+          pageSize={pageSize}
+          pageCount={Math.ceil(pagedAgencies.total / pageSize)}
+          loading={!(agencies && !agencies.isFetching)}
+          lockPageSize={true}
+        />
+      </div>
+    </Container>
+  );
+};
+
+export default () => <ManageAgencies />;

--- a/frontend/src/features/admin/constants/index.tsx
+++ b/frontend/src/features/admin/constants/index.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { ColumnWithProps } from 'components/Table';
+import { CellProps } from 'react-table';
+import { Link } from 'react-router-dom';
+import { IAgency, IAgencyRecord } from 'interfaces';
+
+export const columnDefinitions: ColumnWithProps<IAgencyRecord>[] = [
+  {
+    Header: 'Agency name',
+    accessor: 'name',
+    align: 'left',
+    sortable: true,
+    clickable: true,
+  },
+  {
+    Header: 'Short name',
+    accessor: 'code',
+    align: 'left',
+    clickable: true,
+    sortable: true,
+  },
+  {
+    Header: 'Description',
+    accessor: 'description',
+    align: 'left',
+    clickable: true,
+    sortable: true,
+  },
+  {
+    Header: 'Parent Agency',
+    accessor: 'parent',
+    align: 'left',
+    clickable: true,
+    Cell: (props: CellProps<IAgency>) => {
+      return (
+        <Link to={`/admin/agency/${props.row.original.parentId}`}>{props.row.original.parent}</Link>
+      );
+    },
+    sortable: true,
+  },
+];

--- a/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`Manage Users Component Snapshot matches 1`] = `
     <div
       className="search-bar form-row"
     >
+      <h3
+        className="filterBarHeading"
+      />
       <div
         className="bar-item col"
       >
@@ -155,7 +158,7 @@ exports[`Manage Users Component Snapshot matches 1`] = `
         className="bar-item flex-grow-0 col"
       >
         <button
-          className="Button Button--icon-only btn btn-warning"
+          className="Button Button--icon-only bg-warning btn btn-primary"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`renders correctly 1`] = `
             className="bar-item flex-grow-0 col"
           >
             <button
-              className="Button Button--icon-only btn btn-warning"
+              className="Button Button--icon-only bg-warning btn btn-primary"
               disabled={false}
               onBlur={[Function]}
               onFocus={[Function]}

--- a/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
@@ -174,16 +174,20 @@ exports[`GRE Transfer Step renders correctly 1`] = `
         <div
           className="form-group"
         >
-          <input
-            autoComplete="new-password"
-            className="form-control"
-            disabled={true}
-            id="input-agencyId"
-            name="agencyId"
-            onChange={[Function]}
-            required={true}
-            value=""
-          />
+          <div
+            className="input-area"
+          >
+            <input
+              autoComplete="new-password"
+              className="form-control"
+              disabled={true}
+              id="input-agencyId"
+              name="agencyId"
+              onChange={[Function]}
+              required={true}
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
@@ -15,6 +15,9 @@ exports[`Project list view tests Matches snapshot 1`] = `
       <div
         className="search-bar form-row"
       >
+        <h3
+          className="filterBarHeading"
+        />
         <div
           className="bar-item col-2"
         >
@@ -46,15 +49,19 @@ exports[`Project list view tests Matches snapshot 1`] = `
             <div
               className="form-group"
             >
-              <input
-                autoComplete="off"
-                className="form-control"
-                id="input-agencies"
-                name="agencies"
-                onChange={[Function]}
-                placeholder="Enter an agency"
-                value=""
-              />
+              <div
+                className="input-area"
+              >
+                <input
+                  autoComplete="off"
+                  className="form-control"
+                  id="input-agencies"
+                  name="agencies"
+                  onChange={[Function]}
+                  placeholder="Enter an agency"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -79,7 +86,7 @@ exports[`Project list view tests Matches snapshot 1`] = `
           className="bar-item flex-grow-0 col"
         >
           <button
-            className="Button Button--icon-only btn btn-warning"
+            className="Button Button--icon-only bg-warning btn btn-primary"
             disabled={false}
             onBlur={[Function]}
             onFocus={[Function]}

--- a/frontend/src/features/properties/components/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
@@ -34,12 +34,16 @@ exports[`ParcelDetail Functionality ParcelDetailForm renders view-only correctly
               </div>
               <div class=\\"form-row\\"><label class=\\"form-label\\">Agency</label>
                 <div class=\\"AutoCompleteText\\">
-                  <div class=\\"form-group\\"><input name=\\"agencyId\\" id=\\"input-agencyId\\" class=\\"form-control\\" value=\\"TEST\\"></div>
+                  <div class=\\"form-group\\">
+                    <div class=\\"input-area\\"><input name=\\"agencyId\\" id=\\"input-agencyId\\" class=\\"form-control\\" value=\\"TEST\\"></div>
+                  </div>
                 </div>
               </div>
               <div class=\\"form-row\\"><label class=\\"form-label\\">Sub-Agency</label>
                 <div class=\\"AutoCompleteText\\">
-                  <div class=\\"form-group\\"><input name=\\"agencyId\\" id=\\"input-agencyId\\" class=\\"form-control\\" value=\\"\\"></div>
+                  <div class=\\"form-group\\">
+                    <div class=\\"input-area\\"><input name=\\"agencyId\\" id=\\"input-agencyId\\" class=\\"form-control\\" value=\\"\\"></div>
+                  </div>
                 </div>
               </div>
               <div class=\\"form-row\\"><label class=\\"form-label\\"></label>

--- a/frontend/src/features/properties/components/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
@@ -117,14 +117,18 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
           <div
             className="form-group"
           >
-            <input
-              className="form-control"
-              disabled={true}
-              id="input-agencyId"
-              name="agencyId"
-              onChange={[Function]}
-              value=""
-            />
+            <div
+              className="input-area"
+            >
+              <input
+                className="form-control"
+                disabled={true}
+                id="input-agencyId"
+                name="agencyId"
+                onChange={[Function]}
+                value=""
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -142,14 +146,18 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
           <div
             className="form-group"
           >
-            <input
-              className="form-control"
-              disabled={true}
-              id="input-agencyId"
-              name="agencyId"
-              onChange={[Function]}
-              value=""
-            />
+            <div
+              className="input-area"
+            >
+              <input
+                className="form-control"
+                disabled={true}
+                id="input-agencyId"
+                name="agencyId"
+                onChange={[Function]}
+                value=""
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/features/properties/components/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
@@ -209,14 +209,18 @@ Array [
           <div
             className="form-group"
           >
-            <input
-              className="form-control"
-              disabled={true}
-              id="input-buildings.0.agencyId"
-              name="buildings.0.agencyId"
-              onChange={[Function]}
-              value=""
-            />
+            <div
+              className="input-area"
+            >
+              <input
+                className="form-control"
+                disabled={true}
+                id="input-buildings.0.agencyId"
+                name="buildings.0.agencyId"
+                onChange={[Function]}
+                value=""
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -234,14 +238,18 @@ Array [
           <div
             className="form-group"
           >
-            <input
-              className="form-control"
-              disabled={true}
-              id="input-buildings.0.agencyId"
-              name="buildings.0.agencyId"
-              onChange={[Function]}
-              value=""
-            />
+            <div
+              className="input-area"
+            >
+              <input
+                className="form-control"
+                disabled={true}
+                id="input-buildings.0.agencyId"
+                name="buildings.0.agencyId"
+                onChange={[Function]}
+                value=""
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -207,10 +207,7 @@ const PropertyListView: React.FC = () => {
   };
 
   const checkExpanded = (row: IProperty, property: IProperty) => {
-    const latLongcheck = row.latitude === property.latitude && row.longitude === property.longitude;
-    const propertyTypeCheck = row.propertyTypeId === property.propertyTypeId;
-    const pidOrPinCheck = row.pid === property.pid || row.pin === property.pin;
-    return latLongcheck && propertyTypeCheck && pidOrPinCheck;
+    return row.id === property.id;
   };
 
   const loadBuildings = async (expandedRows: IProperty[]) => {

--- a/frontend/src/features/properties/list/__snapshots__/FilterBar.test.tsx.snap
+++ b/frontend/src/features/properties/list/__snapshots__/FilterBar.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`FilterBar renders correctly 1`] = `
       className="bar-item flex-grow-0 col"
     >
       <button
-        className="Button Button--icon-only btn btn-warning"
+        className="Button Button--icon-only bg-warning btn btn-primary"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}

--- a/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
+++ b/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
@@ -180,7 +180,7 @@ Array [
               className="bar-item flex-grow-0 col"
             >
               <button
-                className="Button Button--icon-only btn btn-warning"
+                className="Button Button--icon-only bg-warning btn btn-primary"
                 disabled={false}
                 onBlur={[Function]}
                 onFocus={[Function]}

--- a/frontend/src/interfaces/agency.ts
+++ b/frontend/src/interfaces/agency.ts
@@ -1,4 +1,53 @@
 export interface IAgency {
-  id: string;
+  parentId: any;
+  code: string;
+  id: number;
+  name: string;
+  description?: string;
+  /** string value of parent not given by api but found by frontend */
+  parent?: string;
+}
+
+/** for use in editing and viewing agency details */
+export interface IAgencyDetail {
+  parentId: number;
+  email: string;
+  id: number;
+  name: string;
+  description?: string;
+  isDisabled: boolean;
+  sendEmail: boolean;
+  code: string;
+  rowVersion: string;
+  parent?: string;
+}
+
+/** for use in filtering agencies*/
+export interface IAgencyFilter {
   name?: string;
+  description?: string;
+  id?: number;
+}
+
+/** for use in creating an agency */
+export interface IAddAgency {
+  name: string;
+  code: string;
+  email?: string;
+  isDisabled: boolean;
+  sendEmail: boolean;
+  parentId?: number;
+  description?: string;
+}
+
+/** for use in agency tables */
+export interface IAgencyRecord {
+  name: string;
+  id: number;
+  code: string;
+  description?: string;
+  parentId?: number;
+  parent?: string;
+  email?: string;
+  sendEmail?: boolean;
 }

--- a/frontend/src/reducers/agencyDetailReducer.tsx
+++ b/frontend/src/reducers/agencyDetailReducer.tsx
@@ -1,0 +1,26 @@
+import * as actionTypes from 'constants/actionTypes';
+import { IStoreAgencyDetail } from 'actions/adminActions';
+import { IAgencyDetail } from 'interfaces';
+
+const initialState: IAgencyDetail = {
+  parentId: -1,
+  code: '',
+  id: -1,
+  name: '',
+  description: '',
+  email: '',
+  isDisabled: false,
+  sendEmail: false,
+  rowVersion: '',
+};
+
+const agencyDetailReducer = (state = initialState, action: IStoreAgencyDetail) => {
+  switch (action.type) {
+    case actionTypes.STORE_AGENCY_DETAILS:
+      return action.agencyDetail;
+    default:
+      return state;
+  }
+};
+
+export default agencyDetailReducer;

--- a/frontend/src/reducers/agencyReducer.tsx
+++ b/frontend/src/reducers/agencyReducer.tsx
@@ -1,0 +1,38 @@
+import * as actionTypes from 'constants/actionTypes';
+import { IStoreAgencyAction } from 'actions/adminActions';
+import { IAgency, IAgencyFilter, IAgencyRecord, IPagedItems } from 'interfaces';
+import { TableSort } from 'components/Table/TableSort';
+import { DEFAULT_PAGE_SIZE } from 'components/Table/constants';
+
+export interface IAgenciesState {
+  pagedAgencies: IPagedItems<IAgency>;
+  rowsPerPage: number;
+  filter: IAgencyFilter;
+  sort: TableSort<IAgencyRecord>;
+  pageIndex: number;
+}
+
+const initialState: IAgenciesState = {
+  pagedAgencies: { page: 1, pageIndex: 0, total: 0, quantity: 0, items: [] },
+  rowsPerPage: DEFAULT_PAGE_SIZE,
+  filter: {},
+  sort: { column: 'name', direction: 'asc' },
+  pageIndex: 0,
+};
+
+const agencyReducer = (state = initialState, action: IStoreAgencyAction) => {
+  switch (action.type) {
+    case actionTypes.STORE_AGENCY_RESULTS:
+      return {
+        ...state,
+        pagedAgencies: {
+          ...action.pagedAgencies,
+          items: [...action.pagedAgencies.items],
+        },
+      };
+    default:
+      return state;
+  }
+};
+
+export default agencyReducer;

--- a/frontend/src/reducers/rootReducer.ts
+++ b/frontend/src/reducers/rootReducer.ts
@@ -20,6 +20,8 @@ import erpTabSlice from 'features/projects/erp/slices/erpTabSlice';
 import splTabSlice from 'features/projects/spl/slices/splTabSlice';
 import projectStatusesSlice from 'features/projects/common/slices/projectStatusesSlice';
 import filterSlice from './filterSlice';
+import agencyReducer from './agencyReducer';
+import agencyDetailReducer from './agencyDetailReducer';
 
 export const reducerObject = {
   loadingBar: loadingBarReducer,
@@ -27,7 +29,9 @@ export const reducerObject = {
   [reducerTypes.ACCESS_REQUEST]: accessRequestReducer,
   [reducerTypes.USERS]: usersReducer,
   [reducerTypes.GET_USER_DETAIL]: userDetailReducer,
+  [reducerTypes.GET_AGENCY_DETAIL]: agencyDetailReducer,
   [reducerTypes.LOOKUP_CODE]: lookupCodeReducer,
+  [reducerTypes.AGENCIES]: agencyReducer,
   [reducerTypes.NETWORK]: networkReducer,
   [reducerTypes.LEAFLET_CLICK_EVENT]: leafletMouseSlice.reducer,
   [reducerTypes.JWT]: jwtSlice.reducer,

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -20,6 +20,8 @@ import { LogoutPage } from 'features/account/Logout';
 import { ProjectRouter } from 'features/projects/common';
 import { ProjectDisposeView } from 'features/projects/dispose';
 import SplReportContainer from 'features/splReports/containers/SplReportContainer';
+import ManageAgencies from 'features/admin/agencies/ManageAgencies';
+import EditAgencyPage from 'features/admin/agencies/EditAgencyPage';
 
 const AppRouter: React.FC = () => {
   const getTitle = (page: string) => {
@@ -139,6 +141,30 @@ const AppRouter: React.FC = () => {
         layout={AuthLayout}
         claim={Claims.ADMIN_USERS}
         title={getTitle('Edit User')}
+      />
+      <AppRoute
+        protected
+        path="/admin/agencies"
+        component={ManageAgencies}
+        layout={AuthLayout}
+        claim={Claims.ADMIN_USERS}
+        title={getTitle('Agency Management')}
+      />
+      <AppRoute
+        protected
+        path="/admin/agency/:id"
+        component={EditAgencyPage}
+        layout={AuthLayout}
+        claim={Claims.ADMIN_USERS}
+        title={getTitle('Edit Agency')}
+      />
+      <AppRoute
+        protected
+        path="/admin/agency/new"
+        component={EditAgencyPage}
+        layout={AuthLayout}
+        claim={Claims.ADMIN_USERS}
+        title={getTitle('Edit Agency')}
       />
       <AppRoute
         protected


### PR DESCRIPTION
Edit/Add/View Agencies 

Also quick bug fix for the view inventory page. Working on the other issues, but want to get this in for testing as it is functional.

Known issues:

- Need to change the way I assign parents to the corresponding agencies

- add typeahead component instead of custom autocomplete after grouping work completed