### PR TITLE
Filterbar Revamp

### DIFF
--- a/backend/api/Areas/Property/Controllers/SearchController.cs
+++ b/backend/api/Areas/Property/Controllers/SearchController.cs
@@ -121,6 +121,7 @@ namespace Pims.Api.Areas.Property.Controllers
             if (!filter.IsValid()) throw new BadRequestException("Property filter must contain valid values.");
 
             var pfilter = filter.CopyValues(new AllPropertyFilter());
+            pfilter.PropertyType = filter.PropertyType;
 
             var properties = _pimsService.Property.Search(pfilter).ToArray();
             return new JsonResult(_mapper.Map<GeoJson<PropertyModel>[]>(properties).ToArray());

--- a/backend/api/Areas/Property/Models/Search/GeoJsonFilterModel.cs
+++ b/backend/api/Areas/Property/Models/Search/GeoJsonFilterModel.cs
@@ -106,6 +106,12 @@ namespace Pims.Api.Areas.Property.Models.Search
         public decimal? MinMarketValue { get; set; }
 
         /// <summary>
+        /// get/set - Bare land only flag
+        /// </summary>
+        /// <value></value>
+        public bool? BareLandOnly { get; set; }
+
+        /// <summary>
         /// get/set - Building maximum market value.
         /// </summary>
         /// <value></value>
@@ -155,6 +161,12 @@ namespace Pims.Api.Areas.Property.Models.Search
         /// </summary>
         /// <value></value>
         public int? ConstructionTypeId { get; set; }
+
+        /// <summary>
+        /// get/set - Property name.
+        /// </summary>
+        /// <value></value>
+        public string Name { get; set; }
 
         /// <summary>
         /// get/set - Building predominant use Id.
@@ -230,6 +242,7 @@ namespace Pims.Api.Areas.Property.Models.Search
                 return this.StatusId.HasValue
                     || this.ClassificationId.HasValue
                     || !String.IsNullOrWhiteSpace(this.ProjectNumber)
+                    || !String.IsNullOrWhiteSpace(this.Name)
                     || !String.IsNullOrWhiteSpace(this.AdministrativeArea)
                     || this.ConstructionTypeId.HasValue
                     || this.PredominateUseId.HasValue
@@ -264,6 +277,7 @@ namespace Pims.Api.Areas.Property.Models.Search
         {
             // We want case-insensitive query parameter properties.
             var filter = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(query, StringComparer.OrdinalIgnoreCase);
+            PropertyTypes propType;
 
             this.Service = filter.GetStringValue(nameof(this.Service));
             this.Request = filter.GetStringValue(nameof(this.Request));
@@ -273,10 +287,11 @@ namespace Pims.Api.Areas.Property.Models.Search
             this.Address = filter.GetStringValue(nameof(this.Address));
             this.AdministrativeArea = filter.GetStringValue(nameof(this.AdministrativeArea));
 
+            this.BareLandOnly = filter.GetBoolNullValue(nameof(this.BareLandOnly));
             this.StatusId = filter.GetIntNullValue(nameof(this.StatusId));
             this.ClassificationId = filter.GetIntNullValue(nameof(this.ClassificationId));
             this.ParcelId = filter.GetIntNullValue(nameof(this.ParcelId));
-            this.PropertyType = Enum.TryParse(typeof(PropertyTypes), filter.GetStringValue(nameof(this.PropertyType), null), out object propType) ? (PropertyTypes?)propType : null;
+            this.PropertyType = Enum.TryParse(filter.GetStringValue(nameof(this.PropertyType), null), out propType) ? (PropertyTypes?)propType : null;
             this.ProjectNumber = filter.GetStringValue(nameof(this.ProjectNumber));
             this.IgnorePropertiesInProjects = filter.GetBoolNullValue(nameof(this.IgnorePropertiesInProjects));
             this.InSurplusPropertyProgram = filter.GetBoolNullValue(nameof(this.InSurplusPropertyProgram));
@@ -289,6 +304,7 @@ namespace Pims.Api.Areas.Property.Models.Search
 
             this.Agencies = filter.GetIntArrayValue(nameof(this.Agencies)).Where(a => a != 0).ToArray();
             this.Sort = filter.GetStringArrayValue(nameof(this.Sort));
+            this.Name = filter.GetStringValue(nameof(this.Name));
 
             // Parcel filters.
             this.PID = filter.GetStringValue(nameof(this.PID));
@@ -402,6 +418,8 @@ namespace Pims.Api.Areas.Property.Models.Search
                 NELongitude = model.Boundary.MaxX,
                 NELatitude = model.Boundary.MaxY,
 
+                BareLandOnly = model.BareLandOnly,
+                Name = model.Name,
                 ProjectNumber = model.ProjectNumber,
                 IgnorePropertiesInProjects = model.IgnorePropertiesInProjects,
                 InSurplusPropertyProgram = model.InSurplusPropertyProgram,
@@ -454,6 +472,7 @@ namespace Pims.Api.Areas.Property.Models.Search
                 || this.MinMarketValue.HasValue
                 || this.MaxMarketValue.HasValue
                 || this.Agencies?.Any() == true
+                || this.PropertyType.HasValue
                 || this.StatusId.HasValue
                 || this.ClassificationId.HasValue
                 || this.MinLandArea.HasValue
@@ -462,9 +481,11 @@ namespace Pims.Api.Areas.Property.Models.Search
                 || this.PredominateUseId.HasValue
                 || this.FloorCount.HasValue
                 || this.MinRentableArea.HasValue
+                || this.BareLandOnly == true
                 || this.MaxRentableArea.HasValue
                 || !String.IsNullOrWhiteSpace(this.PID)
-                || !String.IsNullOrWhiteSpace(this.Tenancy);
+                || !String.IsNullOrWhiteSpace(this.Tenancy)
+                || !String.IsNullOrWhiteSpace(this.Name);
         }
         #endregion
     }

--- a/backend/api/Areas/Property/Models/Search/GeoJsonFilterModel.cs
+++ b/backend/api/Areas/Property/Models/Search/GeoJsonFilterModel.cs
@@ -205,6 +205,12 @@ namespace Pims.Api.Areas.Property.Models.Search
         public float? MinRentableArea { get; set; }
 
         /// <summary>
+        /// get/set - Building rentable area.
+        /// </summary>
+        /// <value></value>
+        public float? RentableArea { get; set; }
+
+        /// <summary>
         /// get/set - Building maximum rentable area.
         /// </summary>
         /// <value></value>
@@ -249,7 +255,8 @@ namespace Pims.Api.Areas.Property.Models.Search
                     || this.FloorCount.HasValue
                     || !String.IsNullOrWhiteSpace(this.Tenancy)
                     || this.MinRentableArea.HasValue
-                    || this.MaxRentableArea.HasValue;
+                    || this.MaxRentableArea.HasValue
+                    || this.RentableArea.HasValue;
             }
         }
         #endregion
@@ -318,6 +325,8 @@ namespace Pims.Api.Areas.Property.Models.Search
             this.Tenancy = filter.GetStringValue(nameof(this.Tenancy));
             this.MinRentableArea = filter.GetFloatNullValue(nameof(this.MinRentableArea)) ?? filter.GetFloatNullValue(nameof(this.MinLotArea));
             this.MaxRentableArea = filter.GetFloatNullValue(nameof(this.MaxRentableArea)) ?? filter.GetFloatNullValue(nameof(this.MaxLotArea));
+            this.RentableArea = filter.GetFloatNullValue(nameof(this.RentableArea)) ?? filter.GetFloatNullValue(nameof(this.RentableArea));
+
         }
         #endregion
 
