### PR TITLE
PA-2211 Added Documentation Note

### DIFF
--- a/auth/keycloak/config/realm-export.json
+++ b/auth/keycloak/config/realm-export.json
@@ -878,6 +878,38 @@
         "account": ["view-profile", "manage-account"]
       },
       "notBefore": 0,
+      "groups": ["/Real Estate Manager", "/SRES"]
+    },
+    {
+      "id": "6c384423-c113-46c5-b23a-14680f4e7b78",
+      "createdTimestamp": 1600787542788,
+      "username": "sresfm",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "firstName": "SRES",
+      "lastName": "Financial Manager",
+      "email": "sresfm@test.com",
+      "attributes": {
+        "displayName": ["Financial Manager, SRES"],
+        "agencies": ["110"]
+      },
+      "credentials": [
+        {
+          "id": "3bd2277a-2c1d-4300-8b8c-a3b4c06d57a3",
+          "type": "password",
+          "createdDate": 1600787563095,
+          "secretData": "{\"value\":\"02MdIh5KlDbjtWM/1gOpdPTsjRVapPr0pJg7Gpkz+vRdQ36fglxnXSwjjoYw2uEExCS9PuD0HP3XI58lcp3vdQ==\",\"salt\":\"JnhiXLXTXG260+B4RUQbcQ==\"}",
+          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\"}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": ["offline_access", "uma_authorization"],
+      "clientRoles": {
+        "account": ["view-profile", "manage-account"]
+      },
+      "notBefore": 0,
       "groups": ["/Real Estate Manager", "/SRES", "/SRES Financial Manager"]
     }
   ],

--- a/backend/entities/NoteTypes.cs
+++ b/backend/entities/NoteTypes.cs
@@ -88,6 +88,10 @@ namespace Pims.Dal.Entities
         /// <summary>
         /// Rational for being removed from SPL.
         /// </summary>
-        SplRemoval = 20
+        SplRemoval = 20,
+        /// <summary>
+        /// Notes related to the provided documentation.
+        /// </summary>
+        Documentation = 21
     }
 }

--- a/frontend/src/constants/noteTypes.ts
+++ b/frontend/src/constants/noteTypes.ts
@@ -44,4 +44,6 @@ export enum NoteTypes {
   Remediation = 19,
   /** Surplus Property List removal rationale. */
   SplRemoval = 20,
+  /** Notes related to the provided documentation. */
+  Documentation = 21,
 }

--- a/frontend/src/features/projects/assess/forms/ReviewApproveForm.tsx
+++ b/frontend/src/features/projects/assess/forms/ReviewApproveForm.tsx
@@ -84,7 +84,7 @@ const ReviewApproveForm = ({
           <TasksForm tasks={exemptionReviewTasks} className="reviewRequired" />
         </>
       )}
-      <DocumentationForm tasks={documentationTasks} isReadOnly={true} />
+      <DocumentationForm tasks={documentationTasks} isReadOnly={true} showNote={true} />
       <TasksForm
         tasks={documentationReviewTasks}
         className="reviewRequired"

--- a/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
+++ b/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
@@ -692,6 +692,25 @@ exports[`Review Approve Step renders correctly 1`] = `
       Documentation
     </h3>
     <div
+      class="ProjectNotes form-row"
+    >
+      <div
+        class="col-md-10 form-group col"
+      >
+        <label
+          class="form-label"
+          for="input-notes[21].note"
+        >
+          Note
+        </label>
+        <textarea
+          class="col-md-auto form-control"
+          id="input-notes[21].note"
+          name="notes[21].note"
+        />
+      </div>
+    </div>
+    <div
       class="tasksForm reviewRequired form-row"
     >
       <div

--- a/frontend/src/features/projects/common/forms/DocumentationForm.tsx
+++ b/frontend/src/features/projects/common/forms/DocumentationForm.tsx
@@ -1,20 +1,30 @@
+import { NoteTypes } from 'constants/noteTypes';
 import React, { Fragment } from 'react';
+import { ProjectNotes } from '..';
 import { IStepProps, IProjectTask } from '../interfaces';
 import TasksForm from './TasksForm';
 
 interface IDocumentationFormProps extends IStepProps {
   tasks: IProjectTask[];
+  showNote?: boolean;
 }
 
 /**
  * Form component of DocumentationForm.
  * @param param0 isReadOnly disable editing
  */
-const DocumentationForm = ({ isReadOnly, tasks }: IDocumentationFormProps) => {
+const DocumentationForm = ({ isReadOnly, tasks, showNote = false }: IDocumentationFormProps) => {
   return (
     <Fragment>
       <h3>Documentation</h3>
       <TasksForm tasks={tasks ?? []} isReadOnly={isReadOnly} />
+      {showNote && (
+        <ProjectNotes
+          label="Note"
+          field={`notes[${NoteTypes.Documentation}].note`}
+          className="col-md-auto"
+        />
+      )}
     </Fragment>
   );
 };

--- a/frontend/src/features/projects/common/tabs/DocumentationTab.tsx
+++ b/frontend/src/features/projects/common/tabs/DocumentationTab.tsx
@@ -31,7 +31,7 @@ const DocumentationTab: React.FunctionComponent<IDocumentationTabProps> = ({
 
   return (
     <Container fluid>
-      <DocumentationForm tasks={documentationTasks} isReadOnly={!canOverride} />
+      <DocumentationForm tasks={documentationTasks} isReadOnly={!canOverride} showNote={true} />
       <AppraisalCheckListForm isReadOnly={isReadOnly} taskStatusCode={appraisalTaskStatusCode} />
       <FirstNationsCheckListForm isReadOnly={isReadOnly} />
     </Container>

--- a/frontend/src/features/projects/dispose/testUtils.ts
+++ b/frontend/src/features/projects/dispose/testUtils.ts
@@ -969,6 +969,13 @@ export const mockFlatProject = {
       projectId: 1007,
       rowVersion: undefined,
     },
+    {
+      id: undefined,
+      noteType: NoteTypes.Documentation,
+      note: '',
+      projectId: 1007,
+      rowVersion: undefined,
+    },
   ],
   description: 'desc',
   properties: [


### PR DESCRIPTION
During assessment of a disposal project an assessor can now capture notes specific to documentation provided.

- Added separate `sresfm` to Keycloak for testing the **SRES Financial Manager** role.

![image](https://user-images.githubusercontent.com/3180256/102237881-fa9e3700-3ea9-11eb-979a-7f7a5cffa11b.png)
