### PR TITLE
Group autocomplete for filters

### DIFF
--- a/frontend/src/components/SearchBar/FilterBar.tsx
+++ b/frontend/src/components/SearchBar/FilterBar.tsx
@@ -24,6 +24,10 @@ interface IProps<T extends object = {}> {
   /** the two probs below are for controlling the tool tip for the plust button */
   toolTipAddId?: string;
   toolTipAddText?: string;
+  /** override formiks handleReset default for customized components */
+  customReset?: () => void;
+  /** custom component field name to clear/reset */
+  customResetField?: string;
 }
 
 const FilterBar = <T extends object = {}>(props: PropsWithChildren<IProps<T>>) => {
@@ -41,7 +45,7 @@ const FilterBar = <T extends object = {}>(props: PropsWithChildren<IProps<T>>) =
         setSubmitting(false);
       }}
     >
-      {({ isSubmitting, handleReset }) => (
+      {({ isSubmitting, handleReset, setFieldValue }) => (
         <Form>
           <Form.Row className="search-bar">
             <h3 className="filterBarHeading">{props.filterBarHeading}</h3>
@@ -54,7 +58,17 @@ const FilterBar = <T extends object = {}>(props: PropsWithChildren<IProps<T>>) =
             </Col>
             {!props.hideReset && (
               <Col className="bar-item flex-grow-0">
-                <ResetButton disabled={isSubmitting} onClick={handleReset} />
+                <ResetButton
+                  disabled={isSubmitting}
+                  onClick={() => {
+                    if (props.customReset && props.customResetField) {
+                      props.customReset();
+                      setFieldValue(props.customResetField, '');
+                    } else {
+                      handleReset();
+                    }
+                  }}
+                />
               </Col>
             )}
             {props.plusButton && (

--- a/frontend/src/components/SearchBar/ParentGroupedFilter.tsx
+++ b/frontend/src/components/SearchBar/ParentGroupedFilter.tsx
@@ -1,0 +1,66 @@
+import { SelectOption, SelectOptions } from 'components/common/form';
+import { TypeaheadField } from 'components/common/form/Typeahead';
+import { groupBy, sortBy } from 'lodash';
+import React, { Fragment } from 'react';
+import { Highlighter, Menu, MenuItem } from 'react-bootstrap-typeahead';
+
+interface IParentGroupedFilterProps {
+  name: string;
+  options: SelectOptions;
+  className: string;
+  inputSize?: 'small' | 'large';
+  filterBy?: string[];
+  placeholder?: string;
+}
+
+export const ParentGroupedFilter: React.FC<IParentGroupedFilterProps> = ({
+  name,
+  options,
+  className,
+  inputSize,
+  filterBy,
+  placeholder,
+}) => {
+  return (
+    <TypeaheadField
+      name={name}
+      options={options}
+      inputProps={{ className: className }}
+      bsSize={inputSize}
+      filterBy={filterBy}
+      placeholder={placeholder}
+      filter={true}
+      renderMenu={(results, menuProps) => {
+        const parents = groupBy(
+          results.map((x: SelectOption) => {
+            return {
+              ...x,
+              parentId: x.parentId || x.value,
+            };
+          }),
+          x => x.parentId,
+        );
+        const items = Object.keys(parents)
+          .sort()
+          .map(parent => (
+            <Fragment key={parent}>
+              {!!results.find((x: SelectOption) => x.value === parent) && (
+                <Menu.Header>
+                  <b>{results.find(x => x.value === parent)?.label}</b>
+                </Menu.Header>
+              )}
+              {sortBy(parents[parent], (x: SelectOption) => x.value).map((i, index) => {
+                return (
+                  <MenuItem key={index + 1} option={i} position={index + 1}>
+                    <Highlighter>{i.label}</Highlighter>
+                  </MenuItem>
+                );
+              })}
+            </Fragment>
+          ));
+
+        return <Menu {...menuProps}>{items}</Menu>;
+      }}
+    />
+  );
+};

--- a/frontend/src/components/common/form/Select.tsx
+++ b/frontend/src/components/common/form/Select.tsx
@@ -45,6 +45,7 @@ export type SelectOption = {
   selected?: boolean;
   code?: string;
   parentId?: string | number;
+  parent?: string;
 };
 
 export type SelectOptions = SelectOption[];

--- a/frontend/src/components/common/form/Typeahead.tsx
+++ b/frontend/src/components/common/form/Typeahead.tsx
@@ -8,6 +8,8 @@ interface ITypeaheadFieldProps<T extends TypeaheadModel> extends TypeaheadProps<
   name: string;
   label?: string;
   required?: boolean;
+  /** whether or not this component is being used to filter so we can ignore the validation checkmark */
+  filter?: boolean;
 }
 
 const Group = styled(Form.Group)`
@@ -28,6 +30,7 @@ export function TypeaheadField<T extends TypeaheadModel>({
   label,
   required,
   name,
+  filter,
   ...rest
 }: ITypeaheadFieldProps<T>) {
   const { touched, values, errors, setFieldTouched, setFieldValue } = useFormikContext();
@@ -44,11 +47,13 @@ export function TypeaheadField<T extends TypeaheadModel>({
 
       <Typeahead<T>
         {...rest}
-        inputProps={{ name: name }}
+        inputProps={{ ...rest.inputProps, name: name }}
         isInvalid={hasError as any}
-        isValid={isValid}
+        isValid={!filter && isValid}
         selected={!!getIn(values, name) ? [getIn(values, name)] : []}
-        onChange={(newValues: T[]) => setFieldValue(name, newValues[0])}
+        onChange={(newValues: T[]) => {
+          setFieldValue(name, newValues[0]);
+        }}
         onBlur={() => setFieldTouched(name, true)}
         id={`${name}-field`}
       />

--- a/frontend/src/components/maps/MapFilterBar.scss
+++ b/frontend/src/components/maps/MapFilterBar.scss
@@ -1,27 +1,25 @@
 @import '../../fonts.scss';
 @import '../../variables';
-
 .container-fluid {
   &.map-filter-container {
     height: #{$mapfilter-height};
     background-color: #f2f2f2;
-
     .map-filter-bar {
       align-items: center;
       padding: 1rem 0;
-
       .bar-item {
         .form-group {
           padding: 0;
           margin: 0;
         }
       }
-
+      .map-filter-typeahead {
+        min-width: 350px;
+      }
       .btn-warning {
         color: white;
         font-weight: bold;
       }
-
       .form-control {
         border-radius: 0;
       }

--- a/frontend/src/components/maps/__snapshots__/MapFilterBar.test.tsx.snap
+++ b/frontend/src/components/maps/__snapshots__/MapFilterBar.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MapFilterBar renders correctly 1`] = `
+.c0 div {
+  width: 100%;
+}
+
 <form
   className=""
   noValidate={true}
@@ -79,21 +83,63 @@ exports[`MapFilterBar renders correctly 1`] = `
       className="bar-item col"
     >
       <div
-        className="AutoCompleteText"
+        className="c0 form-group"
       >
         <div
-          className="form-group"
+          className="rbt"
+          style={
+            Object {
+              "outline": "none",
+              "position": "relative",
+            }
+          }
+          tabIndex={-1}
         >
           <div
-            className="input-area"
+            style={
+              Object {
+                "display": "flex",
+                "flex": 1,
+                "height": "100%",
+                "position": "relative",
+              }
+            }
           >
             <input
+              aria-autocomplete="both"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
-              className="form-control"
-              id="input-agencies"
+              className="rbt-input-main form-control rbt-input map-filter-typeahead"
               name="agencies"
+              onBlur={[Function]}
               onChange={[Function]}
-              placeholder="Enter an agency"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Enter an Agency"
+              role="combobox"
+              type="text"
+              value=""
+            />
+            <input
+              aria-hidden={true}
+              className="rbt-input-hint"
+              readOnly={true}
+              style={
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderColor": "transparent",
+                  "boxShadow": "none",
+                  "color": "rgba(0, 0, 0, 0.35)",
+                  "left": 0,
+                  "pointerEvents": "none",
+                  "position": "absolute",
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+              tabIndex={-1}
               value=""
             />
           </div>

--- a/frontend/src/features/admin/agencies/AgencyFilterBar.tsx
+++ b/frontend/src/features/admin/agencies/AgencyFilterBar.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import FilterBar from 'components/SearchBar/FilterBar';
-import { Col } from 'react-bootstrap';
-import { AutoCompleteText } from 'components/common/form';
 import { IAgencyFilter } from 'interfaces';
 import useCodeLookups from 'hooks/useLookupCodes';
+import { ParentGroupedFilter } from 'components/SearchBar/ParentGroupedFilter';
+import { Label } from 'components/common/Label';
+import { mapLookupCodeWithParentString } from 'utils';
 
 interface IProps {
   value: IAgencyFilter;
@@ -13,8 +14,10 @@ interface IProps {
 
 export const AgencyFilterBar: React.FC<IProps> = ({ value, onChange, handleAdd }) => {
   const lookupCodes = useCodeLookups();
-  const agencyOptions = lookupCodes.getOptionsByType('Agency');
-
+  const agencyOptions = lookupCodes.getByType('Agency');
+  const agencyWithParent = (agencyOptions ?? []).map(c =>
+    mapLookupCodeWithParentString(c, agencyOptions),
+  );
   return (
     <FilterBar<IAgencyFilter>
       initialValues={value}
@@ -25,17 +28,20 @@ export const AgencyFilterBar: React.FC<IProps> = ({ value, onChange, handleAdd }
       handleAdd={handleAdd}
       toolTipAddId="agency-filter-add"
       toolTipAddText="Add a new Agency"
+      customReset={() => {
+        onChange?.({ id: '' });
+      }}
+      customResetField="id"
     >
-      <Col className="d-item">
-        {/* TODO: Swap out with new auto complete after grouping complete*/}
-        <AutoCompleteText
-          autoSetting="off"
-          field="id"
-          options={agencyOptions!}
-          placeholder="Enter an agency"
-          label="Search by Name: "
-        />
-      </Col>
+      <Label>Search agency by name: </Label>
+      <ParentGroupedFilter
+        name="id"
+        options={agencyWithParent}
+        className="agency-search"
+        placeholder="Enter an Agency"
+        filterBy={['parent', 'code', 'name']}
+        inputSize="large"
+      />
     </FilterBar>
   );
 };

--- a/frontend/src/features/admin/agencies/EditAgencyPage.scss
+++ b/frontend/src/features/admin/agencies/EditAgencyPage.scss
@@ -2,6 +2,9 @@
 .navBar {
   font-weight: 700;
   text-align: left;
+  .navbar-brand {
+    cursor: pointer;
+  }
 }
 
 .required {

--- a/frontend/src/features/admin/agencies/ManageAgencies.scss
+++ b/frontend/src/features/admin/agencies/ManageAgencies.scss
@@ -1,33 +1,32 @@
-$header-height: 72px;
-$footer-height: 46px;
-$navbar-height: 45px;
-$filter-height: 76px;
-$contentheading-height: 60px;
+@import '../../../variables';
 .ManageAgencies {
-  background-color: white;
   display: flex;
   flex-direction: column;
   padding: 0;
   .agency-toolbar {
-    padding: 0;
-    background-color: var(--light);
+    justify-content: center;
+    padding: 0px;
     .search-bar {
-      .filterBarHeading {
-        margin-left: 500px;
-        margin-right: 100px;
+      justify-content: center;
+      .label {
+        margin-top: 10px;
+        margin-right: 10px;
       }
-      .plus-button {
-        margin-right: 600px;
-      }
+    }
+    .agency-search {
+      min-width: 250px;
+      margin-right: 50px;
+    }
+    .filterBarHeading {
+      margin-right: 50px;
     }
   }
   .table-section {
     margin-left: 15%;
     margin-right: 15%;
     padding: 1rem 2rem;
-    // display: flex;
     max-height: calc(
-      100vh - #{$header-height} - #{$navbar-height} - #{$filter-height} - #{$footer-height}
+      100vh - #{$header-height} - #{$navbar-height} - #{$mapfilter-height} - #{$footer-height}
     );
     table {
       background-color: white;

--- a/frontend/src/features/properties/components/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/__snapshots__/ParcelDetailForm.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`ParcelDetail Functionality ParcelDetailForm renders view-only correctly
                 </div>
               </div>
               <div class=\\"form-row\\"><label class=\\"required form-label\\">Location</label>
-                <div class=\\"sc-AxhCb gFkCzc form-group\\">
+                <div class=\\"sc-AxjAm gLmrxD form-group\\">
                   <div class=\\"rbt\\" style=\\"outline: none; position: relative;\\" tabindex=\\"-1\\">
                     <div style=\\"display: flex; flex: 1; height: 100%; position: relative;\\"><input autocomplete=\\"off\\" type=\\"text\\" name=\\"address.administrativeArea\\" aria-autocomplete=\\"both\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\" role=\\"combobox\\" class=\\"rbt-input-main form-control rbt-input\\" value=\\"Victoria\\"><input aria-hidden=\\"true\\" class=\\"rbt-input-hint\\" readonly=\\"\\" style=\\"background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.35); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%; border-style: inset inset inset inset; border-width: 2px 2px 2px 2px; line-height: normal; padding: 1px 1px 1px 1px;\\" tabindex=\\"-1\\" value=\\"\\"></div>
                   </div>

--- a/frontend/src/features/properties/components/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/subforms/__snapshots__/BuildingForm.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
+.c0 div {
+  width: 100%;
+}
+
 .c1 {
   position: absolute;
   top: 20px;
@@ -15,10 +19,6 @@ exports[`sub-form BuildingForm functionality loads initial building data 1`] = `
 .c1 p {
   width: 35px;
   margin: 0;
-}
-
-.c0 div {
-  width: 100%;
 }
 
 <form

--- a/frontend/src/features/properties/components/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
+++ b/frontend/src/features/properties/components/forms/subforms/__snapshots__/PagedBuildingForms.test.tsx.snap
@@ -103,7 +103,11 @@ Array [
       </svg>
     </button>
   </div>,
-  .c1 {
+  .c0 div {
+  width: 100%;
+}
+
+.c1 {
   position: absolute;
   top: 20px;
   right: 20px;
@@ -117,10 +121,6 @@ Array [
 .c1 p {
   width: 35px;
   margin: 0;
-}
-
-.c0 div {
-  width: 100%;
 }
 
 <div

--- a/frontend/src/features/properties/list/FilterBar.test.tsx
+++ b/frontend/src/features/properties/list/FilterBar.test.tsx
@@ -40,7 +40,7 @@ describe('FilterBar', () => {
     );
     const { container } = render(uiElement);
     const address = container.querySelector('input[name="address"]');
-    const agencies = container.querySelector('select[name="agencies"]');
+    // const agencies = container.querySelector('input[name="agencies"]');
     const classificationId = container.querySelector('select[name="classificationId"]');
     const minLotSize = container.querySelector('input[name="minLotSize"]');
     const maxLotSize = container.querySelector('input[name="maxLotSize"]');
@@ -56,13 +56,13 @@ describe('FilterBar', () => {
       });
     });
 
-    await wait(() => {
-      fireEvent.change(agencies!, {
-        target: {
-          value: '1',
-        },
-      });
-    });
+    // await wait(() => {
+    //   fireEvent.change(agencies!, {
+    //     target: {
+    //       value: '1',
+    //     },
+    //   });
+    // });
 
     await wait(() => {
       fireEvent.change(classificationId!, {
@@ -93,13 +93,14 @@ describe('FilterBar', () => {
     });
 
     // Assert
-    expect(onFilterChange).toBeCalledWith<[IFilterBarState]>({
+    // TODO: New test for more complex typeahead autocomplete
+    expect(onFilterChange).toBeCalledWith({
       searchBy: 'address',
       pid: '',
       address: 'mockaddress',
       administrativeArea: '',
       projectNumber: '',
-      agencies: '1',
+      agencies: undefined,
       classificationId: '0',
       minLotSize: '1',
       maxLotSize: '3',

--- a/frontend/src/features/properties/list/__snapshots__/FilterBar.test.tsx.snap
+++ b/frontend/src/features/properties/list/__snapshots__/FilterBar.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FilterBar renders correctly 1`] = `
+.c0 div {
+  width: 100%;
+}
+
 <form
   className=""
   noValidate={true}
@@ -79,52 +83,67 @@ exports[`FilterBar renders correctly 1`] = `
       className="bar-item col"
     >
       <div
-        className="form-group"
+        className="c0 form-group"
       >
-        <select
-          className="form-select form-control"
-          id="input-agencies"
-          name="agencies"
-          onBlur={[Function]}
-          onChange={[Function]}
-          value=""
+        <div
+          className="rbt"
+          style={
+            Object {
+              "outline": "none",
+              "position": "relative",
+            }
+          }
+          tabIndex={-1}
         >
-          <option
-            value=""
+          <div
+            style={
+              Object {
+                "display": "flex",
+                "flex": 1,
+                "height": "100%",
+                "position": "relative",
+              }
+            }
           >
-            Enter an Agency
-          </option>
-          <option
-            className="option"
-            value="1"
-          >
-            AEST
-          </option>
-          <option
-            className="option"
-            value="2"
-          >
-            HTLH
-          </option>
-          <option
-            className="option"
-            value="3"
-          >
-            MOTI
-          </option>
-          <option
-            className="option"
-            value="4"
-          >
-            FLNR
-          </option>
-          <option
-            className="option"
-            value="5"
-          >
-            MAH
-          </option>
-        </select>
+            <input
+              aria-autocomplete="both"
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              autoComplete="off"
+              className="rbt-input-main form-control rbt-input map-filter-typeahead"
+              name="agencies"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Enter an Agency"
+              role="combobox"
+              type="text"
+              value=""
+            />
+            <input
+              aria-hidden={true}
+              className="rbt-input-hint"
+              readOnly={true}
+              style={
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderColor": "transparent",
+                  "boxShadow": "none",
+                  "color": "rgba(0, 0, 0, 0.35)",
+                  "left": 0,
+                  "pointerEvents": "none",
+                  "position": "absolute",
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+              tabIndex={-1}
+              value=""
+            />
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
+++ b/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`Property list view Matches snapshot 1`] = `
 Array [
-  .c0 {
+  .c0 div {
+  width: 100%;
+}
+
+.c1 {
   background-color: #fff !important;
   color: #003366 !important;
   padding: 6px 5px;
@@ -95,28 +99,67 @@ Array [
               className="bar-item col"
             >
               <div
-                className="form-group"
+                className="c0 form-group"
               >
-                <select
-                  className="form-select form-control"
-                  id="input-agencies"
-                  name="agencies"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  value=""
+                <div
+                  className="rbt"
+                  style={
+                    Object {
+                      "outline": "none",
+                      "position": "relative",
+                    }
+                  }
+                  tabIndex={-1}
                 >
-                  <option
-                    value=""
+                  <div
+                    style={
+                      Object {
+                        "display": "flex",
+                        "flex": 1,
+                        "height": "100%",
+                        "position": "relative",
+                      }
+                    }
                   >
-                    Enter an Agency
-                  </option>
-                  <option
-                    className="option"
-                    value="1"
-                  >
-                    agencyVal
-                  </option>
-                </select>
+                    <input
+                      aria-autocomplete="both"
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
+                      autoComplete="off"
+                      className="rbt-input-main form-control rbt-input map-filter-typeahead"
+                      name="agencies"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      placeholder="Enter an Agency"
+                      role="combobox"
+                      type="text"
+                      value=""
+                    />
+                    <input
+                      aria-hidden={true}
+                      className="rbt-input-hint"
+                      readOnly={true}
+                      style={
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderColor": "transparent",
+                          "boxShadow": "none",
+                          "color": "rgba(0, 0, 0, 0.35)",
+                          "left": 0,
+                          "pointerEvents": "none",
+                          "position": "absolute",
+                          "top": 0,
+                          "width": "100%",
+                        }
+                      }
+                      tabIndex={-1}
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
             </div>
             <div
@@ -303,7 +346,7 @@ Array [
           </div>
         </div>
         <button
-          className="c0 btn btn-primary"
+          className="c1 btn btn-primary"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -333,7 +376,7 @@ Array [
           </svg>
         </button>
         <button
-          className="c0 btn btn-primary"
+          className="c1 btn btn-primary"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}

--- a/frontend/src/hooks/useRouterFilter.ts
+++ b/frontend/src/hooks/useRouterFilter.ts
@@ -51,8 +51,8 @@ export const useRouterFilter = <T extends BasePropertyFilter>(
   React.useEffect(() => {
     const filterParams = new URLSearchParams(filter as any);
     const allParams = {
-      ...queryString.parse(filterParams.toString()),
       ...queryString.parse(history.location.search),
+      ...queryString.parse(filterParams.toString()),
     };
     history.push({ pathname: history.location.pathname, search: queryString.stringify(allParams) });
     const keyedFilter = { [key]: filter };

--- a/frontend/src/interfaces/agency.ts
+++ b/frontend/src/interfaces/agency.ts
@@ -26,7 +26,7 @@ export interface IAgencyDetail {
 export interface IAgencyFilter {
   name?: string;
   description?: string;
-  id?: number;
+  id?: number | '';
 }
 
 /** for use in creating an agency */

--- a/frontend/src/utils/YupSchema.ts
+++ b/frontend/src/utils/YupSchema.ts
@@ -40,6 +40,16 @@ export const UserUpdateSchema = Yup.object().shape({
   lastName: Yup.string().max(100, 'Last Name must be less than 100 characters'),
 });
 
+export const AgencyEditSchema = Yup.object().shape({
+  email: Yup.string()
+    .email('Please enter a valid email.')
+    .max(100, 'Email must be less than 100 characters'),
+  name: Yup.string()
+    .max(100, 'Agency name must be less than 100 characters')
+    .required('An agency name is required.'),
+  code: Yup.string().required('An agnecy code is required.'),
+});
+
 export const UserSchema = Yup.object().shape({
   email: Yup.string()
     .email()

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -55,6 +55,19 @@ export const mapLookupCode = (
   parentId: code.parentId,
 });
 
+/** used for filters that need to display the string value of a parent agency agency */
+export const mapLookupCodeWithParentString = (
+  code: ILookupCode,
+  /** the list of lookup codes to look for parent */
+  options: ILookupCode[],
+): SelectOption => ({
+  label: code.name,
+  value: code.id.toString(),
+  code: code.code,
+  parentId: code.parentId,
+  parent: options.find((a: ILookupCode) => a.id.toString() === code.parentId?.toString())?.name,
+});
+
 export const mapStatuses = (status: IStatus): SelectOption => ({
   label: status.name,
   value: status.id.toString(),


### PR DESCRIPTION
Grouped auto complete filter now on map landing page and property list view. Further customization may be needed but this is a good start to get some feedback. 

Bug fixes included in this PR are as follows:

- styling changes so the agency page now scales and doesn't look terrible

- email validation on edit user page

- popup display for when agency has associated buildings while trying to delete

- only select parent agencies where appropriate

- name and code validation when updating or adding an agency 

- agencies now appear in appropriate lists when they are newly added or edited

- parent agency field is locked when it is a parent agency

- leaving the parent agency on the placeholder (blank) will lock that field and change the text to no parent on save

**New since last edit**

- grouped agency filter now on the page (search by parent, child, or code)

- fixed paging + filter bug


