### PR TITLE
Classification - remove disposed from non-sres

### DIFF
--- a/frontend/src/features/properties/components/forms/subforms/InformationForm.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/InformationForm.tsx
@@ -47,7 +47,7 @@ const InformationForm: FunctionComponent<InformationFormProps> = (props: Informa
   /** only SRES can change to Disposed  */
   const classifications = keycloak.hasClaim(Claims.ADMIN_PROPERTIES)
     ? props.classifications
-    : props.classifications.filter(x => x.value !== Classifications.Disposed);
+    : props.classifications.filter(x => Number(x.value) !== Classifications.Disposed);
 
   return (
     <>


### PR DESCRIPTION
Originally had this checking the label not the value and when I switched it over to use the value and enum I forgot to cast it to a number