@@ -389,6 +398,7 @@ namespace Pims.Api.Areas.Property.Models.Search
                 Tenancy = model.Tenancy,
                 MinRentableArea = model.MinRentableArea ?? model.MinLotArea,
                 MaxRentableArea = model.MaxRentableArea ?? model.MaxLotArea,
+                RentableArea = model.RentableArea ?? model.RentableArea,
 
                 MinMarketValue = model.MinMarketValue,
                 MaxMarketValue = model.MaxMarketValue,
@@ -440,7 +450,7 @@ namespace Pims.Api.Areas.Property.Models.Search
                 Tenancy = model.Tenancy,
                 MinRentableArea = model.MinRentableArea ?? model.MinLotArea,
                 MaxRentableArea = model.MaxRentableArea ?? model.MaxLotArea,
-
+                RentableArea = model.RentableArea ?? model.RentableArea,
                 MinMarketValue = model.MinMarketValue,
                 MaxMarketValue = model.MaxMarketValue,
                 MinAssessedValue = model.MinAssessedValue,
@@ -481,6 +491,7 @@ namespace Pims.Api.Areas.Property.Models.Search
                 || this.PredominateUseId.HasValue
                 || this.FloorCount.HasValue
                 || this.MinRentableArea.HasValue
+                || this.RentableArea.HasValue
                 || this.BareLandOnly == true
                 || this.MaxRentableArea.HasValue
                 || !String.IsNullOrWhiteSpace(this.PID)

--- a/backend/api/Areas/Property/Models/Search/PropertyFilterModel.cs
+++ b/backend/api/Areas/Property/Models/Search/PropertyFilterModel.cs
@@ -204,6 +204,12 @@ namespace Pims.Api.Areas.Property.Models.Search
         public float? MinRentableArea { get; set; }
 
         /// <summary>
+        /// get/set - Building rentable area.
+        /// </summary>
+        /// <value></value>
+        public float? RentableArea { get; set; }
+
+        /// <summary>
         /// get/set - Building maximum rentable area.
         /// </summary>
         /// <value></value>
@@ -321,6 +327,9 @@ namespace Pims.Api.Areas.Property.Models.Search
             this.Tenancy = filter.GetStringValue(nameof(this.Tenancy));
             this.MinRentableArea = filter.GetFloatNullValue(nameof(this.MinRentableArea)) ?? filter.GetFloatNullValue(nameof(this.MinLotArea));
             this.MaxRentableArea = filter.GetFloatNullValue(nameof(this.MaxRentableArea)) ?? filter.GetFloatNullValue(nameof(this.MaxLotArea));
+            this.RentableArea = filter.GetFloatNullValue(nameof(this.RentableArea)) ?? filter.GetFloatNullValue(nameof(this.RentableArea));
+
+
         }
         #endregion
 
@@ -393,6 +402,7 @@ namespace Pims.Api.Areas.Property.Models.Search
                 Tenancy = model.Tenancy,
                 MinRentableArea = model.MinRentableArea ?? model.MinLotArea,
                 MaxRentableArea = model.MaxRentableArea ?? model.MaxLotArea,
+                RentableArea = model.RentableArea ?? model.RentableArea,
 
                 MinMarketValue = model.MinMarketValue,
                 MaxMarketValue = model.MaxMarketValue,
@@ -444,6 +454,8 @@ namespace Pims.Api.Areas.Property.Models.Search
                 Tenancy = model.Tenancy,
                 MinRentableArea = model.MinRentableArea ?? model.MinLotArea,
                 MaxRentableArea = model.MaxRentableArea ?? model.MaxLotArea,
+                RentableArea = model.RentableArea ?? model.RentableArea,
+
 
                 MinMarketValue = model.MinMarketValue,
                 MaxMarketValue = model.MaxMarketValue,
@@ -487,6 +499,7 @@ namespace Pims.Api.Areas.Property.Models.Search
                 || this.FloorCount.HasValue
                 || this.MinRentableArea.HasValue
                 || this.MaxRentableArea.HasValue
+                || this.RentableArea.HasValue
                 || !String.IsNullOrWhiteSpace(this.PID)
                 || !String.IsNullOrWhiteSpace(this.Tenancy)
                 || !String.IsNullOrWhiteSpace(this.Name);

--- a/backend/api/Areas/Property/Models/Search/PropertyFilterModel.cs
+++ b/backend/api/Areas/Property/Models/Search/PropertyFilterModel.cs
@@ -87,6 +87,12 @@ namespace Pims.Api.Areas.Property.Models.Search
         public bool? InEnhancedReferralProcess { get; set; }
 
         /// <summary>
+        /// get/set - Value of the property name to be filtered.
+        /// </summary>
+        /// <value></value>
+        public string Name { get; set; }
+
+        /// <summary>
         /// get/set - A way to filter both Parcel.LandArea and the Building.BuildingRentableArea.
         /// </summary>
         /// <value></value>
@@ -162,16 +168,22 @@ namespace Pims.Api.Areas.Property.Models.Search
         public int? PredominateUseId { get; set; }
 
         /// <summary>
+        /// get/set - Bare land only flag
+        /// </summary>
+        /// <value></value>
+        public bool? BareLandOnly { get; set; }
+
+        /// <summary>
         /// get/set - Parent Parcel Id.
         /// </summary>
         /// <value></value>
-        public int? ParcelId {get; set;}
+        public int? ParcelId { get; set; }
 
         /// <summary>
         /// get/set - Parent Property Type Id.
         /// </summary>
         /// <value></value>
-        public PropertyTypes? PropertyType {get; set;}
+        public PropertyTypes? PropertyType { get; set; }
 
         /// <summary>
         /// get/set - Building floor count Id.
