### PR TITLE
Multiselect + new filter functionality

### DIFF
--- a/backend/dal/Migrations/Initial/Up/PostUp/01-Workflow.sql
+++ b/backend/dal/Migrations/Initial/Up/PostUp/01-Workflow.sql
@@ -18,21 +18,21 @@ INSERT INTO dbo.[Workflows] (
     , 0
 ), (
     2
-    , 'Access Surplus Property Process Project Request'
+    , 'Assess Surplus Property Process Project Request'
     , 'ASSESS-DISPOSAL'
     , 0
     , 'Assess a submitted Surplus Property Process Project to determine whether it will be approved or denied.'
     , 1
 ), (
     3
-    , 'Access Enhanced Referral Process Exemption'
+    , 'Assess Enhanced Referral Process Exemption'
     , 'ASSESS-EXEMPTION'
     , 0
     , 'Assess a requested ERP exemption.'
     , 2
 ), (
     4
-    , 'Access Enhanced Referral Process Exemption Project Request'
+    , 'Assess Enhanced Referral Process Exemption Project Request'
     , 'ASSESS-EX-DISPOSAL'
     , 0
     , 'Assess a submitted Surplus Property Process Project to determine whether it will be approved or denied.'

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -2,9 +2,15 @@ import * as React from 'react';
 import './Label.scss';
 interface ILabelProps {
   children?: string;
+  required?: boolean;
 }
 
 /** generic inline label element */
 export const Label = (props: ILabelProps | null | undefined) => {
-  return <p className="label">{props?.children}</p>;
+  return (
+    <p className="label">
+      {props?.required && <span className="req">*</span>}
+      {props?.children}
+    </p>
+  );
 };

--- a/frontend/src/components/common/form/ParentSelect.tsx
+++ b/frontend/src/components/common/form/ParentSelect.tsx
@@ -1,0 +1,180 @@
+import { getIn, useFormikContext } from 'formik';
+import { groupBy, sortBy } from 'lodash';
+import React, { Fragment, useEffect, useState } from 'react';
+import { Highlighter, Menu, MenuItem } from 'react-bootstrap-typeahead';
+import { Label } from '../Label';
+import { SelectOption, SelectOptions } from './Select';
+import { TypeaheadField } from './Typeahead';
+
+interface IParentSelect {
+  /** specify the field that is being accessed */
+  field: string;
+  /** give the component the desired options to group by parent with */
+  options: SelectOptions;
+  /** if you would like placeholder text within the input */
+  placeholder?: string;
+  /** filterBy is optional - if used can determine what you can filter with */
+  filterBy?: string[];
+  /** provide the opitional label text*/
+  label?: string;
+  /** flag used to control whehter to display red astrix indicating required */
+  required?: boolean;
+  /** determine whether this component is disabled or not */
+  disabled?: boolean;
+  /** if this component is being used as a filter do not pre populate the value */
+  isFilter?: boolean;
+  /** set this flag if the grouped parent select will be used to make multiple selection */
+  enableMultiple?: boolean;
+  /** check to see whether reset button has been called to clear multiple selected */
+  clearSelected?: boolean;
+  /** reset state of clear selected via this component */
+  setClearSelected?: Function;
+}
+
+/** Component used to group children items with their parent.
+ *  Can click the parent item as a value or the subsequent children
+ **/
+export const ParentSelect: React.FC<IParentSelect> = ({
+  field,
+  options,
+  placeholder,
+  filterBy,
+  required,
+  disabled,
+  enableMultiple,
+  isFilter,
+  clearSelected,
+  setClearSelected,
+  label,
+}) => {
+  const { setFieldValue, values } = useFormikContext();
+  const value = getIn(values, field);
+  /** determine whether the initial value has been loaded into the component or not */
+  const [loaded, setLoaded] = useState(false);
+  /** used to trigger onBlur so menu disappears on custom header click */
+  const [clear, setClear] = useState(false);
+  /** select appropriate agency to set the field value to when present */
+  const option = value ? options.find(x => x.value === value.toString()) : null;
+  /** controls the multi selections displayed to the user */
+  const [multiSelections, setMultiSelections] = React.useState<any>([]);
+
+  useEffect(() => {
+    if (value && !loaded && !isFilter) {
+      if (value.value) {
+        setFieldValue(field, value);
+      } else if (value && !value.value) {
+        setFieldValue(field, option);
+      } else {
+        setFieldValue(field, option);
+        setLoaded(true);
+      }
+    }
+  }, [value, loaded, setFieldValue, isFilter, field, option]);
+
+  /** wipe the selection from input on reset */
+  useEffect(() => {
+    console.log('here');
+    clearSelected && setMultiSelections([]);
+    setClearSelected && setClearSelected(false);
+  }, [clearSelected, setClearSelected]);
+
+  /** function that gets called when menu header is clicked */
+  const handleMenuHeaderClick = (x: SelectOption) => {
+    setFieldValue(field, x);
+    /** trigger ref in Typeahead to call onBlur so menu closes */
+    setClear(true);
+  };
+
+  /** fill the multiselect enabled input to all the corresponding values */
+  const handleMultiSelectHeaderClick = (x: any) => {
+    setMultiSelections(x);
+    setFieldValue(
+      field,
+      x.map((x: any) => x.value),
+    );
+    setClear(true);
+  };
+
+  return (
+    <>
+      {label && <Label required={required}>{label}</Label>}
+      <TypeaheadField
+        disabled={disabled}
+        clearMenu={clear}
+        setClear={setClear}
+        name={field}
+        labelKey={option => `${option.label}`}
+        onChange={(vals: any) => {
+          if (enableMultiple) {
+            setMultiSelections(vals);
+            setFieldValue(
+              field,
+              vals.map((x: any) => x.value),
+            );
+          } else {
+            setFieldValue(field, getIn(vals[0], 'name') ?? vals[0]);
+          }
+        }}
+        multiple={enableMultiple}
+        options={options}
+        bsSize={'large'}
+        filterBy={filterBy}
+        getOptionByValue={
+          enableMultiple
+            ? (value: any) => value
+            : (value: any) => (!!value ? ([value] as any[]) : ([] as any[]))
+        }
+        multiSelections={multiSelections}
+        clearSelected={clearSelected}
+        placeholder={placeholder}
+        hideValidation
+        renderMenu={(results, menuProps) => {
+          const parents = groupBy(
+            results.map((x: SelectOption) => {
+              return {
+                ...x,
+                parentId: x.parentId,
+              };
+            }),
+            x => x.parentId,
+          );
+          const items = Object.keys(parents)
+            .sort()
+            .map(parent => (
+              <Fragment key={parent}>
+                {!!results.find((x: SelectOption) => x.value === parent) && (
+                  <Menu.Header
+                    onClick={() =>
+                      enableMultiple
+                        ? handleMultiSelectHeaderClick(
+                            results.filter(x => x.parentId?.toString() === parent),
+                          )
+                        : handleMenuHeaderClick(results.find(x => x.value === parent)!)
+                    }
+                  >
+                    <b style={{ cursor: 'pointer' }}>
+                      {field === 'statusId'
+                        ? results.find(x => x.parentId?.toString() === parent)?.parent
+                        : results.find(x => x.value === parent)?.label}
+                    </b>
+                  </Menu.Header>
+                )}
+                {sortBy(parents[parent], (x: SelectOption) => x.value).map((i, index) => {
+                  if (i.parent) {
+                    return (
+                      <MenuItem key={index + 1} option={i} position={index + 1}>
+                        <Highlighter search="">{i.label}</Highlighter>
+                      </MenuItem>
+                    );
+                  }
+                  return null;
+                })}
+              </Fragment>
+            ));
+
+          return <Menu {...menuProps}>{items}</Menu>;
+        }}
+      />
+    </>
+  );
+};

--- a/frontend/src/components/maps/MapFilterBar.scss
+++ b/frontend/src/components/maps/MapFilterBar.scss
@@ -13,6 +13,11 @@
           margin: 0;
         }
       }
