### PR TITLE
Minor improvements to resolve memory issues

### DIFF
--- a/backend/api/Areas/Property/Controllers/SearchController.cs
+++ b/backend/api/Areas/Property/Controllers/SearchController.cs
@@ -122,7 +122,7 @@ namespace Pims.Api.Areas.Property.Controllers
 
             var pfilter = filter.CopyValues(new AllPropertyFilter());
 
-            var properties = _pimsService.Property.Get(pfilter).ToArray();
+            var properties = _pimsService.Property.Search(pfilter).ToArray();
             return new JsonResult(_mapper.Map<GeoJson<PropertyModel>[]>(properties).ToArray());
         }
 

--- a/backend/dal/Services/IPropertyService.cs
+++ b/backend/dal/Services/IPropertyService.cs
@@ -11,6 +11,7 @@ namespace Pims.Dal.Services
     {
         int Count();
         IEnumerable<ProjectProperty> Get(AllPropertyFilter filter);
+        IEnumerable<ProjectProperty> Search(AllPropertyFilter filter);
         Paged<Property> GetPage(AllPropertyFilter filter);
     }
 }


### PR DESCRIPTION
The massive request for all properties is killing the DB and API.  Constant `Out of Memory` issues keep showing up.  Which results in a `Gateway Timeout` on the app.

This change reimplements `_.debounce(...)` to reduce the number of requests.  In addition a temporary DAL method that does not incur an additional request for project status information has been created to reduce the load.  In reality we shouldn't be making the project status request in this endpoint anyway, but I don't have time to refactor other features presently.