### PR TITLE
PA-1740, 1771: Allow text boxes to expand, fix Net Book Value

### DIFF
--- a/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
+++ b/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`Review Approve Step renders correctly 1`] = `
             Description
           </label>
           <textarea
-            class="col-md-5 form-control"
+            class="col-md-auto form-control"
             disabled=""
             id="input-description"
             name="description"
@@ -737,7 +737,7 @@ exports[`Review Approve Step renders correctly 1`] = `
                 Appraised Notes
               </label>
               <textarea
-                class="col-md-5 form-control"
+                class="col-md-auto form-control"
                 id="input-appraisedNote"
                 name="appraisedNote"
               />

--- a/frontend/src/features/projects/common/ProjectLayout.scss
+++ b/frontend/src/features/projects/common/ProjectLayout.scss
@@ -123,7 +123,14 @@
   }
 
   textarea {
-    height: 8rem;
+    min-height: 8rem;
+
+    &.col-md-auto {
+      resize: both;
+      min-width: 41.666667%; //match col-md-5 percentage
+      width: 41.666667%; //match col-md-5 percentage on load
+      max-width: 83.3%; //prevents box from moving labels around
+    }
   }
 
   input:disabled {

--- a/frontend/src/features/projects/common/__snapshots__/ProjectSummaryView.test.tsx.snap
+++ b/frontend/src/features/projects/common/__snapshots__/ProjectSummaryView.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`Review Summary View renders approved correctly 1`] = `
             Description
           </label>
           <textarea
-            className="col-md-5 form-control"
+            className="col-md-auto form-control"
             disabled={true}
             id="input-description"
             name="description"
@@ -1003,7 +1003,7 @@ exports[`Review Summary View renders denied correctly 1`] = `
             Description
           </label>
           <textarea
-            className="col-md-5 form-control"
+            className="col-md-auto form-control"
             disabled={true}
             id="input-description"
             name="description"