+      .agency-item {
+        .form-control {
+          width: 300px;
+        }
+      }
       .map-filter-typeahead {
         min-width: 350px;
       }

--- a/frontend/src/components/maps/MapFilterBar.tsx
+++ b/frontend/src/components/maps/MapFilterBar.tsx
@@ -12,8 +12,8 @@ import { FilterBarSchema } from 'utils/YupSchema';
 import ResetButton from 'components/common/form/ResetButton';
 import SearchButton from 'components/common/form/SearchButton';
 import { BasePropertyFilter } from 'components/common/interfaces';
-import { ParentGroupedFilter } from 'components/SearchBar/ParentGroupedFilter';
 import { mapLookupCodeWithParentString } from 'utils';
+import { ParentSelect } from 'components/common/form/ParentSelect';
 
 const SearchBar: React.FC = () => {
   const state: { options: any[]; placeholders: Record<string, string> } = {
@@ -162,14 +162,13 @@ const MapFilterBar: React.FC<MapFilterProps> = ({
             <Col className="bar-item">
               <SearchBar />
             </Col>
-            <Col className="bar-item">
-              <ParentGroupedFilter
-                name="agencies"
+            <Col className="agency-item">
+              <ParentSelect
+                field="agencies"
                 options={agencies}
-                className="map-filter-typeahead"
                 filterBy={['code', 'label', 'parent']}
                 placeholder="Enter an Agency"
-                inputSize="large"
+                isFilter
               />
             </Col>
             <Col className="bar-item">

--- a/frontend/src/components/maps/__snapshots__/MapFilterBar.test.tsx.snap
+++ b/frontend/src/components/maps/__snapshots__/MapFilterBar.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`MapFilterBar renders correctly 1`] = `
       </div>
     </div>
     <div
-      className="bar-item col"
+      className="agency-item col"
     >
       <div
         className="form-group"
@@ -106,7 +106,7 @@ exports[`MapFilterBar renders correctly 1`] = `
               aria-expanded={false}
               aria-haspopup="listbox"
               autoComplete="off"
-              className="rbt-input-main form-control rbt-input map-filter-typeahead"
+              className="rbt-input-main form-control rbt-input"
               id="agencies-field"
               name="agencies"
               onBlur={[Function]}

--- a/frontend/src/features/projects/common/interfaces.ts
+++ b/frontend/src/features/projects/common/interfaces.ts
@@ -266,6 +266,7 @@ export interface IStatus {
   isOptional: boolean;
   toStatus?: IStatus[];
   isActive: boolean;
+  parentId?: number;
 }
 
 export interface IStepProps {

--- a/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
@@ -23,17 +23,45 @@ exports[`Project list view tests Matches snapshot 1`] = `
           <div
             class="form-group"
           >
-            <select
-              class="form-select form-control"
-              id="input-statusId"
-              name="statusId"
+            <div
+              class="rbt"
+              style="outline: none; position: relative;"
+              tabindex="-1"
             >
-              <option
-                value=""
+              <div
+                class="rbt-input-multi form-control rbt-input"
+                tabindex="-1"
               >
-                Select a project status
-              </option>
-            </select>
+                <div
+                  class="rbt-input-wrapper"
+                >
+                  <div
+                    style="display: flex; flex: 1; height: 100%; position: relative;"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-haspopup="listbox"
+                      autocomplete="off"
+                      class="rbt-input-main"
+                      id="statusId-field"
+                      name="statusId"
+                      placeholder="Enter an Status"
+                      style="background-color: transparent; border: 0px; box-shadow: none; cursor: inherit; outline: none; padding: 0px; width: 100%; z-index: 1;"
+                      type="text"
+                      value=""
+                    />
+                    <input
+                      aria-hidden="true"
+                      class="rbt-input-hint"
+                      readonly=""
+                      style="background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.35); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%;"
+                      tabindex="-1"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
@@ -55,7 +83,7 @@ exports[`Project list view tests Matches snapshot 1`] = `
                   aria-expanded="false"
                   aria-haspopup="listbox"
                   autocomplete="off"
-                  class="rbt-input-main form-control rbt-input map-filter-typeahead"
+                  class="rbt-input-main form-control rbt-input"
                   id="agencies-field"
                   name="agencies"
                   placeholder="Enter an Agency"

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -102,9 +102,27 @@ export const mapLookupCodeWithParentString = (
   parent: options.find((a: ILookupCode) => a.id.toString() === code.parentId?.toString())?.name,
 });
 
+const createParentWorkflow = (code: string) => {
+  if (/^DR/.test(code)) {
+    return { name: 'Draft Statuses', id: 1 };
+  } else if (/EXE/.test(code)) {
+    return { name: 'Exemption Statuses', id: 2 };
+  } else if (/^AS/.test(code)) {
+    return { name: 'Assessment Statuses', id: 3 };
+  } else if (/^ERP/.test(code) || /^AP-ERP$/.test(code)) {
+    return { name: 'ERP Statuses', id: 4 };
+  } else if (/^SPL/.test(code) || /^AP-SPL$/.test(code)) {
+    return { name: 'SPL Statuses', id: 5 };
+  } else {
+    return { name: 'General Statuses', id: 6 };
+  }
+};
+
 export const mapStatuses = (status: IStatus): SelectOption => ({
   label: status.name,
   value: status.id.toString(),
+  parent: createParentWorkflow(status.code).name,
+  parentId: createParentWorkflow(status.code).id,
 });
 
 type FormikMemoProps = {


### PR DESCRIPTION
Draft PR for now have some bugs I want to fix first but just getting the PR up

- updated map filter bar to have the new agency filter component (clickable headers)

- project statuses can now be multi selected in the project list view (fixing some bugs here in regards to resetting the filter and how the group headings are chosen)

![multiselect](https://user-images.githubusercontent.com/15724124/101231914-355ece80-3663-11eb-83f5-c02d729bb82e.gif)

**Update**: can now select parent and it will supply the input with the corresponding statuses as shown in GIF below

![selectparent](https://user-images.githubusercontent.com/15724124/101267353-8676cd00-370c-11eb-821d-32ae10163fdd.gif)

 