### PR TITLE
Fixed SPL form error

### DIFF
--- a/frontend/src/features/projects/common/interfaces.ts
+++ b/frontend/src/features/projects/common/interfaces.ts
@@ -127,7 +127,6 @@ export interface IProject {
   notes: IProjectNote[];
   publicNote: string;
   privateNote: string;
-  agencyResponseNote?: string;
   offersNote?: string;
   agencyId: number;
   agency?: string;
@@ -182,7 +181,7 @@ export interface IProject {
   ocgFinancialStatement?: number | '';
   salesCost?: number | '';
   gainBeforeSpl?: number | '';
-  gainAfterSpp?: number | '';
+  netProceeds?: number | '';
   gainNote?: string;
   programCost?: number | '';
   programCostNote?: string;
@@ -308,13 +307,18 @@ export const initialValues: IProject = {
   sixtyDayNoficationSentOn: '',
   ninetyDayNotificationSentOn: '',
   onHoldNotificationSentOn: '',
+  interestedReceivedOn: '',
+  interestFromEnhancedReferralNote: '',
   transferredWithinGreOn: '',
   clearanceNotificationSentOn: '',
+  requestForSplReceivedOn: '',
+  approvedForSplOn: '',
   marketedOn: '',
   disposedOn: '',
   offerAcceptedOn: '',
   assessedOn: '',
   adjustedOn: '',
+  offersNote: '',
   preliminaryFormSignedOn: '',
   finalFormSignedOn: '',
   netBook: '',
@@ -333,12 +337,13 @@ export const initialValues: IProject = {
   ocgFinancialStatement: '',
   salesCost: '',
   gainBeforeSpl: '',
-  gainAfterSpp: '',
+  netProceeds: '',
   programCost: '',
   priorYearAdjustmentAmount: '',
   removalFromSplRequestOn: '',
   removalFromSplApprovedOn: '',
   removalFromSplRationale: '',
+  documentationNote: '',
   salesHistoryNote: '',
   comments: '',
   loanTermsNote: '',
@@ -346,6 +351,7 @@ export const initialValues: IProject = {
   remediationNote: '',
   programCostNote: '',
   gainNote: '',
+  adjustmentNote: '',
 };
 
 export interface IApiProject {
@@ -366,7 +372,7 @@ export interface IApiProject {
   exemptionRequested?: boolean;
   exemptionRationale?: string;
   exemptionApprovedOn?: Date | string;
-  agencyResponseNote?: string;
+  interestFromEnhancedReferralNote?: string;
   agencyId: number;
   statusId: number;
   statusCode?: string;

--- a/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
@@ -612,6 +612,7 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                   >
                     <input
                       class="form-control input-number"
+                      disabled=""
                       name="gainBeforeSpl"
                       placeholder=""
                       value=""
@@ -659,6 +660,7 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                   >
                     <input
                       class="form-control input-number"
+                      disabled=""
                       name="netProceeds"
                       placeholder=""
                       value=""

--- a/frontend/src/features/projects/spl/forms/CloseOutFinancialSummaryForm.tsx
+++ b/frontend/src/features/projects/spl/forms/CloseOutFinancialSummaryForm.tsx
@@ -10,6 +10,11 @@ interface CloseOutFinancialSummaryFormProps {
   isReadOnly?: boolean; // TODO: Need to make `disabled` and `isReadonly` consistent.  Choose one throughout app.
 }
 
+const getValue = (value?: string | number) => {
+  const result = Number(value);
+  return isNaN(result) ? 0 : result;
+};
+
 /**
  * Close out form financial summary fields.
  * @param props
@@ -23,14 +28,17 @@ const CloseOutFinancialSummaryForm = (props: CloseOutFinancialSummaryFormProps) 
   const netBook = getIn(values, 'netBook');
   useEffect(() => {
     // Calculate the Gain before SPL.
-    setFieldValue('gainBeforeSpl', market - interestComponent - salesCost - netBook);
+    setFieldValue(
+      'gainBeforeSpl',
+      getValue(market) - getValue(interestComponent) - getValue(salesCost) - getValue(netBook),
+    );
   }, [market, interestComponent, salesCost, netBook, setFieldValue]);
 
   const gainBeforeSpl = getIn(values, 'gainBeforeSpl');
   const programCost = getIn(values, 'programCost');
   useEffect(() => {
     // Calculate the Gain after SPL.
-    setFieldValue('netProceeds', gainBeforeSpl - programCost);
+    setFieldValue('netProceeds', getValue(gainBeforeSpl) - getValue(programCost));
   }, [gainBeforeSpl, programCost, setFieldValue]);
 
   const formikProps = useFormikContext<IProject>();
@@ -90,7 +98,7 @@ const CloseOutFinancialSummaryForm = (props: CloseOutFinancialSummaryFormProps) 
             </Form.Label>
             <FastCurrencyInput
               formikProps={formikProps}
-              disabled={props.isReadOnly}
+              disabled={true}
               field="gainBeforeSpl"
               allowNegative={true}
               md={6}
@@ -113,7 +121,7 @@ const CloseOutFinancialSummaryForm = (props: CloseOutFinancialSummaryFormProps) 
             </Form.Label>
             <FastCurrencyInput
               formikProps={formikProps}
-              disabled={props.isReadOnly}
+              disabled={true}
               field="netProceeds"
               allowNegative={true}
               md={6}

--- a/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.tsx
+++ b/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.tsx
@@ -65,6 +65,7 @@ const SurplusPropertyListForm = ({
   onClickContractInPlaceUnconditional,
   onClickDisposedExternally,
 }: ISurplusPropertyListFormProps) => {
+  debugger;
   const formikProps = useFormikContext<IProject>();
   const [dispose, setDispose] = useState(false);
   const cipConditionalTasks = _.filter(formikProps.values.tasks, {

--- a/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
+++ b/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
@@ -624,9 +624,10 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                   >
                     <input
                       class="form-control input-number"
+                      disabled=""
                       name="gainBeforeSpl"
                       placeholder=""
-                      value="NaN"
+                      value="0"
                     />
                   </div>
                 </div>
@@ -671,9 +672,10 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                   >
                     <input
                       class="form-control input-number"
+                      disabled=""
                       name="netProceeds"
                       placeholder=""
-                      value="NaN"
+                      value="0"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Don't entirely understand the issue that was occurring, but it appears to be related to Formik handling of undefined values.  While this was working originally without these additional steps, it now will calculate and return $0 for the calculated fields.