@@ -1869,7 +1869,7 @@ exports[`Review Summary View renders submitted correctly 1`] = `
             Description
           </label>
           <textarea
-            className="col-md-5 form-control"
+            className="col-md-auto form-control"
             disabled={true}
             id="input-description"
             name="description"

--- a/frontend/src/features/projects/common/forms/AppraisalCheckListForm.tsx
+++ b/frontend/src/features/projects/common/forms/AppraisalCheckListForm.tsx
@@ -34,6 +34,7 @@ const AppraisalCheckListForm: React.FunctionComponent<IAppraisalCheckListFormPro
           </h3>
           <TasksForm tasks={tasks} isReadOnly={props.isReadOnly} />
           <ProjectNotes
+            className="col-md-auto"
             outerClassName="col-md-12 reviewRequired"
             field="appraisedNote"
             label="Appraised Notes"

--- a/frontend/src/features/projects/common/forms/ProjectDraftForm.tsx
+++ b/frontend/src/features/projects/common/forms/ProjectDraftForm.tsx
@@ -59,7 +59,7 @@ const ProjectDraftForm = ({
           disabled={isReadOnly}
           field="description"
           label="Description"
-          className="col-md-5"
+          className="col-md-auto"
           outerClassName="col-md-10"
         />
       </Form.Row>

--- a/frontend/src/features/projects/common/forms/SelectProjectPropertiesForm.tsx
+++ b/frontend/src/features/projects/common/forms/SelectProjectPropertiesForm.tsx
@@ -27,7 +27,7 @@ const SelectProjectPropertiesForm = ({
         setPageIndex={setPageIndex}
         field="properties"
       />
-      <ProjectNotes />
+      <ProjectNotes className="col-md-auto" />
       <StepErrorSummary />
     </Form>
   );

--- a/frontend/src/features/projects/common/tabs/ProjectInformationTab.tsx
+++ b/frontend/src/features/projects/common/tabs/ProjectInformationTab.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { Container } from 'react-bootstrap';
-import { ProjectNotes, ProjectDraftForm, UpdateInfoForm, useProject } from '../../common';
-import { PublicNotes, PrivateNotes } from '../../common';
+import {
+  ProjectNotes,
+  PublicNotes,
+  PrivateNotes,
+  ProjectDraftForm,
+  UpdateInfoForm,
+  useProject,
+} from '../../common';
 import AdditionalPropertyInformationForm from '../forms/AdditionalPropertyInformationForm';
 
 interface IProjectInformationTabProps {
@@ -25,14 +31,15 @@ const ProjectInformationTab: React.FunctionComponent<IProjectInformationTabProps
       />
 
       <h3>Notes</h3>
-      <ProjectNotes disabled={true} label="Agency Notes" />
-      <PublicNotes disabled={isReadOnly} />
-      <PrivateNotes disabled={isReadOnly} />
+      <ProjectNotes className="col-md-auto" disabled={true} label="Agency Notes" />
+      <PublicNotes className="col-md-auto" disabled={isReadOnly} />
+      <PrivateNotes className="col-md-auto" disabled={isReadOnly} />
       <ProjectNotes
         label="Reporting"
-        field="reportingNote"
-        disabled={isReadOnly}
         tooltip="Notes for Reporting"
+        field="reportingNote"
+        className="col-md-auto"
+        disabled={isReadOnly}
       />
     </Container>
   );

--- a/frontend/src/features/projects/dispose/ProjectDisposeView.scss
+++ b/frontend/src/features/projects/dispose/ProjectDisposeView.scss
@@ -126,7 +126,14 @@
   }
 
   textarea {
-    height: 8rem;
+    min-height: 8rem;
+
+    &.col-md-auto {
+      resize: both;
+      min-width: 41.666667%; //match col-md-5 percentage
+      width: 41.666667%; //match col-md-5 percentage on load
+      max-width: 83.3%; //prevents box from moving labels around
+    }
   }
 
   input:disabled {

--- a/frontend/src/features/projects/dispose/steps/DocumentationStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/DocumentationStep.tsx
@@ -62,7 +62,7 @@ const DocumentationStep = ({ isReadOnly, formikRef }: IStepProps) => {
               isReadOnly={isReadOnly || !canUserEditForm(project.agencyId)}
               tasks={tasks}
             />
-            {!isReadOnly && <ProjectNotes />}
+            {!isReadOnly && <ProjectNotes className="col-md-auto" />}
             <StepErrorSummary />
           </Form>
         )}

--- a/frontend/src/features/projects/dispose/steps/ProjectDraftStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/ProjectDraftStep.tsx
@@ -41,7 +41,7 @@ const ProjectDraftStep = ({ isReadOnly, formikRef }: IStepProps) => {
             <ProjectDraftForm
               isReadOnly={isPreDraft() ? false : isReadOnly || !canUserEditForm(project.agencyId)}
             />
-            <ProjectNotes />
+            <ProjectNotes className="col-md-auto" />
             <StepErrorSummary />
           </Form>
         )}

--- a/frontend/src/features/projects/dispose/steps/ReviewProjectStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/ReviewProjectStep.tsx
@@ -32,8 +32,8 @@ const ReviewProjectStep = ({ formikRef }: IStepProps) => {
       >
         <Form>
           <ReviewProjectForm canEdit={canEdit} />
-          <ProjectNotes disabled={true} />
-          <PublicNotes disabled={!canEdit} />
+          <ProjectNotes className="col-md-auto" disabled={true} />
+          <PublicNotes className="col-md-auto" disabled={!canEdit} />
           {canSubmit ? (
             <Form.Label style={{ float: 'right' }}>
               Apply to the Surplus Property Program

--- a/frontend/src/features/projects/dispose/steps/UpdateInfoStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/UpdateInfoStep.tsx
@@ -32,7 +32,7 @@ const UpdateInfoStep = ({ isReadOnly, formikRef }: IStepProps) => {
             isReadOnly={isReadOnly || !canUserEditForm(project.agencyId)}
             title="Project Information"
           />
-          <ProjectNotes />
+          <ProjectNotes className="col-md-auto" />
           <StepErrorSummary />
         </Form>
       </Formik>

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/DocumentationStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/DocumentationStep.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Documentation Step renders correctly 1`] = `
           Notes
         </label>
         <textarea
-          className="col-md-5 form-control"
+          className="col-md-auto form-control"
           id="input-note"
           name="note"
           onBlur={[Function]}

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/ProjectDraftStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/ProjectDraftStep.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`Project Draft Step renders correctly 1`] = `
             Description
           </label>
           <textarea
-            class="col-md-5 form-control"
+            class="col-md-auto form-control"
             disabled=""
             id="input-description"
             name="description"
@@ -100,7 +100,7 @@ exports[`Project Draft Step renders correctly 1`] = `
           Notes
         </label>
         <textarea
-          class="col-md-5 form-control"
+          class="col-md-auto form-control"
           id="input-note"
           name="note"
         />

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/ReviewProjectStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/ReviewProjectStep.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`renders correctly 1`] = `
             Description
           </label>
           <textarea
-            className="col-md-5 form-control"
+            className="col-md-auto form-control"
             disabled={true}
             id="input-description"
             name="description"
@@ -719,7 +719,7 @@ exports[`renders correctly 1`] = `
           Notes
         </label>
         <textarea
-          className="col-md-5 form-control"
+          className="col-md-auto form-control"
           disabled={true}
           id="input-note"
           name="note"
@@ -765,7 +765,7 @@ exports[`renders correctly 1`] = `
           </svg>
         </label>
         <textarea
-          className="col-md-5 form-control"
+          className="col-md-auto form-control"
           disabled={true}
           id="input-publicNote"
           name="publicNote"

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
@@ -804,7 +804,7 @@ exports[`renders correctly 1`] = `
           Notes
         </label>
         <textarea
-          className="col-md-5 form-control"
+          className="col-md-auto form-control"
           id="input-note"
           name="note"
           onBlur={[Function]}

--- a/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
@@ -1141,7 +1141,7 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                 Adjustment to Prior Year Sale Notes
               </label>
               <textarea
-                class="col-md-5 form-control"
+                class="col-md-auto form-control"
                 id="input-notes[11].note"
                 name="notes[11].note"
               >

--- a/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`GRE Transfer Step renders correctly 1`] = `
             Description
           </label>
           <textarea
