### PR TITLE
Refactoring the Supercluster rendering for easy testing

### DIFF
--- a/frontend/src/actions/parcelsActions.ts
+++ b/frontend/src/actions/parcelsActions.ts
@@ -144,14 +144,16 @@ export interface IStoreParcelDetail {
 export const storeParcelDetail = (
   parcel: IParcel | null,
   position?: [number, number],
-): IStoreParcelDetail => ({
-  type: ActionTypes.STORE_PARCEL_DETAIL,
-  parcelDetail: {
-    propertyTypeId: 0,
-    parcelDetail: parcel,
-    position,
-  },
-});
+): IStoreParcelDetail => {
+  return {
+    type: ActionTypes.STORE_PARCEL_DETAIL,
+    parcelDetail: {
+      propertyTypeId: 0,
+      parcelDetail: parcel,
+      position,
+    },
+  };
+};
 
 export interface IStoreBuildingDetail {
   type: typeof ActionTypes.STORE_BUILDING_DETAIL;

--- a/frontend/src/components/maps/BuildingPopupView.tsx
+++ b/frontend/src/components/maps/BuildingPopupView.tsx
@@ -15,6 +15,7 @@ export interface IBuildingDetailProps {
   building: IBuilding | null;
   zoomTo?: () => void;
   disabled?: boolean;
+  onLinkClick?: () => void;
 }
 
 export const BuildingPopupView: React.FC<IBuildingDetailProps> = (props: IBuildingDetailProps) => {
@@ -80,6 +81,9 @@ export const BuildingPopupView: React.FC<IBuildingDetailProps> = (props: IBuildi
             <Row className="menu">
               <Col>
                 <Link
+                  onClick={() => {
+                    props?.onLinkClick && props.onLinkClick();
+                  }}
                   to={{
                     pathname: `/mapview/${buildingDetail?.parcelId}`,
                     search: queryString.stringify({
@@ -96,6 +100,9 @@ export const BuildingPopupView: React.FC<IBuildingDetailProps> = (props: IBuildi
                 {(keycloak.hasAgency(buildingDetail?.agencyId as number) ||
                   keycloak.hasClaim(Claims.ADMIN_PROPERTIES)) && (
                   <Link
+                    onClick={() => {
+                      props?.onLinkClick && props.onLinkClick();
+                    }}
                     to={{
                       pathname: `/mapview/${buildingDetail?.parcelId}`,
                       search: queryString.stringify({

--- a/frontend/src/components/maps/ParcelPopupView.tsx
+++ b/frontend/src/components/maps/ParcelPopupView.tsx
@@ -14,6 +14,7 @@ export interface IParcelDetailProps {
   parcel: IParcel | null;
   zoomTo?: () => void;
   disabled?: boolean;
+  onLinkClick?: () => void;
 }
 
 export const ParcelPopupView = (props: IParcelDetailProps | null) => {
@@ -84,6 +85,9 @@ export const ParcelPopupView = (props: IParcelDetailProps | null) => {
             <Row className="menu">
               <Col>
                 <Link
+                  onClick={() => {
+                    props?.onLinkClick && props.onLinkClick();
+                  }}
                   to={{
                     pathname: `/mapview/${parcelDetail?.id}`,
                     search: queryString.stringify({
@@ -99,6 +103,9 @@ export const ParcelPopupView = (props: IParcelDetailProps | null) => {
                 {(keycloak.hasAgency(parcelDetail?.agencyId as number) ||
                   keycloak.hasClaim(Claims.ADMIN_PROPERTIES)) && (
                   <Link
+                    onClick={() => {
+                      props?.onLinkClick && props.onLinkClick();
+                    }}
                     to={{
                       pathname: `/mapview/${parcelDetail?.id}`,
                       search: queryString.stringify({

--- a/frontend/src/components/maps/PopupView.tsx
+++ b/frontend/src/components/maps/PopupView.tsx
@@ -8,6 +8,7 @@ export type IPopupViewProps = {
   propertyDetail: IParcel | IBuilding | null;
   zoomTo?: () => void;
   disabled?: boolean;
+  onLinkClick?: () => void;
 };
 
 export const PopupView: React.FC<IPopupViewProps> = ({
@@ -15,14 +16,26 @@ export const PopupView: React.FC<IPopupViewProps> = ({
   propertyDetail,
   disabled,
   zoomTo,
+  onLinkClick,
 }) => {
   if (propertyTypeId === PropertyTypes.PARCEL) {
     return (
-      <ParcelPopupView zoomTo={zoomTo} disabled={disabled} parcel={propertyDetail as IParcel} />
+      <ParcelPopupView
+        zoomTo={zoomTo}
+        disabled={disabled}
+        parcel={propertyDetail as IParcel}
+        onLinkClick={onLinkClick}
+      />
     );
   }
   if (propertyTypeId === PropertyTypes.BUILDING) {
-    return <BuildingPopupView zoomTo={zoomTo} building={propertyDetail as IBuilding} />;
+    return (
+      <BuildingPopupView
+        zoomTo={zoomTo}
+        building={propertyDetail as IBuilding}
+        onLinkClick={onLinkClick}
+      />
+    );
   }
   if (propertyTypeId === PropertyTypes.DRAFT_PARCEL) {
     return <p>This is a draft marker for parcel: {propertyDetail?.name ?? 'New Parcel'}</p>;

--- a/frontend/src/components/maps/leaflet/SelectedPropertyMarker/SelectedPropertyMarker.tsx
+++ b/frontend/src/components/maps/leaflet/SelectedPropertyMarker/SelectedPropertyMarker.tsx
@@ -1,0 +1,20 @@
+import { Map } from 'leaflet';
+import * as React from 'react';
+import { Marker, MarkerProps } from 'react-leaflet';
+
+/**
+ * Wrapper of the React Leaflet marker to auto open the popup for a selected property
+ */
+const SelectedPropertyMarker: React.FC<MarkerProps & { map: Map }> = props => {
+  const ref = React.useRef<any>(undefined);
+
+  React.useEffect(() => {
+    if (ref.current.leafletElement) {
+      ref.current.leafletElement.openPopup();
+    }
+  }, []);
+
+  return <Marker {...props} ref={ref} zIndexOffset={9} />;
+};
+
+export default SelectedPropertyMarker;

--- a/frontend/src/components/maps/leaflet/mapUtils.tsx
+++ b/frontend/src/components/maps/leaflet/mapUtils.tsx
@@ -101,34 +101,38 @@ export const pointToLayer = (feature: ICluster, latlng: LatLngExpression): Layer
 };
 
 /**
+ * Get an icon type for the specified cluster property details (type, draft, erp, spp etc)
+ */
+export const getMarkerIcon = (feature: ICluster) => {
+  const { propertyTypeId, projectNumber, projectStatus } = feature?.properties;
+  if (
+    [
+      ReviewWorkflowStatus.ERP,
+      ReviewWorkflowStatus.OnHold,
+      ReviewWorkflowStatus.ApprovedForErp,
+    ].includes(projectStatus)
+  ) {
+    return erpIcon;
+  } else if (projectNumber !== undefined) {
+    return sppIcon;
+  } else if (propertyTypeId === PropertyTypes.PARCEL) {
+    return parcelIcon;
+  } else if (propertyTypeId === PropertyTypes.DRAFT_PARCEL) {
+    return draftParcelIcon;
+  } else if (propertyTypeId === PropertyTypes.DRAFT_BUILDING) {
+    return draftBuildingIcon;
+  } else {
+    return buildingIcon;
+  }
+};
+
+/**
  * Creates a map pin for a single point; e.g. a parcel or a building
  * @param feature the geojson object
  * @param latlng the point position
  */
 export const createSingleMarker = (feature: ICluster, latlng: LatLngExpression): Layer => {
-  const { propertyTypeId, projectNumber, projectStatus } = feature?.properties;
-  const getIconType = () => {
-    if (
-      [
-        ReviewWorkflowStatus.ERP,
-        ReviewWorkflowStatus.OnHold,
-        ReviewWorkflowStatus.ApprovedForErp,
-      ].includes(projectStatus)
-    ) {
-      return erpIcon;
-    } else if (projectNumber !== undefined) {
-      return sppIcon;
-    } else if (propertyTypeId === PropertyTypes.PARCEL) {
-      return parcelIcon;
-    } else if (propertyTypeId === PropertyTypes.DRAFT_PARCEL) {
-      return draftParcelIcon;
-    } else if (propertyTypeId === PropertyTypes.DRAFT_BUILDING) {
-      return draftBuildingIcon;
-    } else {
-      return buildingIcon;
-    }
-  };
-  const icon = getIconType();
+  const icon = getMarkerIcon(feature);
   return new Marker(latlng, { icon });
 };
 

--- a/frontend/src/features/mapSideBar/hooks/useQueryParamSideBar.tsx
+++ b/frontend/src/features/mapSideBar/hooks/useQueryParamSideBar.tsx
@@ -2,6 +2,8 @@ import { useLocation, useHistory, useParams } from 'react-router-dom';
 import { useState } from 'react';
 import queryString from 'query-string';
 import useDeepCompareEffect from 'hooks/useDeepCompareEffect';
+import { useDispatch } from 'react-redux';
+import { storeParcelDetail } from 'actions/parcelsActions';
 
 interface IMapSideBar {
   showSideBar: boolean;
@@ -18,8 +20,9 @@ const useQueryParamSideBar = (): IMapSideBar => {
   const [showSideBar, setShowSideBar] = useState(false);
   const [parcelId, setParcelId] = useState<number | undefined>(undefined);
   const location = useLocation();
-  const { id } = useParams();
+  const { id } = useParams<any>();
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const searchParams = queryString.parse(location.search);
   useDeepCompareEffect(() => {
@@ -38,6 +41,9 @@ const useQueryParamSideBar = (): IMapSideBar => {
   }, [id, searchParams, location.search]);
 
   const setShow = (show: boolean) => {
+    if (!show) {
+      dispatch(storeParcelDetail(null));
+    }
     const search = new URLSearchParams({ ...(searchParams as any), sidebar: show });
     history.push({ search: search.toString() });
   };

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -6,6 +6,8 @@ import { ENVIRONMENT } from 'constants/environment';
 import * as _ from 'lodash';
 import { LatLngTuple } from 'leaflet';
 import { useCallback } from 'react';
+import { IGeoSearchParams } from 'constants/API';
+import queryString from 'query-string';
 
 export interface IGeocoderResponse {
   siteId: string;
@@ -35,6 +37,7 @@ export interface PimsAPI extends AxiosInstance {
   searchAddress: (text: string) => Promise<IGeocoderResponse[]>;
   getSitePids: (siteId: string) => Promise<IGeocoderPidsResponse>;
   getAdministrativeAreaLatLng: (city: string) => Promise<LatLngTuple | null>;
+  loadProperties: (params?: IGeoSearchParams) => Promise<any[]>;
 }
 
 export const useApi = (): PimsAPI => {
@@ -109,6 +112,13 @@ export const useApi = (): PimsAPI => {
   axios.getSitePids = async (siteId: string): Promise<IGeocoderPidsResponse> => {
     const { data } = await axios.get<IGeocoderPidsResponse>(
       `${ENVIRONMENT.apiUrl}/tools/geocoder/parcels/pids/${siteId}`,
+    );
+    return data;
+  };
+
+  axios.loadProperties = async (params?: IGeoSearchParams): Promise<any[]> => {
+    const { data } = await axios.get<any[]>(
+      `${ENVIRONMENT.apiUrl}/properties/search/wfs?${params ? queryString.stringify(params) : ''}`,
     );
     return data;
   };

--- a/frontend/src/utils/testUtils.ts
+++ b/frontend/src/utils/testUtils.ts
@@ -1,5 +1,6 @@
 import { wait, fireEvent } from '@testing-library/react';
 import { act } from 'react-test-renderer';
+import { Map as LeafletMap, Layer } from 'leaflet';
 
 export const fillInput = async (
   container: HTMLElement,
@@ -52,4 +53,11 @@ export const fillInput = async (
 export const getInput = (container: HTMLElement, name: string, type: string = 'input') => {
   const input = container.querySelector(`${type}[name="${name}"]`);
   return input;
+};
+
+export const getLeafletLayers = (map?: LeafletMap): Layer[] => {
+  if (!map) {
+    return [];
+  }
+  return Object.keys((map as any)._layers).map(key => (map as any)._layers[key]);
 };


### PR DESCRIPTION
The supercluster render in the PointCluster component was easy to test, interacting directly with leaflet in the react tests is not any playground. I refactored the component to use react component in the render. 

I used this refactored code to write unit tests, showcasing how we can write more tests in the leaflet component