### PR TITLE
Fixing deserializing null metadata

### DIFF
--- a/backend/dal/Helpers/Extensions/ProjectExtensions.cs
+++ b/backend/dal/Helpers/Extensions/ProjectExtensions.cs
@@ -379,7 +379,7 @@ namespace Pims.Dal.Helpers.Extensions
         {
             // Update a project
             var agency = originalProject.Agency;
-            var originalMetadata = context.Deserialize<DisposalProjectMetadata>(originalProject.Metadata); // TODO: Need to test whether automatically overwriting the metadata is correct.
+            var originalMetadata = context.Deserialize<DisposalProjectMetadata>(originalProject.Metadata ?? "{}"); // TODO: Need to test whether automatically overwriting the metadata is correct.
 
             var createdById = originalProject.CreatedById;
             var updatedById = originalProject.UpdatedById;

--- a/backend/dal/Services/Concrete/ProjectReportService.cs
+++ b/backend/dal/Services/Concrete/ProjectReportService.cs
@@ -100,9 +100,9 @@ namespace Pims.Dal.Services
 
             foreach (ProjectSnapshot snapshot in toSnapshots)
             {
-                var metadata = !String.IsNullOrWhiteSpace(snapshot.Metadata) ? this.Context.Deserialize<DisposalProjectSnapshotMetadata>(snapshot.Metadata) : new DisposalProjectSnapshotMetadata();
+                var metadata = !String.IsNullOrWhiteSpace(snapshot.Metadata) ? this.Context.Deserialize<DisposalProjectSnapshotMetadata>(snapshot.Metadata ?? "{}") : new DisposalProjectSnapshotMetadata();
                 var prevSnapshot = fromSnapshots.GetValueOrDefault(snapshot.ProjectId);
-                var prevMetadata = prevSnapshot != null ? this.Context.Deserialize<DisposalProjectMetadata>(prevSnapshot.Metadata) : null;
+                var prevMetadata = prevSnapshot != null ? this.Context.Deserialize<DisposalProjectMetadata>(prevSnapshot.Metadata ?? "{}") : null;
                 metadata.BaselineIntegrity = (metadata?.NetProceeds ?? 0) - (prevMetadata?.NetProceeds ?? 0);
                 snapshot.Metadata = this.Context.Serialize(metadata);
             }
@@ -281,9 +281,9 @@ namespace Pims.Dal.Services
 
             foreach (Project project in splProjects)
             {
-                var metadata = !String.IsNullOrWhiteSpace(project.Metadata) ? this.Context.Deserialize<DisposalProjectSnapshotMetadata>(project.Metadata) : new DisposalProjectSnapshotMetadata();
+                var metadata = !String.IsNullOrWhiteSpace(project.Metadata) ? this.Context.Deserialize<DisposalProjectSnapshotMetadata>(project.Metadata ?? "{}") : new DisposalProjectSnapshotMetadata();
                 var prevSnapshot = fromSnapshots.GetValueOrDefault(project.Id);
-                var prevMetadata = prevSnapshot != null ? this.Context.Deserialize<DisposalProjectSnapshotMetadata>(prevSnapshot.Metadata) : new DisposalProjectSnapshotMetadata();
+                var prevMetadata = prevSnapshot != null ? this.Context.Deserialize<DisposalProjectSnapshotMetadata>(prevSnapshot.Metadata ?? "{}") : new DisposalProjectSnapshotMetadata();
 
                 metadata.BaselineIntegrity = (metadata?.NetProceeds ?? 0) - (prevMetadata?.NetProceeds ?? 0);
 

--- a/backend/dal/Services/Concrete/ProjectService.cs
+++ b/backend/dal/Services/Concrete/ProjectService.cs
@@ -673,7 +673,7 @@ namespace Pims.Dal.Services
 
             var userAgencies = this.User.GetAgencies();
             if (!isAdmin && !userAgencies.Contains(originalProject.AgencyId)) throw new NotAuthorizedException("User may not edit projects outside of their agency.");
-             
+
             // Only allow valid project status transitions.
             var fromStatusId = (int)this.Context.Entry(originalProject).OriginalValues[nameof(Project.StatusId)];
             var fromStatus = this.Context.WorkflowProjectStatus
@@ -713,7 +713,7 @@ namespace Pims.Dal.Services
             // If the note was changed generate a notification for it.
             var noteChanged = !String.IsNullOrWhiteSpace(project.GetNoteText(NoteTypes.Public)) && originalProject.GetNoteText(NoteTypes.Public) != project.GetNoteText(NoteTypes.Public);
 
-            var metadata = !String.IsNullOrWhiteSpace(project.Metadata) ? this.Context.Deserialize<DisposalProjectMetadata>(project.Metadata) : new DisposalProjectMetadata();
+            var metadata = !String.IsNullOrWhiteSpace(project.Metadata) ? this.Context.Deserialize<DisposalProjectMetadata>(project.Metadata ?? "{}") : new DisposalProjectMetadata();
             originalProject.Merge(project, this.Context);
             var now = DateTime.UtcNow;
 


### PR DESCRIPTION
Updated extension methods to handle deserialization when `metadata` is null.