### PR TITLE
PA-1968: Group all Disposal Project links under one menu item

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -70,3 +70,12 @@ div.bootstrap-table {
 .form-check.required input {
   border: 1px solid $secondary-variant-color;
 }
+
+//by default, highlight dropdown options blue
+.dropdown-item {
+  color: $text-color;
+  &:hover {
+    color: #fff;
+    background-color: $active-color;
+  }
+}

--- a/frontend/src/components/layout/AppNavBar/AppNavBar.scss
+++ b/frontend/src/components/layout/AppNavBar/AppNavBar.scss
@@ -22,7 +22,7 @@ nav.map-nav {
       width: 30px;
     }
     .active {
-      background-color: #428bca !important;
+      background-color: $secondary-variant-color !important;
     }
     .nav-item {
       height: 100%;
@@ -30,7 +30,7 @@ nav.map-nav {
     .nav-link {
       font-size: 14px;
       color: #fff;
-      padding: 0.75rem 2rem;
+      padding: 0.75rem 2.5rem;
     }
     .dropdown {
       background-color: transparent;

--- a/frontend/src/components/layout/AppNavBar/AppNavBar.test.tsx
+++ b/frontend/src/components/layout/AppNavBar/AppNavBar.test.tsx
@@ -12,6 +12,8 @@ import { Provider } from 'react-redux';
 import { useKeycloak } from '@react-keycloak/web';
 import { mountToJson } from 'enzyme-to-json';
 import AppNavBar from './AppNavBar';
+import Claims from 'constants/claims';
+import Roles from 'constants/roles';
 
 jest.mock('@react-keycloak/web');
 Enzyme.configure({ adapter: new Adapter() });
@@ -46,55 +48,14 @@ describe('AppNavBar', () => {
     expect(mountToJson(tree.find(AppNavBar))).toMatchSnapshot();
   });
 
-  it('AppNavBar include View Projects Link', () => {
-    (useKeycloak as jest.Mock).mockReturnValue({
-      keycloak: {
-        subject: 'test',
-        userInfo: {
-          roles: ['admin-properties', 'admin-projects'],
-        },
-      },
-    });
-
-    const { getByText } = render(
-      <Provider store={store}>
-        <Router history={history}>
-          <AppNavBar />
-        </Router>
-      </Provider>,
-    );
-    const link = getByText('View Projects');
-    expect(link).toBeTruthy();
-  });
-
   describe('AppNavBar Links Based on Security', () => {
-    it('AppNavBar include Approval Requests Link', () => {
-      (useKeycloak as jest.Mock).mockReturnValue({
-        keycloak: {
-          subject: 'test',
-          userInfo: {
-            roles: ['dispose-approve'],
-          },
-        },
-      });
-      const { getByText } = render(
-        <Provider store={store}>
-          <Router history={history}>
-            <AppNavBar />
-          </Router>
-        </Provider>,
-      );
-      const link = getByText('Approval Requests');
-      expect(link).toBeTruthy();
-    });
-
     describe('AppNavBar Administation Dropdown', () => {
       it('AppNavBar include Administration Dropdown', () => {
         (useKeycloak as jest.Mock).mockReturnValue({
           keycloak: {
             subject: 'test',
             userInfo: {
-              groups: ['System Administrator'],
+              groups: [Roles.SYSTEM_ADMINISTRATOR],
             },
           },
         });
@@ -107,29 +68,7 @@ describe('AppNavBar', () => {
         );
         const element = getByText('Administration');
 
-        expect(element).toBeTruthy();
-      });
-
-      it('AppNavBar include Admin Access Requests Link', () => {
-        (useKeycloak as jest.Mock).mockReturnValue({
-          keycloak: {
-            subject: 'test',
-            userInfo: {
-              groups: ['System Administrator'],
-            },
-          },
-        });
-        const { getByText } = render(
-          <Provider store={store}>
-            <Router history={history}>
-              <AppNavBar />
-            </Router>
-          </Provider>,
-        );
-        fireEvent.click(getByText('Administration'));
-        const element = getByText('Access Requests');
-
-        expect(element).toBeTruthy();
+        expect(element).toBeVisible();
       });
 
       it('AppNavBar include Admin Users Link', () => {
@@ -137,7 +76,7 @@ describe('AppNavBar', () => {
           keycloak: {
             subject: 'test',
             userInfo: {
-              groups: ['System Administrator'],
+              groups: [Roles.SYSTEM_ADMINISTRATOR],
             },
           },
         });
@@ -152,7 +91,50 @@ describe('AppNavBar', () => {
         fireEvent.click(getByText('Administration'));
         const element = getByText('Users');
 
-        expect(element).toBeTruthy();
+        expect(element).toBeVisible();
+      });
+      it('AppNavBar include Admin Access Requests Link', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              groups: [Roles.SYSTEM_ADMINISTRATOR],
+            },
+          },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        fireEvent.click(getByText('Administration'));
+        const element = getByText('Access Requests');
+
+        expect(element).toBeVisible();
+      });
+
+      it('AppNavBar include Admin Agencies link', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              groups: [Roles.SYSTEM_ADMINISTRATOR],
+            },
+          },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        fireEvent.click(getByText('Administration'));
+        const element = getByText('Agencies');
+
+        expect(element).toBeVisible();
       });
     });
 
@@ -162,7 +144,7 @@ describe('AppNavBar', () => {
           keycloak: {
             subject: 'test',
             userInfo: {
-              roles: ['property-add', 'property-view'],
+              roles: [Claims.PROPERTY_ADD, Claims.PROPERTY_VIEW],
             },
           },
         });
@@ -175,7 +157,7 @@ describe('AppNavBar', () => {
         );
         const element = getByText('Manage Property');
 
-        expect(element).toBeTruthy();
+        expect(element).toBeVisible();
       });
 
       it('AppNavBar include Submit Property Link', () => {
@@ -183,7 +165,7 @@ describe('AppNavBar', () => {
           keycloak: {
             subject: 'test',
             userInfo: {
-              roles: ['property-add', 'property-view'],
+              roles: [Claims.PROPERTY_ADD, Claims.PROPERTY_VIEW],
             },
           },
         });
@@ -198,7 +180,7 @@ describe('AppNavBar', () => {
         fireEvent.click(getByText('Manage Property'));
         const element = getByText('Submit Property');
 
-        expect(element).toBeTruthy();
+        expect(element).toBeVisible();
       });
 
       it('AppNavBar include View Inventory Link', () => {
@@ -206,7 +188,7 @@ describe('AppNavBar', () => {
           keycloak: {
             subject: 'test',
             userInfo: {
-              roles: ['property-view'],
+              roles: [Claims.PROPERTY_ADD, Claims.PROPERTY_VIEW],
             },
           },
         });
@@ -221,51 +203,161 @@ describe('AppNavBar', () => {
         fireEvent.click(getByText('Manage Property'));
         const element = getByText('View Inventory');
 
-        expect(element).toBeTruthy();
+        expect(element).toBeVisible();
       });
     });
 
-    it('AppNavBar include Disposal Project Link', () => {
-      (useKeycloak as jest.Mock).mockReturnValue({
-        keycloak: {
-          subject: 'test',
-          userInfo: {
-            roles: ['admin-properties', 'admin-projects'],
+    describe('AppNavBar Disposal Projects dropdown', () => {
+      it('AppNavBar include Disposal Projects dropdown for admin', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              roles: [Claims.ADMIN_PROPERTIES, Claims.ADMIN_PROJECTS],
+            },
           },
-        },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        const element = getByText('Disposal Projects');
+
+        expect(element).toBeVisible();
+      });
+      it('AppNavBar include Disposal Projects dropdown for Approval requests only', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              roles: [Claims.DISPOSE_APPROVE],
+            },
+          },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        const element = getByText('Disposal Projects');
+
+        expect(element).toBeVisible();
+      });
+      it('AppNavBar include Create Disposal Project Link', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              roles: [Claims.ADMIN_PROPERTIES, Claims.ADMIN_PROJECTS],
+            },
+          },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        fireEvent.click(getByText('Disposal Projects'));
+        const link = getByText('Create Disposal Project');
+
+        expect(link).toBeVisible();
       });
 
-      const { getByText } = render(
-        <Provider store={store}>
-          <Router history={history}>
-            <AppNavBar />
-          </Router>
-        </Provider>,
-      );
-      const link = getByText('Dispose Properties');
-      expect(link).toBeTruthy();
-    });
-  });
+      it('AppNavBar include View Projects Link', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              roles: [Claims.ADMIN_PROPERTIES, Claims.ADMIN_PROJECTS],
+            },
+          },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        fireEvent.click(getByText('Disposal Projects'));
+        const link = getByText('View Projects');
 
