### PR TITLE
PA-2234 Fixing map filter

### DIFF
--- a/frontend/src/components/maps/MapFilterBar.tsx
+++ b/frontend/src/components/maps/MapFilterBar.tsx
@@ -35,7 +35,7 @@ const SearchBar: React.FC = () => {
   const {
     values: { searchBy },
     setFieldValue,
-  } = useFormikContext<MapFilterChangeEvent>();
+  } = useFormikContext<IMapFilter>();
   const desc = state.placeholders[searchBy] || '';
 
   const reset = () => {
@@ -56,7 +56,7 @@ const SearchBar: React.FC = () => {
   );
 };
 
-export interface MapFilterChangeEvent extends BasePropertyFilter {
+export interface IMapFilter extends BasePropertyFilter {
   searchBy: string;
   pid: string;
   address: string;
@@ -75,12 +75,12 @@ type MapFilterProps = {
   agencyLookupCodes: ILookupCode[];
   propertyClassifications: ILookupCode[];
   lotSizes: number[];
-  mapFilter?: MapFilterChangeEvent;
-  onFilterChange: (e: MapFilterChangeEvent) => void;
+  mapFilter?: IMapFilter;
+  onFilterChange: (filter: IMapFilter) => void;
   onFilterReset?: () => void;
 };
 
-const defaultFilterValues: MapFilterChangeEvent = {
+const defaultFilterValues: IMapFilter = {
   searchBy: 'address',
   pid: '',
   address: '',
@@ -128,21 +128,21 @@ const MapFilterBar: React.FC<MapFilterProps> = ({
   }, [agencies, mapFilter]);
 
   const applyEnhancedReferralFilter = () => {
-    const values: MapFilterChangeEvent = { ...formikRef!.values };
+    const values: IMapFilter = { ...formikRef!.values };
     values.inEnhancedReferralProcess = true;
     values.inSurplusPropertyProgram = false;
     onFilterChange(values);
   };
 
   const applySurplusPropertyFilter = () => {
-    const values: MapFilterChangeEvent = { ...formikRef!.values };
+    const values: IMapFilter = { ...formikRef!.values };
     values.inSurplusPropertyProgram = true;
     values.inEnhancedReferralProcess = false;
     onFilterChange(values);
   };
 
   return (
-    <Formik<MapFilterChangeEvent>
+    <Formik<IMapFilter>
       initialValues={{ ...initialValues }}
       enableReinitialize
       validationSchema={FilterBarSchema}

--- a/frontend/src/components/maps/leaflet/InventoryLayer.tsx
+++ b/frontend/src/components/maps/leaflet/InventoryLayer.tsx
@@ -67,7 +67,7 @@ export const InventoryLayer: React.FC<InventoryLayerProps> = ({
   minZoom = minZoom ?? 0;
   maxZoom = maxZoom ?? 18;
 
-  const params = useMemo(
+  const params = useMemo<IGeoSearchParams>(
     () => ({
       bbox: (bounds ?? map.getBounds()).toBBoxString(),
       address: filter?.address,
@@ -86,8 +86,8 @@ export const InventoryLayer: React.FC<InventoryLayerProps> = ({
 
   const search = React.useCallback(
     _.debounce(
-      () => {
-        loadProperties(params)
+      (filter: IGeoSearchParams) => {
+        loadProperties(filter)
           .then(async (data: Feature[]) => {
             const points = data
               .filter(feature => {
@@ -116,7 +116,7 @@ export const InventoryLayer: React.FC<InventoryLayerProps> = ({
 
   // Fetch the geoJSON collection of properties.
   useDeepCompareEffect(() => {
-    search();
+    search(params);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params, bbox, selected, map]);
 

--- a/frontend/src/mocks/filterDataMock.ts
+++ b/frontend/src/mocks/filterDataMock.ts
@@ -1,6 +1,7 @@
 import { ILookupCode } from '../actions/lookupActions';
 import { IParcel, IProperty } from 'actions/parcelsActions';
 import { MapViewportChangeEvent } from 'components/maps/leaflet/Map';
+import { IMapFilter } from 'components/maps/MapFilterBar';
 
 export const SELECTEDCLASSIFICATION = {
   name: 'Core Operational',
@@ -247,7 +248,16 @@ export const ACTIVE = {
 export const mockAgencyModel = {
   bounds: null,
   filter: {
+    searchBy: 'address',
+    pid: '',
+    address: '',
+    administrativeArea: '',
+    projectNumber: '',
     agencies: '1',
-    classificationId: undefined,
-  },
+    classificationId: '',
+    minLotSize: '',
+    maxLotSize: '',
+    inSurplusPropertyProgram: undefined,
+    inEnhancedReferralProcess: undefined,
+  } as IMapFilter,
 } as MapViewportChangeEvent;


### PR DESCRIPTION
Due to rushing in last minute PRs we broke the map filter bar.  This should resolve those issues.  However I have discovered some other issues along the way that will need to be reviewed.  Regrettably there appears to be inconsistent behaviour which results in the following bugs showing up from time-to-time;

- agencies filter input `undefined` and not functioning
- An infinite loop that results in a React error `Maximum update depth exceeded`
- Pins remaining on the map that shouldn't be there after a filter has been entered