### PR TITLE
PA-2114 Zoom to property when filtering on Map

### DIFF
--- a/frontend/src/components/maps/providers/FIlterProvider.tsx
+++ b/frontend/src/components/maps/providers/FIlterProvider.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { noop } from 'lodash';
+
+const FilterContext = React.createContext<{
+  changed: boolean;
+  setChanged: (state: boolean) => void;
+}>({ changed: true, setChanged: noop });
+
+/**
+ * Map filter change state manager,
+ * helps the inventory layer zoom to the results when submitting the filter form
+ */
+export const FilterProvider: React.FC = ({ children }) => {
+  // Default changed state to true on page load
+  const [changed, setChanged] = React.useState(true);
+
+  return (
+    <FilterContext.Provider value={{ changed, setChanged }}>{children}</FilterContext.Provider>
+  );
+};
+
+export const useFilterContext = () => React.useContext(FilterContext);

--- a/frontend/src/features/properties/map/MapView.tsx
+++ b/frontend/src/features/properties/map/MapView.tsx
@@ -20,6 +20,7 @@ import * as API from 'constants/API';
 import _ from 'lodash';
 import MapSideBarContainer from 'features/mapSideBar/containers/MapSideBarContainer';
 import classNames from 'classnames';
+import { FilterProvider } from 'components/maps/providers/FIlterProvider';
 
 /** rough center of bc Itcha Ilgachuz Provincial Park */
 const defaultLatLng = {
@@ -80,56 +81,58 @@ const MapView: React.FC<MapViewProps> = (props: MapViewProps) => {
         }}
         properties={properties}
       ></MapSideBarContainer>
-      <Map
-        lat={
-          (propertyDetail?.parcelDetail?.latitude as number) ??
-          selectedDraftProperty?.parcelDetail?.latitude ??
-          defaultLatLng.lat
-        }
-        lng={
-          (propertyDetail?.parcelDetail?.longitude as number) ??
-          selectedDraftProperty?.parcelDetail?.longitude ??
-          defaultLatLng.lng
-        }
-        properties={properties}
-        selectedProperty={
-          !!propertyDetail?.parcelDetail ? propertyDetail : (selectedDraftProperty as any)
-        }
-        agencies={agencies}
-        propertyClassifications={propertyClassifications}
-        lotSizes={lotSizes}
-        onMarkerClick={
-          props.onMarkerClick ??
-          ((p, position) => {
-            if (
-              p.propertyTypeId !== undefined &&
-              [PropertyTypes.BUILDING, PropertyTypes.PARCEL].includes(p.propertyTypeId)
-            ) {
-              p.id && dispatch(fetchPropertyDetail(p.id, p.propertyTypeId as any, position));
-            } else {
-              setSelectedDraftProperty({
-                propertyTypeId: p.propertyTypeId,
-                parcelDetail: { ...p },
-              } as any);
-            }
-          })
-        }
-        onMarkerPopupClose={() => {
-          setSelectedDraftProperty(null);
-          dispatch(storeParcelDetail(null));
-        }}
-        onViewportChanged={(mapFilterModel: MapViewportChangeEvent) => {
-          if (!loadedProperties) {
-            setLoadedProperties(true);
+      <FilterProvider>
+        <Map
+          lat={
+            (propertyDetail?.parcelDetail?.latitude as number) ??
+            selectedDraftProperty?.parcelDetail?.latitude ??
+            defaultLatLng.lat
           }
-        }}
-        onMapClick={saveLatLng}
-        disableMapFilterBar={props.disableMapFilterBar}
-        interactive={!props.disabled}
-        showParcelBoundaries={props.showParcelBoundaries ?? true}
-        zoom={6}
-        mapRef={mapRef}
-      />
+          lng={
+            (propertyDetail?.parcelDetail?.longitude as number) ??
+            selectedDraftProperty?.parcelDetail?.longitude ??
+            defaultLatLng.lng
+          }
+          properties={properties}
+          selectedProperty={
+            !!propertyDetail?.parcelDetail ? propertyDetail : (selectedDraftProperty as any)
+          }
+          agencies={agencies}
+          propertyClassifications={propertyClassifications}
+          lotSizes={lotSizes}
+          onMarkerClick={
+            props.onMarkerClick ??
+            ((p, position) => {
+              if (
+                p.propertyTypeId !== undefined &&
+                [PropertyTypes.BUILDING, PropertyTypes.PARCEL].includes(p.propertyTypeId)
+              ) {
+                p.id && dispatch(fetchPropertyDetail(p.id, p.propertyTypeId as any, position));
+              } else {
+                setSelectedDraftProperty({
+                  propertyTypeId: p.propertyTypeId,
+                  parcelDetail: { ...p },
+                } as any);
+              }
+            })
+          }
+          onMarkerPopupClose={() => {
+            setSelectedDraftProperty(null);
+            dispatch(storeParcelDetail(null));
+          }}
+          onViewportChanged={(mapFilterModel: MapViewportChangeEvent) => {
+            if (!loadedProperties) {
+              setLoadedProperties(true);
+            }
+          }}
+          onMapClick={saveLatLng}
+          disableMapFilterBar={props.disableMapFilterBar}
+          interactive={!props.disabled}
+          showParcelBoundaries={props.showParcelBoundaries ?? true}
+          zoom={6}
+          mapRef={mapRef}
+        />
+      </FilterProvider>
     </div>
   );
 };

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -49,7 +49,10 @@ export const useApi = (): PimsAPI => {
       dispatch(showLoading());
       return config;
     },
-    error => dispatch(hideLoading()),
+    error => {
+      dispatch(hideLoading());
+      return Promise.reject(error);
+    },
   );
 
   axios.interceptors.response.use(
@@ -57,7 +60,10 @@ export const useApi = (): PimsAPI => {
       dispatch(hideLoading());
       return config;
     },
-    error => dispatch(hideLoading()),
+    error => {
+      dispatch(hideLoading());
+      return Promise.reject(error);
+    },
   );
 
   axios.isPidAvailable = async (parcelId: number | '' | undefined, pid: string | undefined) => {
@@ -117,10 +123,18 @@ export const useApi = (): PimsAPI => {
   };
 
   axios.loadProperties = async (params?: IGeoSearchParams): Promise<any[]> => {
-    const { data } = await axios.get<any[]>(
-      `${ENVIRONMENT.apiUrl}/properties/search/wfs?${params ? queryString.stringify(params) : ''}`,
-    );
-    return data;
+    try {
+      const { data } = await axios.get<any[]>(
+        `${ENVIRONMENT.apiUrl}/properties/search/wfs?${
+          params ? queryString.stringify(params) : ''
+        }`,
+      );
+      return data;
+    } catch (error) {
+      throw new Error(
+        `${(error as any).message}: An error occured while fetching properties in inventory.`,
+      );
+    }
   };
 
   return axios;


### PR DESCRIPTION
When using the filter using the filter bar the map should zoom to the results. The map will resume the default behavior, zooming and moving. I wrapped the inventory results with a featureGroup so that I can zoom to the bounds of the layers/markers on the group. 

I also remove some dead code in the map component, @devinleighsmith ping me if you have an questions