### PR TITLE
PA-633 Replacing Local ID

### DIFF
--- a/backend/tests/core/Entities/BuildingHelper.cs
+++ b/backend/tests/core/Entities/BuildingHelper.cs
@@ -16,7 +16,8 @@ namespace Pims.Core.Test
         /// </summary>
         /// <param name="parcel"></param>
         /// <param name="id"></param>
-        /// <param name="localId"></param>
+        /// <param name="projectNumber"></param>
+        /// <param name="name"></param>
         /// <param name="lat"></param>
         /// <param name="lng"></param>
         /// <param name="agency"></param>
@@ -81,14 +82,14 @@ namespace Pims.Core.Test
         /// <param name="context"></param>
         /// <param name="parcel"></param>
         /// <param name="id"></param>
-        /// <param name="localId"></param>
+        /// <param name="name"></param>
         /// <param name="lat"></param>
         /// <param name="lng"></param>
         /// <param name="agency"></param>
         /// <returns></returns>
-        public static Entity.Building CreateBuilding(this PimsContext context, Entity.Parcel parcel, int id, string projectNumber = null, string localId = null, int lat = 0, int lng = 0, Entity.Agency agency = null)
+        public static Entity.Building CreateBuilding(this PimsContext context, Entity.Parcel parcel, int id, string projectNumber = null, string name = null, int lat = 0, int lng = 0, Entity.Agency agency = null)
         {
-            localId ??= $"l{id}";
+            name ??= $"l{id}";
             agency ??= parcel.Agency;
             var address = EntityHelper.CreateAddress(id, parcel.Address.Address1, parcel.Address.Address2, parcel.Address.AdministrativeArea, parcel.Address.Province, parcel.Address.Postal);
             var predominateUse = context.BuildingPredominateUses.FirstOrDefault(b => b.Id == 1) ?? EntityHelper.CreateBuildingPredominateUse("use"); ;
@@ -99,6 +100,7 @@ namespace Pims.Core.Test
             var building = new Entity.Building(parcel, lat, lng)
             {
                 Id = id,
+                Name = name,
                 ProjectNumber = projectNumber,
                 AgencyId = agency.Id,
                 Agency = agency,

--- a/frontend/src/actions/parcelsActions.ts
+++ b/frontend/src/actions/parcelsActions.ts
@@ -45,7 +45,6 @@ export interface IAddress {
 export interface IBuilding {
   id: number;
   parcelId: number;
-  localId: string;
   projectNumber?: string;
   name: string;
   description: string;
@@ -67,6 +66,8 @@ export interface IBuilding {
   buildingTenancy: string;
   rentableArea: number | '';
   agencyId: number | '';
+  agency: string;
+  agencyCode: string;
   evaluations: IEvaluation[];
   fiscals: IFiscal[];
 }

--- a/frontend/src/components/maps/BuildingPopupView.scss
+++ b/frontend/src/components/maps/BuildingPopupView.scss
@@ -7,6 +7,17 @@
   text-align: left;
   padding: 10px;
 
+  .row .col .list-group {
+    margin-top: 6px;
+
+    .list-group-item {
+      padding: 0px 0px 5px 0px;
+      border: none;
+      font-family: 'BCSans', Fallback, sans-serif;
+      font-size: 12px;
+    }
+  }
+
   .row .col :first-child {
     margin-top: 0px;
   }
@@ -19,15 +30,6 @@
     font-weight: bold;
   }
 
-  .list-group {
-    margin-top: 6px;
-  }
-  .list-group-item {
-    padding: 0px 0px 5px 0px !important;
-    border: none;
-    font-family: 'BCSans', Fallback, sans-serif;
-    font-size: 12px;
-  }
   .menu {
     text-align: center;
   }

--- a/frontend/src/components/maps/BuildingPopupView.scss
+++ b/frontend/src/components/maps/BuildingPopupView.scss
@@ -5,7 +5,7 @@
   max-width: 250px;
   box-shadow: 1px 2px 2px;
   text-align: left;
-  padding: 12px;
+  padding: 10px;
 
   .row .col :first-child {
     margin-top: 0px;
@@ -13,16 +13,23 @@
 
   .label {
     font-weight: 700;
+    padding-right: 5px;
+  }
+  .name {
+    font-weight: bold;
   }
 
   .list-group {
     margin-top: 6px;
   }
   .list-group-item {
-    padding: 0;
+    padding: 0px 0px 5px 0px !important;
     border: none;
     font-family: 'BCSans', Fallback, sans-serif;
     font-size: 12px;
+  }
+  .menu {
+    text-align: center;
   }
   p {
     margin: 0;

--- a/frontend/src/components/maps/BuildingPopupView.test.tsx
+++ b/frontend/src/components/maps/BuildingPopupView.test.tsx
@@ -24,7 +24,6 @@ const mockBuilding = (agencyId: number) => {
   var building: IBuilding = {
     id: 1,
     parcelId: 1,
-    localId: 'string',
     name: 'test name',
     description: 'Test description',
     address: ([
@@ -48,6 +47,8 @@ const mockBuilding = (agencyId: number) => {
     buildingTenancy: 'string',
     rentableArea: 1,
     agencyId: agencyId,
+    agency: 'agency',
+    agencyCode: 'agency code',
     evaluations: [],
     fiscals: [
       {

--- a/frontend/src/components/maps/BuildingPopupView.tsx
+++ b/frontend/src/components/maps/BuildingPopupView.tsx
@@ -24,63 +24,72 @@ export const BuildingPopupView: React.FC<IBuildingDetailProps> = (props: IBuildi
       {!buildingDetail ? (
         <Alert variant="danger">Failed to load building details.</Alert>
       ) : (
-        <Row>
-          <Col>
-            <ListGroup>
-              <ListGroup.Item>
-                <Label>Name: </Label>
-                {buildingDetail?.name}
-              </ListGroup.Item>
-              <ListGroup.Item>
-                <Label>Description: </Label>
-                {buildingDetail?.description}
-              </ListGroup.Item>
-            </ListGroup>
-            <ListGroup>
-              <ListGroup.Item>
-                <Label>Assessed Value: </Label>$
-                {buildingDetail?.evaluations
-                  ?.find(e => e.key === EvaluationKeys.Assessed)
-                  ?.value?.toLocaleString('en-US', { minimumFractionDigits: 2 })}
-              </ListGroup.Item>
-            </ListGroup>
-            <ListGroup>
-              <ListGroup.Item>
-                <div>
-                  <Label>Address: </Label>
-                  {buildingDetail?.address?.line1}
-                </div>
-                <div>
-                  {buildingDetail?.address?.administrativeArea}, {buildingDetail?.address?.province}{' '}
-                  {buildingDetail?.address?.postal}
-                </div>
-              </ListGroup.Item>
-            </ListGroup>
-            <ListGroup>
-              <ListGroup.Item>
-                <Label>Floor Count: </Label>
-                {buildingDetail?.buildingFloorCount}
-              </ListGroup.Item>
-              <ListGroup.Item>
-                <Label>Predominate Use: </Label>
-                {buildingDetail?.buildingPredominateUse}
-              </ListGroup.Item>
-              {buildingDetail?.projectNumber && (
+        <>
+          <Row>
+            <Col>
+              <ListGroup>
+                <ListGroup.Item className="name">{buildingDetail?.name}</ListGroup.Item>
+                {buildingDetail?.name !== buildingDetail?.description ? (
+                  <ListGroup.Item>{buildingDetail?.description}</ListGroup.Item>
+                ) : null}
+              </ListGroup>
+              <ListGroup>
                 <ListGroup.Item>
-                  <Label>RAEG or SPP: </Label>
-                  {buildingDetail?.projectNumber}
+                  <Label>Assessed Value:</Label>$
+                  {buildingDetail?.evaluations
+                    ?.find(e => e.key === EvaluationKeys.Assessed)
+                    ?.value?.toLocaleString('en-US', { minimumFractionDigits: 2 })}
                 </ListGroup.Item>
-              )}
-            </ListGroup>
-            {!props?.disabled &&
-              (!keycloak.hasAgency(buildingDetail?.agencyId as number) &&
-              !keycloak.hasClaim(Claims.ADMIN_PROPERTIES) ? (
+              </ListGroup>
+              <ListGroup>
+                <ListGroup.Item>
+                  <div>{buildingDetail?.address?.line1}</div>
+                  <div>
+                    {buildingDetail?.address?.administrativeArea},{' '}
+                    {buildingDetail?.address?.province} {buildingDetail?.address?.postal}
+                  </div>
+                </ListGroup.Item>
+              </ListGroup>
+              <ListGroup>
+                <ListGroup.Item>
+                  <Label>Agency:</Label>
+                  {buildingDetail?.agency}
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <Label>Floor Count:</Label>
+                  {buildingDetail?.buildingFloorCount}
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <Label>Predominate Use:</Label>
+                  {buildingDetail?.buildingPredominateUse}
+                </ListGroup.Item>
+                {buildingDetail?.projectNumber && (
+                  <ListGroup.Item>
+                    <Label>SPP:</Label>
+                    {buildingDetail?.projectNumber}
+                  </ListGroup.Item>
+                )}
+              </ListGroup>
+            </Col>
+          </Row>
+
+          {buildingDetail?.parcelId && !props?.disabled && (
+            <Row className="menu">
+              <Col>
                 <Link to={`/submitProperty/${buildingDetail?.parcelId}?disabled=true`}>View</Link>
-              ) : (
-                <Link to={`/submitProperty/${buildingDetail?.parcelId}`}>Update</Link>
-              ))}
-          </Col>
-        </Row>
+                {(keycloak.hasAgency(buildingDetail?.agencyId as number) ||
+                  keycloak.hasClaim(Claims.ADMIN_PROPERTIES)) && (
+                  <Link
+                    style={{ paddingLeft: '5px' }}
+                    to={`/submitProperty/${buildingDetail?.parcelId}`}
+                  >
+                    Update
+                  </Link>
+                )}
+              </Col>
+            </Row>
+          )}
+        </>
       )}
     </Container>
   );

--- a/frontend/src/components/maps/ParcelPopupView.scss
+++ b/frontend/src/components/maps/ParcelPopupView.scss
@@ -4,26 +4,36 @@
   max-width: 250px;
   box-shadow: 1px 2px 2px;
   text-align: left;
-  padding: 12px;
+  padding: 10px;
   .row {
     flex-direction: column;
   }
   .row .col :first-child {
     margin-top: 0px;
   }
+  .pid {
+    text-align: center;
+  }
+  .name {
+    font-weight: bold;
+  }
 
   .label {
     font-weight: 700;
+    padding-right: 5px;
   }
 
   .list-group {
     margin-top: 6px;
   }
   .list-group-item {
-    padding: 0;
+    padding: 0px 0px 5px 0px !important;
     border: none;
     font-family: 'BCSans', Fallback, sans-serif;
     font-size: 12px;
+  }
+  .menu {
+    text-align: center;
   }
   p {
     margin: 0;

--- a/frontend/src/components/maps/ParcelPopupView.scss
+++ b/frontend/src/components/maps/ParcelPopupView.scss
@@ -8,6 +8,18 @@
   .row {
     flex-direction: column;
   }
+
+  .row .col .list-group {
+    margin-top: 6px;
+
+    .list-group-item {
+      padding: 0px 0px 5px 0px;
+      border: none;
+      font-family: 'BCSans', Fallback, sans-serif;
+      font-size: 12px;
+    }
+  }
+
   .row .col :first-child {
     margin-top: 0px;
   }
@@ -23,15 +35,6 @@
     padding-right: 5px;
   }
 
-  .list-group {
-    margin-top: 6px;
-  }
-  .list-group-item {
-    padding: 0px 0px 5px 0px !important;
-    border: none;
-    font-family: 'BCSans', Fallback, sans-serif;
-    font-size: 12px;
-  }
   .menu {
     text-align: center;
   }

--- a/frontend/src/components/maps/ParcelPopupView.test.tsx
+++ b/frontend/src/components/maps/ParcelPopupView.test.tsx
@@ -118,7 +118,7 @@ describe('Parcel popup view', () => {
       </Router>,
     );
     const projectNum = getByText(/Test-Project-Number/);
-    expect(getByText(/Project Number/)).toBeInTheDocument();
+    expect(getByText(/SPP/)).toBeInTheDocument();
     expect(projectNum).toBeInTheDocument();
   });
 
@@ -128,6 +128,6 @@ describe('Parcel popup view', () => {
         <ParcelPopupView parcel={mockParcel(1)} />
       </Router>,
     );
-    expect(queryByText(/Project Number/)).toBeNull();
+    expect(queryByText(/SPP/)).toBeNull();
   });
 });

--- a/frontend/src/components/maps/ParcelPopupView.tsx
+++ b/frontend/src/components/maps/ParcelPopupView.tsx
@@ -23,45 +23,39 @@ export const ParcelPopupView = (props: IParcelDetailProps | null) => {
       {!parcelDetail ? (
         <Alert variant="danger">Failed to load parcel details.</Alert>
       ) : (
-        <Row>
-          <Col>
-            <ListGroup>
-              <ListGroup.Item>
-                <Label>Name: </Label>
-                {parcelDetail?.name}
-              </ListGroup.Item>
-              <ListGroup.Item>
-                <Label>Description: </Label>
-                {parcelDetail?.description}
-              </ListGroup.Item>
-            </ListGroup>
-            <ListGroup>
-              <ListGroup.Item>
-                <Label>Assessed Value: </Label>$
-                {parcelDetail?.evaluations
-                  ?.find(e => e.key === EvaluationKeys.Assessed)
-                  ?.value?.toLocaleString('en-US', { minimumFractionDigits: 2 })}
-              </ListGroup.Item>
-            </ListGroup>
-            <ListGroup>
-              <ListGroup.Item>
-                <div>
-                  <Label>Address: </Label>
-                  {parcelDetail?.address?.line1}
-                </div>
-                <div>
-                  {parcelDetail?.address?.administrativeArea}, {parcelDetail?.address?.province}{' '}
-                  {parcelDetail?.address?.postal}
-                </div>
-              </ListGroup.Item>
-              <ListGroup.Item>
-                <Label>PID: </Label> {parcelDetail?.pid}
-              </ListGroup.Item>
-              {parcelDetail?.projectNumber &&
-                (keycloak.hasAgency(parcelDetail?.agencyId as number) ||
-                  keycloak.hasClaim(Claims.ADMIN_PROJECTS)) && (
+        <>
+          <Row>
+            <Col>
+              <ListGroup>
+                <ListGroup.Item className="pid">
+                  {parcelDetail?.pid ?? parcelDetail?.pin}
+                </ListGroup.Item>
+                <ListGroup.Item className="name">{parcelDetail?.name}</ListGroup.Item>
+                {parcelDetail?.name !== parcelDetail?.description ? (
+                  <ListGroup.Item className="description">
+                    {parcelDetail?.description}
+                  </ListGroup.Item>
+                ) : null}
+              </ListGroup>
+              <ListGroup>
+                <ListGroup.Item>
+                  <Label>Assessed Value:</Label>$
+                  {parcelDetail?.evaluations
+                    ?.find(e => e.key === EvaluationKeys.Assessed)
+                    ?.value?.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+                </ListGroup.Item>
+              </ListGroup>
+              <ListGroup>
+                <ListGroup.Item>
+                  <div>{parcelDetail?.address?.line1}</div>
+                  <div>
+                    {parcelDetail?.address?.administrativeArea}, {parcelDetail?.address?.province}{' '}
+                    {parcelDetail?.address?.postal}
+                  </div>
+                </ListGroup.Item>
+                {parcelDetail?.projectNumber && (
                   <ListGroup.Item>
-                    <Label>Project Number: </Label>
+                    <Label>SPP:</Label>
                     <Link
                       to={`/dispose/projects/assess/properties?projectNumber=${parcelDetail?.projectNumber}`}
                     >
@@ -69,31 +63,34 @@ export const ParcelPopupView = (props: IParcelDetailProps | null) => {
                     </Link>
                   </ListGroup.Item>
                 )}
-            </ListGroup>
-            <ListGroup>
-              <ListGroup.Item>
-                <Label>Agency: </Label>
-                {parcelDetail?.agency}
-              </ListGroup.Item>
-              <ListGroup.Item>
-                <Label>Classification: </Label>
-                {parcelDetail?.classification}
-              </ListGroup.Item>
-            </ListGroup>
-          </Col>
+              </ListGroup>
+              <ListGroup>
+                <ListGroup.Item>
+                  <Label>Agency:</Label>
+                  {parcelDetail?.agency}
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <Label>Classification: </Label>
+                  {parcelDetail?.classification}
+                </ListGroup.Item>
+              </ListGroup>
+            </Col>
+          </Row>
 
           {parcelDetail?.id && !props?.disabled && (
-            <Col>
-              <Link to={`/submitProperty/${parcelDetail?.id}?disabled=true`}>View</Link>
-              {(keycloak.hasAgency(parcelDetail?.agencyId as number) ||
-                keycloak.hasClaim(Claims.ADMIN_PROPERTIES)) && (
-                <Link style={{ paddingLeft: '5px' }} to={`/submitProperty/${parcelDetail?.id}`}>
-                  Update
-                </Link>
-              )}
-            </Col>
+            <Row className="menu">
+              <Col>
+                <Link to={`/submitProperty/${parcelDetail?.id}?disabled=true`}>View</Link>
+                {(keycloak.hasAgency(parcelDetail?.agencyId as number) ||
+                  keycloak.hasClaim(Claims.ADMIN_PROPERTIES)) && (
+                  <Link style={{ paddingLeft: '5px' }} to={`/submitProperty/${parcelDetail?.id}`}>
+                    Update
+                  </Link>
+                )}
+              </Col>
+            </Row>
           )}
-        </Row>
+        </>
       )}
     </Container>
   );

--- a/frontend/src/components/maps/__snapshots__/BuildingPopupView.test.tsx.snap
+++ b/frontend/src/components/maps/__snapshots__/BuildingPopupView.test.tsx.snap
@@ -15,16 +15,11 @@ exports[`building popup view renders correctly 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          className="list-group-item"
+          className="name list-group-item"
           data-rb-event-key={null}
           disabled={false}
           onClick={[Function]}
         >
-          <p
-            className="label"
-          >
-            Name: 
-          </p>
           test name
         </div>
         <div
@@ -33,11 +28,6 @@ exports[`building popup view renders correctly 1`] = `
           disabled={false}
           onClick={[Function]}
         >
-          <p
-            className="label"
-          >
-            Description: 
-          </p>
           Test description
         </div>
       </div>
@@ -54,7 +44,7 @@ exports[`building popup view renders correctly 1`] = `
           <p
             className="label"
           >
-            Assessed Value: 
+            Assessed Value:
           </p>
           $
         </div>
@@ -69,15 +59,10 @@ exports[`building popup view renders correctly 1`] = `
           disabled={false}
           onClick={[Function]}
         >
+          <div />
           <div>
-            <p
-              className="label"
-            >
-              Address: 
-            </p>
-          </div>
-          <div>
-            , 
+            ,
+             
              
           </div>
         </div>
@@ -95,7 +80,20 @@ exports[`building popup view renders correctly 1`] = `
           <p
             className="label"
           >
-            Floor Count: 
+            Agency:
+          </p>
+          agency
+        </div>
+        <div
+          className="list-group-item"
+          data-rb-event-key={null}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <p
+            className="label"
+          >
+            Floor Count:
           </p>
           3
         </div>
@@ -108,13 +106,32 @@ exports[`building popup view renders correctly 1`] = `
           <p
             className="label"
           >
-            Predominate Use: 
+            Predominate Use:
           </p>
         </div>
       </div>
+    </div>
+  </div>
+  <div
+    className="menu row"
+  >
+    <div
+      className="col"
+    >
+      <a
+        href="/submitProperty/1?disabled=true"
+        onClick={[Function]}
+      >
+        View
+      </a>
       <a
         href="/submitProperty/1"
         onClick={[Function]}
+        style={
+          Object {
+            "paddingLeft": "5px",
+          }
+        }
       >
         Update
       </a>

--- a/frontend/src/components/maps/__snapshots__/ParcelPopupView.test.tsx.snap
+++ b/frontend/src/components/maps/__snapshots__/ParcelPopupView.test.tsx.snap
@@ -15,29 +15,27 @@ exports[`Parcel popup view renders correctly 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          className="list-group-item"
+          className="pid list-group-item"
           data-rb-event-key={null}
           disabled={false}
           onClick={[Function]}
         >
-          <p
-            className="label"
-          >
-            Name: 
-          </p>
+          1
+        </div>
+        <div
+          className="name list-group-item"
+          data-rb-event-key={null}
+          disabled={false}
+          onClick={[Function]}
+        >
           test name
         </div>
         <div
-          className="list-group-item"
+          className="description list-group-item"
           data-rb-event-key={null}
           disabled={false}
           onClick={[Function]}
         >
-          <p
-            className="label"
-          >
-            Description: 
-          </p>
           Test Description
         </div>
       </div>
@@ -54,7 +52,7 @@ exports[`Parcel popup view renders correctly 1`] = `
           <p
             className="label"
           >
-            Assessed Value: 
+            Assessed Value:
           </p>
           $
         </div>
@@ -69,31 +67,11 @@ exports[`Parcel popup view renders correctly 1`] = `
           disabled={false}
           onClick={[Function]}
         >
-          <div>
-            <p
-              className="label"
-            >
-              Address: 
-            </p>
-          </div>
+          <div />
           <div>
             , 
              
           </div>
-        </div>
-        <div
-          className="list-group-item"
-          data-rb-event-key={null}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <p
-            className="label"
-          >
-            PID: 
-          </p>
-           
-          1
         </div>
       </div>
       <div
@@ -109,7 +87,7 @@ exports[`Parcel popup view renders correctly 1`] = `
           <p
             className="label"
           >
-            Agency: 
+            Agency:
           </p>
         </div>
         <div
@@ -127,6 +105,10 @@ exports[`Parcel popup view renders correctly 1`] = `
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="menu row"
+  >
     <div
       className="col"
     >

--- a/frontend/src/components/maps/leaflet/__snapshots__/MapProperties.test.tsx.snap
+++ b/frontend/src/components/maps/leaflet/__snapshots__/MapProperties.test.tsx.snap
@@ -15,28 +15,25 @@ exports[`MapProperties View ParcelPopupView renders correctly 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          className="list-group-item"
+          className="pid list-group-item"
           data-rb-event-key={null}
           disabled={false}
           onClick={[Function]}
         >
-          <p
-            className="label"
-          >
-            Name: 
-          </p>
+          000-000-000
         </div>
         <div
-          className="list-group-item"
+          className="name list-group-item"
+          data-rb-event-key={null}
+          disabled={false}
+          onClick={[Function]}
+        />
+        <div
+          className="description list-group-item"
           data-rb-event-key={null}
           disabled={false}
           onClick={[Function]}
         >
-          <p
-            className="label"
-          >
-            Description: 
-          </p>
           test
         </div>
       </div>
@@ -53,7 +50,7 @@ exports[`MapProperties View ParcelPopupView renders correctly 1`] = `
           <p
             className="label"
           >
-            Assessed Value: 
+            Assessed Value:
           </p>
           $
         </div>
@@ -69,11 +66,6 @@ exports[`MapProperties View ParcelPopupView renders correctly 1`] = `
           onClick={[Function]}
         >
           <div>
-            <p
-              className="label"
-            >
-              Address: 
-            </p>
             1234 mock Street
           </div>
           <div>
@@ -82,20 +74,6 @@ exports[`MapProperties View ParcelPopupView renders correctly 1`] = `
              
             V1V1V1
           </div>
-        </div>
-        <div
-          className="list-group-item"
-          data-rb-event-key={null}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <p
-            className="label"
-          >
-            PID: 
-          </p>
-           
-          000-000-000
         </div>
         
       </div>
@@ -112,7 +90,7 @@ exports[`MapProperties View ParcelPopupView renders correctly 1`] = `
           <p
             className="label"
           >
-            Agency: 
+            Agency:
           </p>
           FIN
         </div>
@@ -131,6 +109,10 @@ exports[`MapProperties View ParcelPopupView renders correctly 1`] = `
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="menu row"
+  >
     <div
       className="col"
     >

--- a/frontend/src/features/projects/common/interfaces.ts
+++ b/frontend/src/features/projects/common/interfaces.ts
@@ -55,7 +55,6 @@ export interface IProperty {
 
   // Building Properties
   parcelId?: number;
-  localId?: string;
   constructionTypeId?: number;
   constructionType?: string;
   predominateUseId?: number;

--- a/frontend/src/features/properties/components/forms/subforms/BuildingForm.test.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/BuildingForm.test.tsx
@@ -43,7 +43,6 @@ const mockBuilding: IFormBuilding = {
   id: 8,
   latitude: 9,
   longitude: 10,
-  localId: 'localId',
   occupantName: 'occupantName',
   parcelId: 11,
   rentableArea: 12,

--- a/frontend/src/features/properties/components/forms/subforms/BuildingForm.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/BuildingForm.tsx
@@ -35,7 +35,6 @@ export interface IFormBuilding extends IBuilding {
 export const defaultBuildingValues: any = {
   id: 0,
   name: '',
-  localId: '',
   projectNumber: '',
   description: '',
   address: defaultAddressValues,

--- a/frontend/src/features/properties/components/forms/subforms/PagedBuildingForms.test.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/PagedBuildingForms.test.tsx
@@ -45,7 +45,6 @@ const mockBuilding: IFormBuilding = {
   id: 8,
   latitude: 9,
   longitude: 10,
-  localId: 'localId',
   occupantName: 'occupantName',
   parcelId: 11,
   rentableArea: 12,

--- a/frontend/src/features/properties/list/PropertyListView.test.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.test.tsx
@@ -164,7 +164,6 @@ describe('Property list view', () => {
           landArea: 26.9,
           landLegalDescription:
             'LOT A SECTION 22 TOWNSHIP 91 KAMLOOPS DIVISION YALE DISTRICT PLAN EPP50042',
-          localId: 'Residence B',
           parcelId: fakeId,
           constructionTypeId: 2,
           constructionType: 'Mixed',

--- a/frontend/src/features/properties/list/buildings/IProperty.ts
+++ b/frontend/src/features/properties/list/buildings/IProperty.ts
@@ -54,7 +54,6 @@ export interface IProperty {
 
   // Building Properties
   parcelId?: number;
-  localId?: string;
   constructionTypeId?: number;
   constructionType?: string;
   predominateUseId?: number;

--- a/frontend/src/features/properties/list/interfaces.ts
+++ b/frontend/src/features/properties/list/interfaces.ts
@@ -45,7 +45,6 @@ export interface IProperty {
 
   // Building Properties
   parcelId?: number;
-  localId?: string;
   constructionTypeId?: number;
   constructionType?: string;
   predominateUseId?: number;


### PR DESCRIPTION
## Description

Replacing `Building.LocalId` with `Building.Name` property.

Updated the following forms by removing **Local ID** and cleaning up the formatting.

- **Map View** - **Parcel Popup**
- **Map View** - **Building Popup**
- **Property Detail View** - **Building Information Section**

The following formatting has changed on the **Parcel Popup** and **Building Popup**

- PID at the top centered for parcels
- Name bolded at top
- Name label removed
- Description displayed if different than the name
- Description label removed
- Address label removed
- View and Update buttons applied the same to both building and parcel