@@ -269,6 +281,7 @@ namespace Pims.Api.Areas.Property.Models.Search
         {
             // We want case-insensitive query parameter properties.
             var filter = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(query, StringComparer.OrdinalIgnoreCase);
+            PropertyTypes propType;
 
             this.NELatitude = filter.GetDoubleNullValue(nameof(this.NELatitude));
             this.NELongitude = filter.GetDoubleNullValue(nameof(this.NELongitude));
@@ -280,7 +293,7 @@ namespace Pims.Api.Areas.Property.Models.Search
             this.StatusId = filter.GetIntNullValue(nameof(this.StatusId));
             this.ClassificationId = filter.GetIntNullValue(nameof(this.ClassificationId));
             this.ParcelId = filter.GetIntNullValue(nameof(this.ParcelId));
-            this.PropertyType = Enum.TryParse(typeof(PropertyTypes), filter.GetStringValue(nameof(this.PropertyType), null), out object propType) ? (PropertyTypes?)propType : null;
+            this.PropertyType = Enum.TryParse(filter.GetStringValue(nameof(this.PropertyType), null), out propType) ? (PropertyTypes?)propType : null;
             this.ProjectNumber = filter.GetStringValue(nameof(this.ProjectNumber));
             this.IgnorePropertiesInProjects = filter.GetBoolNullValue(nameof(this.IgnorePropertiesInProjects));
             this.InSurplusPropertyProgram = filter.GetBoolNullValue(nameof(this.InSurplusPropertyProgram));
@@ -290,11 +303,13 @@ namespace Pims.Api.Areas.Property.Models.Search
             this.MaxMarketValue = filter.GetDecimalNullValue(nameof(this.MaxMarketValue));
             this.MinAssessedValue = filter.GetDecimalNullValue(nameof(this.MinAssessedValue));
             this.MaxAssessedValue = filter.GetDecimalNullValue(nameof(this.MaxAssessedValue));
+            this.Name = filter.GetStringValue(nameof(this.Name));
 
             this.Agencies = filter.GetIntArrayValue(nameof(this.Agencies)).Where(a => a != 0).ToArray();
             this.Sort = filter.GetStringArrayValue(nameof(this.Sort));
 
             // Parcel filters.
+            this.BareLandOnly = filter.GetBoolNullValue(nameof(this.BareLandOnly));
             this.PID = filter.GetStringValue(nameof(this.PID));
             this.MinLandArea = filter.GetFloatNullValue(nameof(this.MinLandArea)) ?? filter.GetFloatNullValue(nameof(this.MinLotArea));
             this.MaxLandArea = filter.GetFloatNullValue(nameof(this.MaxLandArea)) ?? filter.GetFloatNullValue(nameof(this.MaxLotArea));
@@ -328,6 +343,7 @@ namespace Pims.Api.Areas.Property.Models.Search
 
                 ProjectNumber = model.ProjectNumber,
                 ClassificationId = model.ClassificationId,
+                PropertyType = model.PropertyType,
                 Address = model.Address,
                 AdministrativeArea = model.AdministrativeArea,
 
@@ -407,9 +423,11 @@ namespace Pims.Api.Areas.Property.Models.Search
                 SWLongitude = model.SWLongitude,
 
                 ProjectNumber = model.ProjectNumber,
+                BareLandOnly = model.BareLandOnly,
                 IgnorePropertiesInProjects = model.IgnorePropertiesInProjects,
                 InSurplusPropertyProgram = model.InSurplusPropertyProgram,
                 InEnhancedReferralProcess = model.InEnhancedReferralProcess,
+                Name = model.Name,
                 ParcelId = model.ParcelId,
                 PropertyType = model.PropertyType,
                 ClassificationId = model.ClassificationId,
@@ -458,17 +476,21 @@ namespace Pims.Api.Areas.Property.Models.Search
                 || this.MinMarketValue.HasValue
                 || this.MaxMarketValue.HasValue
                 || this.Agencies?.Any() == true
+                || this.BareLandOnly == true
                 || this.StatusId.HasValue
                 || this.ClassificationId.HasValue
                 || this.MinLandArea.HasValue
                 || this.MaxLandArea.HasValue
                 || this.ConstructionTypeId.HasValue
+                || this.PropertyType.HasValue
                 || this.PredominateUseId.HasValue
                 || this.FloorCount.HasValue
                 || this.MinRentableArea.HasValue
                 || this.MaxRentableArea.HasValue
                 || !String.IsNullOrWhiteSpace(this.PID)
-                || !String.IsNullOrWhiteSpace(this.Tenancy);
+                || !String.IsNullOrWhiteSpace(this.Tenancy)
+                || !String.IsNullOrWhiteSpace(this.Name);
+
         }
         #endregion
     }

--- a/backend/dal/Helpers/Extensions/PropertyExtensions.cs
+++ b/backend/dal/Helpers/Extensions/PropertyExtensions.cs
@@ -45,6 +45,9 @@ namespace Pims.Dal.Helpers.Extensions
             if (filter.PropertyType.HasValue)
                 query = query.Where(p => p.PropertyTypeId == filter.PropertyType.Value);
 
