### PR TITLE
Only SRES can select Disposed classification

### DIFF
--- a/frontend/src/components/common/form/ParentSelect.scss
+++ b/frontend/src/components/common/form/ParentSelect.scss
@@ -1,0 +1,14 @@
+.map-filter-bar {
+  .agency-item {
+    .form-control {
+      width: 230px;
+    }
+    .form-group {
+      .rbt {
+        .rbt-menu {
+          width: 370px !important;
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/components/common/form/ParentSelect.tsx
+++ b/frontend/src/components/common/form/ParentSelect.tsx
@@ -1,3 +1,5 @@
+import './ParentSelect.scss';
+
 import { getIn, useFormikContext } from 'formik';
 import { groupBy, sortBy } from 'lodash';
 import React, { Fragment, useEffect, useState } from 'react';

--- a/frontend/src/features/properties/components/forms/subforms/InformationForm.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/InformationForm.tsx
@@ -15,6 +15,9 @@ import { HARMFUL_DISCLOSURE_URL } from 'constants/strings';
 import { IProperty } from 'actions/parcelsActions';
 import { Link } from 'react-router-dom';
 import { classificationTip, sensitiveTooltip } from '../strings';
+import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
+import Claims from 'constants/claims';
+import { Classifications } from 'constants/classifications';
 
 interface InformationFormProps {
   nameSpace?: string;
@@ -39,6 +42,12 @@ const InformationForm: FunctionComponent<InformationFormProps> = (props: Informa
   const formikProps = useFormikContext();
   const { values } = useFormikContext<IProperty>();
   const projectNumber = getIn(values, withNameSpace('projectNumber'));
+  const keycloak = useKeycloakWrapper();
+
+  /** only SRES can change to Disposed  */
+  const classifications = keycloak.hasClaim(Claims.ADMIN_PROPERTIES)
+    ? props.classifications
+    : props.classifications.filter(x => x.value !== Classifications.Disposed);
 
   return (
     <>
@@ -67,7 +76,7 @@ const InformationForm: FunctionComponent<InformationFormProps> = (props: Informa
           type="number"
           placeholder="Must Select One"
           field={withNameSpace('classificationId')}
-          options={props.classifications}
+          options={classifications}
           tooltip={classificationTip}
         />
       </Form.Row>

--- a/frontend/src/features/properties/filter/PropertyFilter.scss
+++ b/frontend/src/features/properties/filter/PropertyFilter.scss
@@ -1,7 +1,6 @@
 @import '../../../fonts.scss';
 @import '../../../variables';
 @import '../../../colors';
-
 .container-fluid {
   &.map-filter-container {
     height: auto;
@@ -35,12 +34,6 @@
         .form-group {
           padding: 0;
           margin: 0;
-        }
-      }
-      .agency-item {
-        .form-control {
-          width: 230px;
-          max-width: 250px;
         }
       }
       .map-filter-typeahead {


### PR DESCRIPTION
 Quick bug fix to only allow SRES users to select Disposed for property classifications 

Updated: Still fighting off the warnings on the `ParentSelect` component. Split off the larger dropdown menu for agencies into this PR

![image](https://user-images.githubusercontent.com/15724124/103387353-10ba1300-4ab8-11eb-9e45-2b5d9beb7d7b.png)
