### PR TITLE
Location filter bug fix

### DIFF
--- a/frontend/src/components/SearchBar/FindMorePropertiesForm.tsx
+++ b/frontend/src/components/SearchBar/FindMorePropertiesForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from 'reducers/rootReducer';
 import { ILookupCode } from 'actions/lookupActions';
@@ -6,16 +6,17 @@ import { ILookupCodeState } from 'reducers/lookupCodeReducer';
 import { mapLookupCode } from 'utils';
 import * as API from 'constants/API';
 import styled from 'styled-components';
-import { Container, Row } from 'react-bootstrap';
+import { Container, Form, Row } from 'react-bootstrap';
 import { Button, Check, Input, Select } from 'components/common/form';
 import _ from 'lodash';
-import { useFormikContext } from 'formik';
+import { getIn, useFormikContext } from 'formik';
+import { TypeaheadField } from 'components/common/form/Typeahead';
 
 const StyledRow = styled(Row)`
   .form-group {
     display: flex;
     .form-label {
-      margin-top: 5px;
+      margin-top: 0.5rem;
       margin-right: 10px;
       width: 150px;
       text-align: right;
@@ -59,11 +60,18 @@ const SearchButton = styled(props => <Button {...props} />)`
   margin-left: 665px;
 `;
 
+const StyledLocation = styled(props => <TypeaheadField {...props} />)`
+  width: 250px;
+  margin-left: 60px;
+`;
 /** This form is triggered by the FindMorePropertiesButton and contains additional filter fields for the PropertiesFilter */
 const FindMorePropertiesForm = <T extends any>(props: any) => {
   const lookupCodes = useSelector<RootState, ILookupCode[]>(
     state => (state.lookupCode as ILookupCodeState).lookupCodes,
   );
+
+  const { setFieldValue } = useFormikContext<any>();
+  const [clear, setClear] = useState(false);
 
   const constructionType = _.filter(lookupCodes, (lookupCode: ILookupCode) => {
     return lookupCode.type === API.CONSTRUCTION_CODE_SET_NAME;
@@ -71,6 +79,10 @@ const FindMorePropertiesForm = <T extends any>(props: any) => {
   const predominateUses = _.filter(lookupCodes, (lookupCode: ILookupCode) => {
     return lookupCode.type === API.PREDOMINATE_USE_CODE_SET_NAME;
   }).map(mapLookupCode);
+  const administrativeAreas = _.filter(lookupCodes, (lookupCode: ILookupCode) => {
+    return lookupCode.type === API.AMINISTRATIVE_AREA_CODE_SET_NAME;
+  });
+  const adminAreas = (administrativeAreas ?? []).map(c => mapLookupCode(c, null));
 
   const { handleSubmit } = useFormikContext();
 
@@ -92,7 +104,19 @@ const FindMorePropertiesForm = <T extends any>(props: any) => {
           <h6>Search by</h6>
         </Row>
         <StyledRow style={{ marginLeft: 35 }}>
-          <Input field="administrativeArea" label="Location" />
+          <Form.Label style={{ marginTop: '.5rem' }}>Location</Form.Label>
+          <StyledLocation
+            name="administrativeArea"
+            placeholder="Enter a location"
+            paginate={false}
+            hideValidation={true}
+            options={adminAreas.map((x: any) => x.label)}
+            onChange={(vals: any) => {
+              setFieldValue('administrativeArea', getIn(vals[0], 'name') ?? vals[0]);
+            }}
+            clearSelected={clear}
+            setClear={setClear}
+          />
           <VerticalLine />
           <ProjectNumber field="projectNumber" label="Project number" placeholder="SPP #" />
         </StyledRow>

--- a/frontend/src/components/common/form/Typeahead.tsx
+++ b/frontend/src/components/common/form/Typeahead.tsx
@@ -64,12 +64,14 @@ export function TypeaheadField<T extends TypeaheadModel>({
   React.useEffect(() => {
     if (clearSelected && ref.current?.clear) {
       ref.current.clear();
+      setFieldValue(name, '');
+      setClear && setClear(false);
     }
     if (clearMenu && ref.current?.blur) {
       ref.current.blur();
       setClear && setClear(false);
     }
-  }, [clearMenu, clearSelected, setClear]);
+  }, [clearMenu, clearSelected, setClear, name, setFieldValue]);
   return (
     <Form.Group className={classNames(!!required ? 'required' : '', outerClassName)}>
       {!!label && <Form.Label>{label}</Form.Label>}

--- a/frontend/src/features/properties/filter/PropertyFilter.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilter.tsx
@@ -1,6 +1,6 @@
 import './PropertyFilter.scss';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Col } from 'react-bootstrap';
 import { Formik, getIn } from 'formik';
 import { ILookupCode } from 'actions/lookupActions';
@@ -72,6 +72,7 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
   );
   const classifications = (propertyClassifications ?? []).map(c => mapLookupCode(c));
   const adminAreas = (adminAreaLookupCodes ?? []).map(c => mapLookupCode(c));
+  const [clear, setClear] = useState(false);
 
   const initialValues = useMemo(() => {
     const values = { ...defaultFilter, ...propertyFilter };
@@ -97,6 +98,7 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
 
   const resetFilter = () => {
     changeFilter(defaultFilter);
+    setClear(true);
   };
 
   return (
@@ -128,6 +130,8 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
                 onChange={(vals: any) => {
                   setFieldValue('administrativeArea', getIn(vals[0], 'name') ?? vals[0]);
                 }}
+                clearSelected={clear}
+                setClear={setClear}
               />
             </Col>
             <Col className="agency-item">


### PR DESCRIPTION
Note - I am going to make another ticket as I noticed some of the other fields were not clearing properly (eg. Agency). They clear when you hit search and then reset but if you fill in values without submitting and then hit reset they will not. Will assign ticket to myself for this sprint. 

Includes:
- bug fix for the clearing of location
- adding the `Typeahead` component to the `Surplus Properties` location search to allow for autocomplete