### PR TITLE
Fixing map crashing and zoom to results after search

### DIFF
--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -44,6 +44,7 @@ import { IGeoSearchParams } from 'constants/API';
 import { decimalOrUndefined, floatOrUndefined } from 'utils';
 import { IPropertyFilter } from 'features/properties/filter/IPropertyFilter';
 import { PropertyFilter } from 'features/properties/filter';
+import { useFilterContext } from '../providers/FIlterProvider';
 
 export type MapViewportChangeEvent = {
   bounds: LatLngBounds | null;
@@ -137,7 +138,7 @@ const Map: React.FC<MapProps> = ({
   const municipalitiesService = useLayerQuery(MUNICIPALITY_LAYER_URL);
   const parcelsService = useLayerQuery(PARCELS_LAYER_URL);
   const [bounds, setBounds] = useState<LatLngBounds>(defaultBounds);
-
+  const { setChanged } = useFilterContext();
   const [layerPopup, setLayerPopup] = useState<LayerPopupInformation>();
   if (mapRef.current && !selectedProperty?.parcelDetail) {
     lat = (mapRef.current.props.center as Array<number>)[0];
@@ -185,8 +186,8 @@ const Map: React.FC<MapProps> = ({
     if (filter.administrativeArea) {
       await zoomToAdministrativeArea(filter.administrativeArea);
     }
-
     setGeoFilter(getQueryParams(filter));
+    setChanged(true);
   };
 
   const handleBasemapToggle = (e: BasemapToggleEvent) => {
@@ -257,7 +258,7 @@ const Map: React.FC<MapProps> = ({
   };
 
   const handleBounds = (e: any) => {
-    const boundsData: LatLngBounds = e.sourceTarget.getBounds();
+    const boundsData: LatLngBounds = e.target.getBounds();
     if (!isEqual(boundsData.getNorthEast(), boundsData.getSouthWest())) {
       setBounds(boundsData);
     }
@@ -296,7 +297,7 @@ const Map: React.FC<MapProps> = ({
                   onclick={showLocationDetails}
                   closePopupOnClick={interactive}
                   onzoomend={e => setZoom(e.sourceTarget.getZoom())}
-                  onmoveend={handleBounds}
+                  ondragend={handleBounds}
                 >
                   {activeBasemap && (
                     <TileLayer

--- a/frontend/src/components/maps/leaflet/PointClusterer.tsx
+++ b/frontend/src/components/maps/leaflet/PointClusterer.tsx
@@ -13,7 +13,6 @@ import { IPropertyDetail } from 'actions/parcelsActions';
 import SelectedPropertyMarker from './SelectedPropertyMarker/SelectedPropertyMarker';
 import useDeepCompareEffect from 'hooks/useDeepCompareEffect';
 import { useFilterContext } from '../providers/FIlterProvider';
-import { isEqual } from 'lodash';
 
 export type PointClustererProps = {
   points: Array<PointFeature>;
@@ -119,11 +118,8 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
     if (featureGroupRef.current) {
       const group: LeafletFeatureGroup = featureGroupRef.current.leafletElement;
       const groupBounds = group.getBounds();
-      if (
-        !isEqual(groupBounds.getSouthWest(), groupBounds.getNorthEast()) &&
-        group.getBounds().isValid() &&
-        filterState.changed
-      ) {
+
+      if (groupBounds.isValid() && group.getBounds().isValid() && filterState.changed) {
         filterState.setChanged(false);
         map.fitBounds(group.getBounds(), { maxZoom: 10 });
       }
@@ -170,7 +166,7 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
             position={[latitude, longitude]}
             icon={getMarkerIcon(cluster)}
           >
-            <Popup>
+            <Popup autoPan={false}>
               <PopupView
                 propertyTypeId={cluster.properties.propertyTypeId}
                 propertyDetail={cluster.properties as any}
@@ -194,7 +190,7 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
           position={m.position}
           icon={getMarkerIcon(m)}
         >
-          <Popup>
+          <Popup autoPan={false}>
             <PopupView
               propertyTypeId={m.properties.propertyTypeId}
               propertyDetail={m.properties}
@@ -225,7 +221,7 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
           ]}
           map={leaflet.map}
         >
-          <Popup>
+          <Popup autoPan={false}>
             <PopupView
               propertyTypeId={selected.propertyTypeId}
               propertyDetail={selected.parcelDetail}

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -185,7 +185,7 @@ const PropertyListView: React.FC = () => {
         setData(undefined);
         const query = getServerQuery(false, { pageIndex, pageSize, filter, agencyIds });
         const data = await service.getPropertyList(query, sorting);
-        
+
         // The server could send back total page count.
         // For now we'll just calculate it.
         if (fetchId === fetchIdRef.current && data?.items) {


### PR DESCRIPTION
Now subscribing to the map `ondragend` to monitor the map bounds and make API query to load more data. `onzoomend` was too spammy and causing the map to make unnecessary api calls, and infinite loops. 

Also reenabled zoom results after searching