### PR TITLE
Fix Agency Filter

### DIFF
--- a/frontend/src/components/common/form/Typeahead.tsx
+++ b/frontend/src/components/common/form/Typeahead.tsx
@@ -61,7 +61,7 @@ export function TypeaheadField<T extends TypeaheadModel>({
         isValid={!filter && isValid}
         selected={getOptionByValue(getIn(values, name))}
         onChange={(newValues: T[]) => {
-          setFieldValue(name, getIn(newValues[0], 'value') ?? newValues[0]);
+          setFieldValue(name, getIn(newValues[0], 'name') ?? newValues[0]);
         }}
         onBlur={() => setFieldTouched(name, true)}
         id={`${name}-field`}


### PR DESCRIPTION
The agency filter was incorrectly displaying the `Agency.Id` rather than the `Agency.Name`.  This PR should fix this.

Can someone confirm this doesn't break something else, as I'm not sure who broke this in the first place?