-  it('AppNavBar include Reports Link', () => {
-    (useKeycloak as jest.Mock).mockReturnValue({
-      keycloak: {
-        subject: 'test',
-        userInfo: {
-          roles: ['reports-view', 'spl-reports'],
-        },
-      },
+        expect(link).toBeVisible();
+      });
+
+      it('AppNavBar include Approval Requests Link', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              roles: [Claims.DISPOSE_APPROVE],
+            },
+          },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        fireEvent.click(getByText('Disposal Projects'));
+        const link = getByText('Approval Requests');
+
+        expect(link).toBeVisible();
+      });
     });
 
-    const { getByText } = render(
-      <Provider store={store}>
-        <Router history={history}>
-          <AppNavBar />
-        </Router>
-      </Provider>,
-    );
-    const link = getByText('Reports');
-    expect(link).toBeTruthy();
+    describe('AppNavBar Reports Dropdown', () => {
+      it('AppNavBar include Reports Dropdown', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              roles: [Claims.REPORTS_VIEW, Claims.REPORTS_SPL],
+            },
+          },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        const link = getByText('Reports');
+        expect(link).toBeVisible();
+      });
+
+      it('AppNavBar include SPL Reports link', () => {
+        (useKeycloak as jest.Mock).mockReturnValue({
+          keycloak: {
+            subject: 'test',
+            userInfo: {
+              roles: [Claims.REPORTS_VIEW, Claims.REPORTS_SPL],
+            },
+          },
+        });
+        const { getByText } = render(
+          <Provider store={store}>
+            <Router history={history}>
+              <AppNavBar />
+            </Router>
+          </Provider>,
+        );
+        fireEvent.click(getByText('Reports'));
+        const link = getByText('SPL Report');
+
+        expect(link).toBeVisible();
+      });
+    });
   });
 
   describe('AppNavbar user name display', () => {
@@ -276,7 +368,7 @@ describe('AppNavBar', () => {
           userInfo: {
             name: 'display name',
             firstName: 'name',
-            roles: ['project-add'],
+            roles: [Claims.PROJECT_ADD],
           },
         },
       });
@@ -297,7 +389,7 @@ describe('AppNavBar', () => {
         keycloak: {
           subject: 'test',
           userInfo: {
-            roles: ['project-add'],
+            roles: [Claims.PROJECT_ADD],
             firstName: 'firstName',
             lastName: 'lastName',
           },
@@ -320,75 +412,7 @@ describe('AppNavBar', () => {
         keycloak: {
           subject: 'test',
           userInfo: {
-            roles: ['project-add'],
-          },
-        },
-      });
-
-      const { getByText } = render(
-        <Provider store={store}>
-          <Router history={history}>
-            <AppNavBar />
-          </Router>
-        </Provider>,
-      );
-      const name = getByText('default');
-      expect(name).toBeVisible();
-    });
-  });
-  describe('AppNavbar user name display', () => {
-    it('Displays keycloak display name if available', () => {
-      (useKeycloak as jest.Mock).mockReturnValue({
-        keycloak: {
-          subject: 'test',
-          userInfo: {
-            name: 'display name',
-            firstName: 'name',
-            roles: ['project-add'],
-          },
-        },
-      });
-
-      const { getByText } = render(
-        <Provider store={store}>
-          <Router history={history}>
-            <AppNavBar />
-          </Router>
-        </Provider>,
-      );
-      const name = getByText('display name');
-      expect(name).toBeVisible();
-    });
-
-    it('Displays first last name if no display name', () => {
-      (useKeycloak as jest.Mock).mockReturnValue({
-        keycloak: {
-          subject: 'test',
-          userInfo: {
-            roles: ['project-add'],
-            firstName: 'firstName',
-            lastName: 'lastName',
-          },
-        },
-      });
-
-      const { getByText } = render(
-        <Provider store={store}>
-          <Router history={history}>
-            <AppNavBar />
-          </Router>
-        </Provider>,
-      );
-      const name = getByText('firstName lastName');
-      expect(name).toBeVisible();
-    });
-
-    it('Displays default if no user name information found', () => {
-      (useKeycloak as jest.Mock).mockReturnValue({
-        keycloak: {
-          subject: 'test',
-          userInfo: {
-            roles: ['project-add'],
+            roles: [Claims.PROJECT_ADD],
           },
         },
       });

--- a/frontend/src/components/layout/AppNavBar/AppNavBar.tsx
+++ b/frontend/src/components/layout/AppNavBar/AppNavBar.tsx
@@ -10,7 +10,7 @@ import { FaHome } from 'react-icons/fa';
 import queryString from 'query-string';
 
 /**
- * Nav bar with with role-based functionality.
+ * Nav bar with role-based functionality.
  */
 function AppNavBar() {
   const keycloak = useKeycloakWrapper();
@@ -32,9 +32,7 @@ function AppNavBar() {
           </Nav.Item>
           <AdminDropdown />
           <PropertyDropdown />
-          <ViewProjects />
-          <DisposeRequest />
-          <ViewProjectApprovalRequests />
+          <DisposeProjectsDropdown />
           <ReportsDropdown />
         </Nav>
       </Navbar.Collapse>
@@ -132,55 +130,41 @@ function AdminDropdown() {
 }
 
 /**
- * View Projects navigation menu link.
+ * Disposal Projects navigation dropdown menu.
  */
-function ViewProjects() {
+function DisposeProjectsDropdown() {
   const history = useHistory();
   const keycloak = useKeycloakWrapper();
-  return keycloak.hasClaim('admin-properties') && keycloak.hasClaim('admin-projects') ? (
-    <Nav.Link
-      className={history.location.pathname.includes('projects/list') ? 'active' : 'idle'}
-      onClick={() => history.push('/projects/list')}
-    >
-      View Projects
-    </Nav.Link>
-  ) : null;
-}
-
-/**
- * View Projects Approval Requests navigation menu link.
- */
-function ViewProjectApprovalRequests() {
-  const keycloak = useKeycloakWrapper();
-  const history = useHistory();
-  return keycloak.hasClaim(Claims.DISPOSE_APPROVE) ? (
-    <Nav.Link
+  // admin-projects and admin-properties roles are needed to Create/View projects,
+  // but only dispose-approve is needed to see Approval requests
+  return (keycloak.hasClaim(Claims.ADMIN_PROPERTIES) && keycloak.hasClaim(Claims.ADMIN_PROJECTS)) ||
+    keycloak.hasClaim(Claims.DISPOSE_APPROVE) ? (
+    <NavDropdown
       className={
-        history.location.pathname.includes('projects/approval') ||
-        history.location.pathname.includes('assess')
+        history.location.pathname.includes('dispose') ||
+        history.location.pathname.includes('projects')
           ? 'active'
           : 'idle'
       }
-      onClick={() => history.push('/projects/approval/requests')}
+      title="Disposal Projects"
+      id="dispose"
     >
-      Approval Requests
-    </Nav.Link>
-  ) : null;
-}
-
-/**
- * Disposal Project navigation dropdown menu.
- */
-function DisposeRequest() {
-  const history = useHistory();
-  const keycloak = useKeycloakWrapper();
-  return keycloak.hasClaim('admin-properties') && keycloak.hasClaim('admin-projects') ? (
-    <Nav.Link
-      className={history.location.pathname.includes('dispose') ? 'active' : 'idle'}
-      onClick={() => history.push('/dispose')}
-    >
-      Dispose Properties
-    </Nav.Link>
+      {keycloak.hasClaim(Claims.ADMIN_PROPERTIES) && keycloak.hasClaim(Claims.ADMIN_PROJECTS) && (
+        <>
+          <NavDropdown.Item onClick={() => history.push('/dispose')}>
+            Create Disposal Project
+          </NavDropdown.Item>
+          <NavDropdown.Item onClick={() => history.push('/projects/list')}>
+            View Projects
+          </NavDropdown.Item>
+        </>
+      )}
+      {keycloak.hasClaim(Claims.DISPOSE_APPROVE) && (
+        <NavDropdown.Item onClick={() => history.push('/projects/approval/requests')}>
+          Approval Requests
+        </NavDropdown.Item>
+      )}
+    </NavDropdown>
   ) : null;
 }
 
@@ -196,9 +180,9 @@ function ReportsDropdown() {
       title="Reports"
       id="reports"
     >
-      {keycloak.hasClaim(Claims.REPORTS_SPL) ? (
+      {keycloak.hasClaim(Claims.REPORTS_SPL) && (
         <NavDropdown.Item onClick={() => history.push('/reports/spl')}>SPL Report</NavDropdown.Item>
-      ) : null}
+      )}
     </NavDropdown>
   ) : null;
 }

--- a/frontend/src/components/layout/AppNavBar/__snapshots__/AppNavBar.test.tsx.snap
+++ b/frontend/src/components/layout/AppNavBar/__snapshots__/AppNavBar.test.tsx.snap
@@ -120,9 +120,7 @@ exports[`AppNavBar AppNavBar snapshot test. 1`] = `
                     </NavItem>
                     <AdminDropdown />
                     <PropertyDropdown />
-                    <ViewProjects />
-                    <DisposeRequest />
-                    <ViewProjectApprovalRequests />
+                    <DisposeProjectsDropdown />
                     <ReportsDropdown />
                   </div>
                 </ForwardRef>

--- a/frontend/src/features/properties/components/GeocoderAutoComplete.scss
+++ b/frontend/src/features/properties/components/GeocoderAutoComplete.scss
@@ -40,9 +40,10 @@
   width: 400px;
   overflow: hidden;
   cursor: pointer;
-}
+  color: $text-color;
 
-.GeocoderAutoComplete option:hover {
-  background-color: $active-color;
-  color: #fff;
+  &:hover {
+    background-color: $active-color;
+    color: #fff;
+  }
 }


### PR DESCRIPTION
Fixed the NavBar unit tests, reordered tests to match ordering on page, added a few tests to cover all menu items.
Also fixed the dropdown styling so they all match
![Navbar](https://user-images.githubusercontent.com/33818575/101549910-5412dd00-3963-11eb-958e-192a14bf1921.gif)

![Dropdowns](https://user-images.githubusercontent.com/33818575/101549880-478e8480-3963-11eb-904c-ea20399da06d.gif)

