### PR TITLE
Add dev-alpha-pipeline doc.

### DIFF
--- a/openshift/PIPELINES.md
+++ b/openshift/PIPELINES.md
@@ -27,4 +27,16 @@ This project makes use of several pipelines. For each one, use the generic pipel
 
 3. Create the pipeline objects `oc process --param-file=[.env] -f openshift/templates/jenkins/generic-pipeline.yaml | oc create -f -`
 
-## 3 dev-to-test-pipeline
+## 2 dev-alpha-pipeline
+
+The dev alpha pipeline is used to test unreleased features that may not have a complete implementation or includes a design that is not ready to be included in the regular PIMS release lifecycle. The alpha pipeline allows developers to share these kinds of changes with other developers and non-technical users in a similar manner to the core PIMS git flow, but using the dev-alpha branch instead of the regular dev branch. Note that the dev-alpha-pipeline uses the original Jenkinsfile.cicd configuration.
+
+1. View the parameters `oc process --parameters -f openshift/templates/jenkins/generic-pipeline.yaml`
+
+2. Create a **`.env`** file that contains the values for the parameters within the template
+
+   ```
+   APP_NAME=pims-alpha
+   ```
+
+3. Create the pipeline objects `oc process --param-file=[.env] -f openshift/templates/jenkins/generic-pipeline.yaml | oc create -f -`


### PR DESCRIPTION
Note that I did not need to create a new cicd file for this pipeline, nor any new bcs or dcs, I was able to reuse our existing pipeline, bcs, and dcs, configmaps and secrets and just tweak the parameters. Since we aren't committing our params to source, there isn't a whole lot to include with this PR. This shows that the work that we have put into the pipelines into the past is starting to pay off.

The alpha version of the app is running here: https://pims-alpha-dev.pathfinder.gov.bc.ca

note that it is currently reusing the sso pims-app resource, which I think is probably for the best. It is also reusing the database, which needs more discussion.

I think there are use cases for having a separate DB instance for dev-alpha, although I think non-release ready DB changes are probably less likely to occur then non-release ready api and app changes. So the question becomes do we want a new db container, or can we just reuse our existing container and just add another db instance to it?