-            className="col-md-5 form-control"
+            className="col-md-auto form-control"
             disabled={true}
             id="input-description"
             name="description"

--- a/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
             style="box-sizing: border-box; flex: 80 0 auto; min-width: 80px; width: 3.5%; justify-content: flex-start; text-align: left; align-items: center; display: flex;"
             width="3.5%"
           >
-            Net Book
+            Net Book Value
           </div>
           <div
             class="th"

--- a/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
@@ -280,7 +280,7 @@ exports[`Project list view tests Matches snapshot 1`] = `
             style="box-sizing: border-box; flex: 80 0 auto; min-width: 80px; width: 3.5%; justify-content: flex-start; text-align: left; align-items: center; display: flex;"
             width="3.5%"
           >
-            Net Book
+            Net Book Value
           </div>
           <div
             class="th"

--- a/frontend/src/features/projects/list/columns.tsx
+++ b/frontend/src/features/projects/list/columns.tsx
@@ -91,7 +91,7 @@ export const columns = (onDelete?: (id: string) => void): ColumnWithProps<IProje
       minWidth: 80,
     },
     {
-      Header: 'Net Book',
+      Header: 'Net Book Value',
       accessor: 'netBook',
       align: 'left',
       clickable: true,

--- a/frontend/src/features/projects/spl/forms/CloseOutAdjustmentForm.tsx
+++ b/frontend/src/features/projects/spl/forms/CloseOutAdjustmentForm.tsx
@@ -50,6 +50,7 @@ const CloseOutAdjustment = (props: CloseOutAdjustmentProps) => {
       <ProjectNotes
         label="Adjustment to Prior Year Sale Notes"
         field={`notes[${NoteTypes.Adjustment}].note`}
+        className="col-md-auto"
         outerClassName="col-md-12"
       />
     </Fragment>

--- a/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.scss
+++ b/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.scss
@@ -16,4 +16,9 @@
     font-family: 'BCSans', Fallback, sans-serif;
     padding-right: 1rem;
   }
+  textarea {
+    &.col-md-auto {
+      max-width: 75%; //prevents box from stretching off the side of the page
+    }
+  }
 }

--- a/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.tsx
+++ b/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.tsx
@@ -213,6 +213,7 @@ const SurplusPropertyListForm = ({
         label="Offers Received"
         tooltip="Review required for offer(s) in Tier 3 & 4"
         field="offersNote"
+        className="col-md-auto"
         outerClassName="col-md-12"
         disabled={isReadOnly}
       />

--- a/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
+++ b/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
@@ -1153,7 +1153,7 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                 Adjustment to Prior Year Sale Notes
               </label>
               <textarea
-                class="col-md-5 form-control"
+                class="col-md-auto form-control"
                 id="input-notes[11].note"
                 name="notes[11].note"
               >
@@ -1533,7 +1533,7 @@ exports[`SPL Approval Step renders correctly 1`] = `
                 </svg>
               </label>
               <textarea
-                class="col-md-5 form-control"
+                class="col-md-auto form-control"
                 disabled=""
                 id="input-offersNote"
                 name="offersNote"

--- a/frontend/src/features/projects/spl/tabs/SurplusPropertyInformationTab.tsx
+++ b/frontend/src/features/projects/spl/tabs/SurplusPropertyInformationTab.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { Container } from 'react-bootstrap';
-import { ProjectNotes, ProjectDraftForm, UpdateInfoForm, useProject } from '../../common';
-import { PublicNotes, PrivateNotes } from '../../common';
+import {
+  PublicNotes,
+  PrivateNotes,
+  ProjectNotes,
+  ProjectDraftForm,
+  UpdateInfoForm,
+  useProject,
+} from '../../common';
 import AdditionalPropertyInformationForm from '../../common/forms/AdditionalPropertyInformationForm';
 
 interface ISurplusPropertyInformationTabProps {
@@ -25,12 +31,13 @@ const SurplusPropertyInformationTab: React.FunctionComponent<ISurplusPropertyInf
       />
 
       <h3>Notes</h3>
-      <ProjectNotes disabled={true} label="Agency Notes" />
-      <PublicNotes disabled={isReadOnly} />
-      <PrivateNotes disabled={isReadOnly} />
+      <ProjectNotes className="col-md-auto" disabled={true} label="Agency Notes" />
+      <PublicNotes className="col-md-auto" disabled={isReadOnly} />
+      <PrivateNotes className="col-md-auto" disabled={isReadOnly} />
       <ProjectNotes
         label="Reporting"
         field="reportingNote"
+        className="col-md-auto"
         disabled={isReadOnly}
         tooltip="Notes for Reporting"
       />


### PR DESCRIPTION
Allow notes text boxes to expand in disposal projects
Fix "Net Book" to "Net Book Value" everywhere
![textboxes](https://user-images.githubusercontent.com/33818575/101815137-f5b93c00-3ad3-11eb-86ad-828bfe9d3dae.gif)