+            if (filter.RentableArea.HasValue)
+                query = query.Where(p => p.RentableArea == filter.RentableArea);     
+
             if (filter.BareLandOnly == true)
                 query = (from p in query
                          join pb in context.ParcelBuildings

--- a/backend/dal/Helpers/Extensions/PropertyExtensions.cs
+++ b/backend/dal/Helpers/Extensions/PropertyExtensions.cs
@@ -43,7 +43,15 @@ namespace Pims.Dal.Helpers.Extensions
                 query = query.Where(p => !p.IsSensitive);
 
             if (filter.PropertyType.HasValue)
-                query = query.Where(p => p.PropertyTypeId == filter.PropertyType);
+                query = query.Where(p => p.PropertyTypeId == filter.PropertyType.Value);
+
+            if (filter.BareLandOnly == true)
+                query = (from p in query
+                         join pb in context.ParcelBuildings
+                            on p.Id equals pb.ParcelId into ppbGroup
+                         from pb in ppbGroup.DefaultIfEmpty()
+                         where pb == null
+                         select p);
 
             if (filter.NELatitude.HasValue && filter.NELongitude.HasValue && filter.SWLatitude.HasValue && filter.SWLongitude.HasValue)
             {
@@ -58,7 +66,7 @@ namespace Pims.Dal.Helpers.Extensions
                 var agencies = filterAgencies.Concat(context.Agencies.AsNoTracking().Where(a => filterAgencies.Contains(a.Id)).SelectMany(a => a.Children.Select(ac => (int?)ac.Id)).ToArray()).Distinct();
                 query = query.Where(p => agencies.Contains(p.AgencyId));
             }
-            if(filter.ParcelId.HasValue)
+            if (filter.ParcelId.HasValue)
                 query = query.Where(p => p.ParcelId == filter.ParcelId);
             if (filter.ClassificationId.HasValue)
                 query = query.Where(p => p.ClassificationId == filter.ClassificationId);
@@ -70,6 +78,8 @@ namespace Pims.Dal.Helpers.Extensions
                 query = query.Where(p => !String.IsNullOrWhiteSpace(p.ProjectNumber));
             if (!String.IsNullOrWhiteSpace(filter.Description))
                 query = query.Where(p => EF.Functions.Like(p.Description, $"%{filter.Description}%"));
+            if (!String.IsNullOrWhiteSpace(filter.Name))
+                query = query.Where(p => EF.Functions.Like(p.Name, $"%{filter.Name}%"));
 
             if (!String.IsNullOrWhiteSpace(filter.PID))
             {

--- a/backend/entities/Models/AllPropertyFilter.cs
+++ b/backend/entities/Models/AllPropertyFilter.cs
@@ -10,7 +10,6 @@ namespace Pims.Dal.Entities.Models
     public class AllPropertyFilter : PropertyFilter
     {
         #region Properties
-        public PropertyTypes? PropertyType { get; set; }
 
         #region Parcel Properties
         /// <summary>
@@ -110,7 +109,7 @@ namespace Pims.Dal.Entities.Models
         {
             // We want case-insensitive query parameter properties.
             var filter = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(query, StringComparer.OrdinalIgnoreCase);
-            this.PropertyType = Enum.TryParse(typeof(PropertyTypes), filter.GetStringValue(nameof(this.PropertyType), null), out object propType) ? (PropertyTypes?)propType : null;
+            PropertyTypes propType;
 
             this.PID = filter.GetStringValue(nameof(this.PID));
             this.Zoning = filter.GetStringValue(nameof(this.Zoning));
@@ -118,6 +117,7 @@ namespace Pims.Dal.Entities.Models
             this.MinLandArea = filter.GetFloatNullValue(nameof(this.MinLandArea));
             this.MaxLandArea = filter.GetFloatNullValue(nameof(this.MaxLandArea));
 
+            this.PropertyType = Enum.TryParse(filter.GetStringValue(nameof(this.PropertyType), null), out propType) ? (PropertyTypes?)propType : null;
             this.ConstructionTypeId = filter.GetIntNullValue(nameof(this.ConstructionTypeId));
             this.PredominateUseId = filter.GetIntNullValue(nameof(this.PredominateUseId));
             this.FloorCount = filter.GetIntNullValue(nameof(this.FloorCount));

--- a/backend/entities/Models/BuildingFilter.cs
+++ b/backend/entities/Models/BuildingFilter.cs
@@ -70,7 +70,7 @@ namespace Pims.Dal.Entities.Models
         /// <param name="address"></param>
         /// <param name="agencyId"></param>
         /// <param name="constructionTypeId"></param>
-        /// <param name="predominantUseId"></param>
+        /// <param name="predominateUseId"></param>
         /// <param name="floorCount"></param>
         /// <param name="tenancy"></param>
         /// <param name="minRentableArea"></param>
@@ -81,11 +81,11 @@ namespace Pims.Dal.Entities.Models
         /// <param name="maxAssessedValue"></param>
         /// <param name="sort"></param>
         /// <returns></returns>
-        public BuildingFilter(string address, int? agencyId, int? constructionTypeId, int? predominantUseId, int? floorCount, string tenancy, float? minRentableArea, float? maxRentableArea, decimal? minMarketValue, decimal? maxMarketValue, decimal? minAssessedValue, decimal? maxAssessedValue, string[] sort)
+        public BuildingFilter(string address, int? agencyId, int? constructionTypeId, int? predominateUseId, int? floorCount, string tenancy, float? minRentableArea, float? maxRentableArea, decimal? minMarketValue, decimal? maxMarketValue, decimal? minAssessedValue, decimal? maxAssessedValue, string[] sort)
         {
             this.Address = address;
             this.ConstructionTypeId = constructionTypeId;
-            this.PredominateUseId = predominantUseId;
+            this.PredominateUseId = predominateUseId;
             this.FloorCount = floorCount;
             this.Tenancy = tenancy;
             this.MinRentableArea = minRentableArea;

--- a/backend/entities/Models/PropertyFilter.cs
+++ b/backend/entities/Models/PropertyFilter.cs
@@ -48,6 +48,11 @@ namespace Pims.Dal.Entities.Models
         public string ProjectNumber { get; set; }
 
         /// <summary>
+        /// get/set - The property type
+        /// </summary>
+        public PropertyTypes? PropertyType { get; set; }
+
+        /// <summary>
         /// get/set - Flag indicating properties in projects should be ignored.
         /// </summary>
         /// <value></value>
@@ -66,10 +71,16 @@ namespace Pims.Dal.Entities.Models
         public bool? InEnhancedReferralProcess { get; set; }
 
         /// <summary>
+        /// get/set - The value of the property name.
+        /// </summary>
+        /// <value></value>
+        public string Name { get; set; }
+
+        /// <summary>
         /// get/set - The parcelId for the property
         /// </summary>
         /// <value></value>
-        public int? ParcelId { get; set;}
+        public int? ParcelId { get; set; }
 
         /// <summary>
         /// get/set - Building classification Id.
@@ -98,6 +109,12 @@ namespace Pims.Dal.Entities.Models
         /// </summary>
         /// <value></value>
         public decimal? MinMarketValue { get; set; }
+
+        /// <summary>
+        /// get/set - Bare land only flag
+        /// </summary>
+        /// <value></value>
+        public bool? BareLandOnly { get; set; }
 
         /// <summary>
         /// get/set - Building maximum market value.
@@ -179,6 +196,7 @@ namespace Pims.Dal.Entities.Models
         {
             // We want case-insensitive query parameter properties.
             var filter = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(query, StringComparer.OrdinalIgnoreCase);
+            PropertyTypes propType;
 
             this.Boundary = filter.GetEnvelopNullValue("bbox");
             this.NELatitude = filter.GetDoubleNullValue(nameof(this.NELatitude));
@@ -189,9 +207,11 @@ namespace Pims.Dal.Entities.Models
             this.ProjectNumber = filter.GetStringValue(nameof(this.ProjectNumber));
             this.IgnorePropertiesInProjects = filter.GetBoolNullValue(nameof(this.IgnorePropertiesInProjects));
             this.InSurplusPropertyProgram = filter.GetBoolNullValue(nameof(this.InSurplusPropertyProgram));
+            this.PropertyType = Enum.TryParse(filter.GetStringValue(nameof(this.PropertyType), null), out propType) ? (PropertyTypes?)propType : null;
             this.Address = filter.GetStringValue(nameof(this.Address));
             this.AdministrativeArea = filter.GetStringValue(nameof(this.AdministrativeArea));
 
+            this.BareLandOnly = filter.GetBoolNullValue(nameof(this.BareLandOnly));
             this.ClassificationId = filter.GetIntNullValue(nameof(this.ClassificationId));
             this.Description = filter.GetStringValue(nameof(this.Description));
             this.MinMarketValue = filter.GetDecimalNullValue(nameof(this.MinMarketValue));
@@ -225,7 +245,9 @@ namespace Pims.Dal.Entities.Models
                 || this.MinAssessedValue.HasValue
                 || this.MinMarketValue.HasValue
                 || this.MaxMarketValue.HasValue
+                || this.BareLandOnly == true
                 || this.Agencies?.Any() == true
+                || this.PropertyType.HasValue
                 || this.ClassificationId.HasValue;
         }
         #endregion

--- a/backend/entities/Models/PropertyFilter.cs
+++ b/backend/entities/Models/PropertyFilter.cs
@@ -117,6 +117,12 @@ namespace Pims.Dal.Entities.Models
         public bool? BareLandOnly { get; set; }
 
         /// <summary>
+        /// get/set - Rentable Area
+        /// </summary>
+        /// <value></value>
+        public float? RentableArea { get; set; }
+
+        /// <summary>
         /// get/set - Building maximum market value.
         /// </summary>
         /// <value></value>

--- a/frontend/src/components/SearchBar/FindMorePropertiesForm.tsx
+++ b/frontend/src/components/SearchBar/FindMorePropertiesForm.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { RootState } from 'reducers/rootReducer';
+import { ILookupCode } from 'actions/lookupActions';
+import { ILookupCodeState } from 'reducers/lookupCodeReducer';
+import { mapLookupCode } from 'utils';
+import * as API from 'constants/API';
+import styled from 'styled-components';
+import { Container, Row } from 'react-bootstrap';
+import { Button, Check, Input, Select } from 'components/common/form';
+import _ from 'lodash';
+import { useFormikContext } from 'formik';
+
+const StyledRow = styled(Row)`
+  .form-group {
+    display: flex;
+    .form-label {
+      margin-top: 5px;
+      margin-right: 10px;
+      width: 150px;
+      text-align: right;
+    }
+  }
+`;
+
+/** input used to display small number values in this form */
+const NumberInput = styled(props => <Input {...props} />)`
+  width: 86px;
+`;
+
+/** controlling the width of the select component used in this form */
+const StyledSelect = styled(props => <Select {...props} />)`
+  width: 250px;
+`;
+
+/** bar seperator for the inputs */
+const VerticalLine = styled.span`
+  border-left: 10px solid #666666;
+  height: 40px;
+  margin-left: 20px;
+  border-width: 1px;
+`;
+
+/** styled component used for project number */
+const ProjectNumber = styled(props => <Input {...props} />)`
+  width: 129px;
+  margin-right: 10px;
+`;
+
+/** styled container with grey background to contain form contents */
+const FormSection = styled(props => <Container {...props} />)`
+  margin-top: 20px;
+  background-color: #e9ecef;
+  border-radius: 5px;
+`;
+
+const SearchButton = styled(props => <Button {...props} />)`
+  margin-top: 10px;
+  margin-left: 665px;
+`;
+
+/** This form is triggered by the FindMorePropertiesButton and contains additional filter fields for the PropertiesFilter */
+const FindMorePropertiesForm = <T extends any>(props: any) => {
+  const lookupCodes = useSelector<RootState, ILookupCode[]>(
+    state => (state.lookupCode as ILookupCodeState).lookupCodes,
+  );
+
+  const constructionType = _.filter(lookupCodes, (lookupCode: ILookupCode) => {
+    return lookupCode.type === API.CONSTRUCTION_CODE_SET_NAME;
+  }).map(mapLookupCode);
+  const predominateUses = _.filter(lookupCodes, (lookupCode: ILookupCode) => {
+    return lookupCode.type === API.PREDOMINATE_USE_CODE_SET_NAME;
+  }).map(mapLookupCode);
+
+  const { handleSubmit } = useFormikContext();
+
+  return (
+    <>
+      <p>
+        Search for properties within the Enhanced Referral Process (ERP) or Surplus Property Program
+        (SPP)
+      </p>
+      <FormSection>
+        <Row style={{ marginLeft: 10 }}>
+          <h6>Search by</h6>
+        </Row>
+        <StyledRow style={{ marginLeft: 35 }}>
+          <Input field="administrativeArea" label="Location" />
+          <VerticalLine />
+          <ProjectNumber field="projectNumber" label="Project number" placeholder="SPP #" />
+        </StyledRow>
+      </FormSection>
+      <FormSection>
+        <Row style={{ marginLeft: 10 }}>
+          <h6>Building search criteria</h6>
+        </Row>
+        <StyledRow>
+          <StyledSelect
+            field="predominateUseId"
+            placeholder="Any"
+            options={predominateUses}
+            label="Predominate use"
+          />
+          <VerticalLine />
+          <NumberInput label="Number of floors" field="floorCount" />
+        </StyledRow>
+        <StyledRow>
+          <StyledSelect
+            field="constructionTypeId"
+            placeholder="Any"
+            options={constructionType}
+            label="Construction type"
+          />
+          <VerticalLine />
+          <NumberInput label="Net rentable area" field="rentableArea" />
+        </StyledRow>
+      </FormSection>
+      <FormSection>
+        <Row style={{ marginLeft: 10 }}>
+          <h6>Land search criteria</h6>
+        </Row>
+        <StyledRow style={{ marginLeft: -13 }}>
+          <NumberInput label="Lot size" field="minLotSize" placeholder="min" />
+          <span style={{ marginTop: 5, marginLeft: 5, marginRight: 5 }}>-</span>
+          <NumberInput field="maxLotSize" placeholder="max" />
+          <VerticalLine />
+          <Check label="Bare land only" field="bareLandOnly" />
+        </StyledRow>
+      </FormSection>
+      <Row>
+        <SearchButton onClick={handleSubmit}>Search</SearchButton>
+      </Row>
+    </>
+  );
+};
+
+export default FindMorePropertiesForm;

--- a/frontend/src/components/common/form/Input.tsx
+++ b/frontend/src/components/common/form/Input.tsx
@@ -5,6 +5,7 @@ import { DisplayError } from './DisplayError';
 import classNames from 'classnames';
 import TooltipIcon from '../TooltipIcon';
 import TooltipWrapper from '../TooltipWrapper';
+import { CSSProperties } from 'styled-components';
 
 type RequiredAttributes = {
   /** The field name */
@@ -36,6 +37,8 @@ type OptionalAttributes = {
   tooltip?: string;
   /** Display errors in a tooltip instead of in a div */
   displayErrorTooltips?: boolean;
+  /** add inline style to the input component */
+  style?: CSSProperties;
 };
 
 // only "field" is required for <Input>, the rest are optional
@@ -52,6 +55,7 @@ export const Input: React.FC<InputProps> = ({
   className,
   outerClassName,
   pattern,
+  style,
   required,
   disabled,
   custom,
@@ -101,6 +105,7 @@ export const Input: React.FC<InputProps> = ({
           as={asElement}
           name={field}
           required={required}
+          style={style}
           disabled={disabled}
           custom={custom}
           isInvalid={!!touch && !!error}

--- a/frontend/src/components/common/form/ParentSelect.tsx
+++ b/frontend/src/components/common/form/ParentSelect.tsx
@@ -153,7 +153,7 @@ export const ParentSelect: React.FC<IParentSelect> = ({
                     <b style={{ cursor: 'pointer' }}>
                       {field === 'statusId'
                         ? results.find(x => x.parentId?.toString() === parent)?.parent
-                        : results.find(x => x.value === parent)?.label}
+                        : options.find(x => x.value === parent)?.label}
                     </b>
                   </Menu.Header>
                 )}

--- a/frontend/src/components/common/form/Select.scss
+++ b/frontend/src/components/common/form/Select.scss
@@ -1,4 +1,5 @@
 .form-select {
+  min-width: 95px;
   .option {
     padding: 5px;
   }

--- a/frontend/src/components/maps/FindMorePropertiesButton.tsx
+++ b/frontend/src/components/maps/FindMorePropertiesButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { BsXSquareFill } from 'react-icons/bs';
 import { FaSign } from 'react-icons/fa';
@@ -30,28 +30,41 @@ const TitleForSaleSign = styled(FaSign)`
   margin-right: 5px;
 `;
 
+interface IFindMorePropertiesButton {
+  /** the text to appear beside the sign icon on the FindMorePropertiesButton */
+  buttonText: string;
+}
+
 /** this component contains the trigger for additional filter options off the base filter */
-export const FindMorePropertiesButton: React.FC<any> = () => {
+export const FindMorePropertiesButton: React.FC<IFindMorePropertiesButton> = ({ buttonText }) => {
   const smallScreen = useMediaQuery({ maxWidth: 1800 });
-  const TitleContent = () => (
-    <div style={{ display: 'flex' }}>
-      <TitleForSaleSign size={42} />
-      <h3 style={{ color: '#003366' }}>Find available surplus properties</h3>
-      <CloseButton onClick={() => document.body.click()} />
-    </div>
-  );
+
+  const TitleContent = () =>
+    useMemo(
+      () => (
+        <div style={{ display: 'flex' }}>
+          <TitleForSaleSign size={42} />
+          <h3 style={{ color: '#003366' }}>{buttonText}</h3>
+          <CloseButton onClick={() => document.body.click()} />
+        </div>
+      ),
+      [],
+    );
 
   /** this provides a way to create a form with tooltip like behaviour in the overlay trigger */
-  const popover = (
-    <StyledPopover id="popover-basic">
-      <Popover.Title>
-        {' '}
-        <TitleContent />{' '}
-      </Popover.Title>
-      <Popover.Content>
-        <FindMorePropertiesForm />
-      </Popover.Content>
-    </StyledPopover>
+  const popover = useMemo(
+    () => (
+      <StyledPopover id="popover-basic">
+        <Popover.Title>
+          {' '}
+          <TitleContent />{' '}
+        </Popover.Title>
+        <Popover.Content>
+          <FindMorePropertiesForm />
+        </Popover.Content>
+      </StyledPopover>
+    ),
+    [],
   );
 
   return (

--- a/frontend/src/components/maps/FindMorePropertiesButton.tsx
+++ b/frontend/src/components/maps/FindMorePropertiesButton.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import { BsXSquareFill } from 'react-icons/bs';
+import { FaSign } from 'react-icons/fa';
+import styled from 'styled-components';
+import FindMorePropertiesForm from 'components/SearchBar/FindMorePropertiesForm';
+import { useMediaQuery } from 'react-responsive';
+
+const ButtonContent = styled.div`
+  display: flex;
+  .p {
+    font-size: 16px;
+  }
+`;
+
+/** popover that is triggered on button click to display form contents */
+const StyledPopover = styled(Popover)`
+  max-width: 100%;
+`;
+
+/** close button displayed in top right of popover title */
+const CloseButton = styled(BsXSquareFill)`
+  margin-left: 256px;
+  cursor: pointer;
+`;
+
+/** icon for sign used within component, styled blue */
+const TitleForSaleSign = styled(FaSign)`
+  fill: #003366;
+  margin-right: 5px;
+`;
+
+/** this component contains the trigger for additional filter options off the base filter */
+export const FindMorePropertiesButton: React.FC<any> = () => {
+  const smallScreen = useMediaQuery({ maxWidth: 1800 });
+  const TitleContent = () => (
+    <div style={{ display: 'flex' }}>
+      <TitleForSaleSign size={42} />
+      <h3 style={{ color: '#003366' }}>Find available surplus properties</h3>
+      <CloseButton onClick={() => document.body.click()} />
+    </div>
+  );
+
+  /** this provides a way to create a form with tooltip like behaviour in the overlay trigger */
+  const popover = (
+    <StyledPopover id="popover-basic">
+      <Popover.Title>
+        {' '}
+        <TitleContent />{' '}
+      </Popover.Title>
+      <Popover.Content>
+        <FindMorePropertiesForm />
+      </Popover.Content>
+    </StyledPopover>
+  );
+
+  return (
+    <OverlayTrigger trigger="click" rootClose transition overlay={popover} placement="bottom">
+      <Button style={{ height: 38 }}>
+        <ButtonContent>
+          <FaSign size={20} style={{ marginRight: 5, marginTop: 3 }} />
+          {!smallScreen && <p>Find available properties</p>}
+        </ButtonContent>
+      </Button>
+    </OverlayTrigger>
+  );
+};

--- a/frontend/src/components/maps/leaflet/InventoryLayer.tsx
+++ b/frontend/src/components/maps/leaflet/InventoryLayer.tsx
@@ -80,6 +80,12 @@ export const InventoryLayer: React.FC<InventoryLayerProps> = ({
       maxLandArea: filter?.maxLandArea,
       inSurplusPropertyProgram: filter?.inSurplusPropertyProgram,
       inEnhancedReferralProcess: filter?.inEnhancedReferralProcess,
+      floorCount: filter?.floorCount,
+      predominateUseId: Number(filter?.predominateUseId),
+      constructionTypeId: filter?.constructionTypeId,
+      name: filter?.name,
+      bareLandOnly: filter?.bareLandOnly,
+      rentableArea: filter?.rentableArea,
     }),
     [filter, map, bounds],
   );

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -88,6 +88,7 @@ const defaultFilterValues: IPropertyFilter = {
   classificationId: '',
   minLotSize: '',
   maxLotSize: '',
+  rentableArea: '',
   name: '',
 };
 
@@ -105,6 +106,7 @@ const getQueryParams = (filter: IPropertyFilter): IGeoSearchParams => {
     agencies: filter.agencies,
     minLandArea: floatOrUndefined(filter.minLotSize),
     maxLandArea: floatOrUndefined(filter.maxLotSize),
+    rentableArea: floatOrUndefined(filter.rentableArea),
     inSurplusPropertyProgram: filter.inSurplusPropertyProgram === 'true',
     inEnhancedReferralProcess: filter.inEnhancedReferralProcess === 'true',
     name: filter.name,

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -78,15 +78,17 @@ export type LayerPopupInformation = PopupContentConfig & {
 };
 
 const defaultFilterValues: IPropertyFilter = {
-  searchBy: 'address',
+  searchBy: 'name',
   pid: '',
   address: '',
   administrativeArea: '',
+  propertyType: '',
   projectNumber: '',
   agencies: '',
   classificationId: '',
   minLotSize: '',
   maxLotSize: '',
+  name: '',
 };
 
 /**
@@ -105,6 +107,11 @@ const getQueryParams = (filter: IPropertyFilter): IGeoSearchParams => {
     maxLandArea: floatOrUndefined(filter.maxLotSize),
     inSurplusPropertyProgram: filter.inSurplusPropertyProgram === 'true',
     inEnhancedReferralProcess: filter.inEnhancedReferralProcess === 'true',
+    name: filter.name,
+    predominateUseId: parseInt(filter.predominateUseId!),
+    constructionTypeId: parseInt(filter.constructionTypeId!),
+    floorCount: parseInt(filter.floorCount!),
+    bareLandOnly: filter.bareLandOnly,
   };
 };
 

--- a/frontend/src/constants/API.ts
+++ b/frontend/src/constants/API.ts
@@ -63,6 +63,13 @@ export interface IGeoSearchParams {
   maxLandArea?: number;
   inSurplusPropertyProgram?: boolean;
   inEnhancedReferralProcess?: boolean;
+  name?: string;
+  bareLandOnly?: boolean;
+  constructionTypeId?: number;
+  predominateUseId?: number;
+  floorCount?: number;
+  rentableArea?: number;
+  propertyType?: string;
 }
 export const GEO_PROPERTIES = (params: IGeoSearchParams | null) =>
   `/properties/search/wfs?${params ? queryString.stringify(params) : ''}`; // get filtered properties or all if not specified.

--- a/frontend/src/features/properties/filter/IPropertyFilter.ts
+++ b/frontend/src/features/properties/filter/IPropertyFilter.ts
@@ -42,4 +42,6 @@ export interface IPropertyFilter {
   floorCount?: string;
   /** Flag for whether to include buildings */
   bareLandOnly?: boolean;
+  /** filter for building rentable area */
+  rentableArea: string;
 }

--- a/frontend/src/features/properties/filter/IPropertyFilter.ts
+++ b/frontend/src/features/properties/filter/IPropertyFilter.ts
@@ -1,5 +1,4 @@
 import { TrueFalse } from 'constants/trueFalse';
-import { PropertyTypes } from 'constants/propertyTypes';
 
 /**
  * Property filter options used by Formik.
@@ -32,5 +31,15 @@ export interface IPropertyFilter {
   /** Whether the property is in ERP. */
   inEnhancedReferralProcess?: TrueFalse;
   /** Select on of the property types [Land, Building]. */
-  propertyType?: PropertyTypes;
+  propertyType?: string;
+  /** The name of desired target */
+  name?: string;
+  /** The building construction type id */
+  constructionTypeId?: string;
+  /** The building predominant use id */
+  predominateUseId?: string;
+  /** The building number of floors */
+  floorCount?: string;
+  /** Flag for whether to include buildings */
+  bareLandOnly?: boolean;
 }

--- a/frontend/src/features/properties/filter/PropertyFilter.scss
+++ b/frontend/src/features/properties/filter/PropertyFilter.scss
@@ -4,10 +4,32 @@
   &.map-filter-container {
     height: #{$mapfilter-height};
     background-color: #f2f2f2;
+    .container {
+      max-width: 1200px;
+    }
     .map-filter-bar {
       align-items: center;
       padding: 1rem 0;
+      .vl {
+        border-left: 6px solid #666666;
+        height: 40px;
+        margin-left: 1%;
+        margin-right: 1%;
+        border-width: 1px;
+      }
       .bar-item {
+        .input-group {
+          .input-group-prepend {
+            .form-group {
+              width: 155px;
+            }
+          }
+          .input-group-content {
+            .form-group {
+              width: 200px;
+            }
+          }
+        }
         .form-group {
           padding: 0;
           margin: 0;
@@ -15,7 +37,7 @@
       }
       .agency-item {
         .form-control {
-          width: 300px;
+          width: 250px;
         }
       }
       .map-filter-typeahead {

--- a/frontend/src/features/properties/filter/PropertyFilter.test.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilter.test.tsx
@@ -13,6 +13,7 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import * as reducerTypes from 'constants/reducerTypes';
+import { TrueFalse } from 'constants/trueFalse';
 
 const onFilterChange = jest.fn<void, [IPropertyFilter]>();
 //prevent web calls from being made during tests.
@@ -172,7 +173,7 @@ describe('MapFilterBar', () => {
   });
 
   it('loads filter values if provided', () => {
-    const providedFilter = {
+    const providedFilter: IPropertyFilter = {
       pid: 'mockPid',
       searchBy: 'address',
       address: 'mockaddress',
@@ -182,12 +183,10 @@ describe('MapFilterBar', () => {
       classificationId: '0',
       minLotSize: '10',
       maxLotSize: '20',
-      inSurplusPropertyProgram: 'true',
+      inSurplusPropertyProgram: TrueFalse.True,
     };
-    const { getByText, getByPlaceholderText } = render(getUiElement(providedFilter));
+    const { getByText } = render(getUiElement(providedFilter));
     expect(getByText('Address')).toBeVisible();
     expect(getByText('Core Operational')).toBeVisible();
-    expect(getByPlaceholderText('Min Lot Size')).toHaveValue('10');
-    expect(getByPlaceholderText('Max Lot Size')).toHaveValue('20');
   });
 });

--- a/frontend/src/features/properties/filter/PropertyFilter.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilter.tsx
@@ -103,7 +103,7 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
       {({ isSubmitting, handleReset, handleSubmit, setFieldValue, values }) => (
         <Form>
           <Form.Row className="map-filter-bar align-items-start">
-            <FindMorePropertiesButton />
+            <FindMorePropertiesButton buttonText="Find available surplus properties" />
             <div className="vl"></div>
             <Col className="bar-item">
               <PropertyFilterOptions />

--- a/frontend/src/features/properties/filter/PropertyFilter.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilter.tsx
@@ -4,10 +4,7 @@ import React, { useMemo } from 'react';
 import { Col } from 'react-bootstrap';
 import { Formik } from 'formik';
 import { ILookupCode } from 'actions/lookupActions';
-import { Form, Select, Input, SelectOption } from '../../../components/common/form';
-import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
-import { Claims } from 'constants/claims';
-import SppButton from 'components/common/form/SppButton';
+import { Form, Select, SelectOption } from '../../../components/common/form';
 import { FilterBarSchema } from 'utils/YupSchema';
 import ResetButton from 'components/common/form/ResetButton';
 import SearchButton from 'components/common/form/SearchButton';
@@ -17,7 +14,7 @@ import { PropertyFilterOptions } from './';
 import { useRouterFilter } from 'hooks/useRouterFilter';
 import { IPropertyFilter } from './IPropertyFilter';
 import { TableSort } from 'components/Table/TableSort';
-import { TrueFalse } from 'constants/trueFalse';
+import { FindMorePropertiesButton } from 'components/maps/FindMorePropertiesButton';
 
 /**
  * PropertyFilter component properties.
@@ -70,8 +67,6 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
     mapLookupCodeWithParentString(c, agencyLookupCodes),
   );
   const classifications = (propertyClassifications ?? []).map(c => mapLookupCode(c));
-  const keycloak = useKeycloakWrapper();
-  let formikRef = React.useRef<any>() as any;
 
   const initialValues = useMemo(() => {
     const values = { ...defaultFilter, ...propertyFilter };
@@ -83,20 +78,6 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
     }
     return values;
   }, [agencies, propertyFilter, defaultFilter]);
-
-  const applyEnhancedReferralFilter = () => {
-    const values: IPropertyFilter = { ...formikRef!.values };
-    values.inEnhancedReferralProcess = TrueFalse.True;
-    values.inSurplusPropertyProgram = TrueFalse.False;
-    changeFilter(values);
-  };
-
-  const applySurplusPropertyFilter = () => {
-    const values: IPropertyFilter = { ...formikRef!.values };
-    values.inSurplusPropertyProgram = TrueFalse.True;
-    values.inEnhancedReferralProcess = TrueFalse.False;
-    changeFilter(values);
-  };
 
   const changeFilter = (values: IPropertyFilter) => {
     const agencyIds = (values.agencies as any)?.value ?? '';
@@ -118,11 +99,12 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
         changeFilter(values);
         setSubmitting(false);
       }}
-      innerRef={ref => (formikRef = ref)}
     >
       {({ isSubmitting, handleReset, handleSubmit, setFieldValue, values }) => (
         <Form>
           <Form.Row className="map-filter-bar align-items-start">
+            <FindMorePropertiesButton />
+            <div className="vl"></div>
             <Col className="bar-item">
               <PropertyFilterOptions />
             </Col>
@@ -141,21 +123,6 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
                 options={classifications}
               />
             </Col>
-            <Col className="bar-item d-flex align-items-start">
-              <Input field="minLotSize" placeholder="Min Lot Size" />
-              <span className="mx-2 align-self-center">-</span>
-              <Input field="maxLotSize" placeholder="Max Lot Size" />
-            </Col>
-            {keycloak.hasClaim(Claims.ADMIN_PROPERTIES) && (
-              <Col className="bar-item flex-grow-0">
-                <SppButton
-                  handleErpClick={applyEnhancedReferralFilter}
-                  handleSppClick={applySurplusPropertyFilter}
-                  inEnhancedReferralProcess={values.inEnhancedReferralProcess === TrueFalse.True}
-                  inSurplusPropertyProgram={values.inSurplusPropertyProgram === TrueFalse.True}
-                />
-              </Col>
-            )}
             <Col className="bar-item flex-grow-0">
               <SearchButton disabled={isSubmitting} />
             </Col>

--- a/frontend/src/features/properties/filter/PropertyFilterOptions.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilterOptions.tsx
@@ -9,16 +9,12 @@ import { IPropertyFilter } from './IPropertyFilter';
 export const PropertyFilterOptions: React.FC = () => {
   const state: { options: any[]; placeholders: Record<string, string> } = {
     options: [
+      { label: 'Property Name', value: 'name' },
       { label: 'Address', value: 'address' },
-      { label: 'Location', value: 'administrativeArea' },
-      { label: 'PID/PIN', value: 'pid' },
-      { label: 'RAEG or SPP No.', value: 'projectNumber' },
     ],
     placeholders: {
+      name: 'Enter a name',
       address: 'Enter an address or city',
-      administrativeArea: 'Enter a location name',
-      pid: 'Enter a PID or PIN',
-      projectNumber: 'Enter an SPP/RAEG number',
     },
   };
 
@@ -30,10 +26,8 @@ export const PropertyFilterOptions: React.FC = () => {
   const desc = state.placeholders[searchBy] || '';
 
   const reset = () => {
+    setFieldValue('name', '');
     setFieldValue('address', '');
-    setFieldValue('administrativeArea', '');
-    setFieldValue('projectNumber', '');
-    setFieldValue('city', '');
   };
 
   return (

--- a/frontend/src/features/properties/filter/__snapshots__/PropertyFilter.test.tsx.snap
+++ b/frontend/src/features/properties/filter/__snapshots__/PropertyFilter.test.tsx.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MapFilterBar renders correctly 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c0 .p {
+  font-size: 16px;
+}
+
 <form
   className=""
   noValidate={true}
@@ -9,6 +20,49 @@ exports[`MapFilterBar renders correctly 1`] = `
   <div
     className="map-filter-bar align-items-start form-row"
   >
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "height": 38,
+        }
+      }
+      type="button"
+    >
+      <div
+        className="c0"
+      >
+        <svg
+          fill="currentColor"
+          height={20}
+          size={20}
+          stroke="currentColor"
+          strokeWidth="0"
+          style={
+            Object {
+              "color": undefined,
+              "marginRight": 5,
+              "marginTop": 3,
+            }
+          }
+          viewBox="0 0 512 512"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M496 64H128V16c0-8.8-7.2-16-16-16H80c-8.8 0-16 7.2-16 16v48H16C7.2 64 0 71.2 0 80v32c0 8.8 7.2 16 16 16h48v368c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V128h368c8.8 0 16-7.2 16-16V80c0-8.8-7.2-16-16-16zM160 384h320V160H160v224z"
+          />
+        </svg>
+        <p>
+          Find available properties
+        </p>
+      </div>
+    </button>
+    <div
+      className="vl"
+    />
     <div
       className="bar-item col"
     >
@@ -31,27 +85,15 @@ exports[`MapFilterBar renders correctly 1`] = `
             >
               <option
                 className="option"
+                value="name"
+              >
+                Property Name
+              </option>
+              <option
+                className="option"
                 value="address"
               >
                 Address
-              </option>
-              <option
-                className="option"
-                value="administrativeArea"
-              >
-                Location
-              </option>
-              <option
-                className="option"
-                value="pid"
-              >
-                PID/PIN
-              </option>
-              <option
-                className="option"
-                value="projectNumber"
-              >
-                RAEG or SPP No.
               </option>
             </select>
           </div>
@@ -193,41 +235,6 @@ exports[`MapFilterBar renders correctly 1`] = `
             Disposed
           </option>
         </select>
-      </div>
-    </div>
-    <div
-      className="bar-item d-flex align-items-start col"
-    >
-      <div
-        className="form-group"
-      >
-        <input
-          className="form-control"
-          id="input-minLotSize"
-          name="minLotSize"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="Min Lot Size"
-          value=""
-        />
-      </div>
-      <span
-        className="mx-2 align-self-center"
-      >
-        -
-      </span>
-      <div
-        className="form-group"
-      >
-        <input
-          className="form-control"
-          id="input-maxLotSize"
-          name="maxLotSize"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="Max Lot Size"
-          value=""
-        />
       </div>
     </div>
     <div

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -52,6 +52,7 @@ const defaultFilterValues: IPropertyFilter = {
   classificationId: '',
   minLotSize: '',
   maxLotSize: '',
+  rentableArea: '',
   propertyType: PropertyTypes.Land,
 };
 

--- a/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
+++ b/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Property list view Matches snapshot 1`] = `
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16,11 +16,22 @@ exports[`Property list view Matches snapshot 1`] = `
   justify-items: center;
 }
 
-.c2 {
+.c3 {
   color: #007bff;
 }
 
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c0 .p {
+  font-size: 16px;
+}
+
+.c1 {
   background-color: #fff !important;
   color: #003366 !important;
   padding: 6px 5px;
@@ -42,6 +53,37 @@ exports[`Property list view Matches snapshot 1`] = `
         <div
           class="map-filter-bar align-items-start form-row"
         >
+          <button
+            class="btn btn-primary"
+            style="height: 38px;"
+            type="button"
+          >
+            <div
+              class="c0"
+            >
+              <svg
+                fill="currentColor"
+                height="20"
+                size="20"
+                stroke="currentColor"
+                stroke-width="0"
+                style="margin-right: 5px; margin-top: 3px;"
+                viewBox="0 0 512 512"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M496 64H128V16c0-8.8-7.2-16-16-16H80c-8.8 0-16 7.2-16 16v48H16C7.2 64 0 71.2 0 80v32c0 8.8 7.2 16 16 16h48v368c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V128h368c8.8 0 16-7.2 16-16V80c0-8.8-7.2-16-16-16zM160 384h320V160H160v224z"
+                />
+              </svg>
+              <p>
+                Find available properties
+              </p>
+            </div>
+          </button>
+          <div
+            class="vl"
+          />
           <div
             class="bar-item col"
           >
@@ -61,27 +103,15 @@ exports[`Property list view Matches snapshot 1`] = `
                   >
                     <option
                       class="option"
+                      value="name"
+                    >
+                      Property Name
+                    </option>
+                    <option
+                      class="option"
                       value="address"
                     >
                       Address
-                    </option>
-                    <option
-                      class="option"
-                      value="administrativeArea"
-                    >
-                      Location
-                    </option>
-                    <option
-                      class="option"
-                      value="pid"
-                    >
-                      PID/PIN
-                    </option>
-                    <option
-                      class="option"
-                      value="projectNumber"
-                    >
-                      RAEG or SPP No.
                     </option>
                   </select>
                 </div>
@@ -165,37 +195,6 @@ exports[`Property list view Matches snapshot 1`] = `
                   classificationVal
                 </option>
               </select>
-            </div>
-          </div>
-          <div
-            class="bar-item d-flex align-items-start col"
-          >
-            <div
-              class="form-group"
-            >
-              <input
-                class="form-control"
-                id="input-minLotSize"
-                name="minLotSize"
-                placeholder="Min Lot Size"
-                value=""
-              />
-            </div>
-            <span
-              class="mx-2 align-self-center"
-            >
-              -
-            </span>
-            <div
-              class="form-group"
-            >
-              <input
-                class="form-control"
-                id="input-maxLotSize"
-                name="maxLotSize"
-                placeholder="Max Lot Size"
-                value=""
-              />
             </div>
           </div>
           <div
@@ -294,7 +293,7 @@ exports[`Property list view Matches snapshot 1`] = `
         </div>
       </div>
       <button
-        class="c0 btn btn-primary"
+        class="c1 btn btn-primary"
         type="button"
       >
         <svg
@@ -314,7 +313,7 @@ exports[`Property list view Matches snapshot 1`] = `
         </svg>
       </button>
       <button
-        class="c0 btn btn-primary"
+        class="c1 btn btn-primary"
         type="button"
       >
         <svg
@@ -378,7 +377,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Agency
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"
@@ -422,7 +421,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Sub Agency
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"
@@ -466,10 +465,10 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Property Name
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
-                  class="c2"
+                  class="c3"
                   fill="currentColor"
                   height="1em"
                   stroke="currentColor"
@@ -497,7 +496,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Classification
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"
@@ -554,7 +553,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Street Address
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"
@@ -598,7 +597,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Location
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"
@@ -642,7 +641,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Assessed Value
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"
@@ -686,7 +685,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Net Book Value
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"
@@ -730,7 +729,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Market Value
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"
@@ -774,7 +773,7 @@ exports[`Property list view Matches snapshot 1`] = `
             >
               Lot Size (in ha)
               <div
-                class="c1"
+                class="c2"
               >
                 <svg
                   fill="currentColor"


### PR DESCRIPTION
New filter bar revamp, clicking Find available properties will allow you to search by:

- location
- project number
- Building predominate use
- Building construction type
- Building number of floors
- Net rentable area
- Min/max lot size
- Bare land only

See GIF below for UI:
_**Updated**: Bare Land Only filter now filters out land with buildings on it properly and changed building name -> name so users can search for any property name_
![fitler](https://user-images.githubusercontent.com/15724124/102297655-7927c280-3f04-11eb-8a5f-9a38ce911191.gif)

