### PR TITLE
Coverlet console fix

### DIFF
--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -23,7 +23,7 @@ jobs:
         run: dotnet restore
         working-directory: ${{env.working-directory}}
       - name: Install coverlet for code coverage
-        run: dotnet tool install -g coverlet.console
+        run: dotnet tool install -g coverlet.console --version 1.7.2
         working-directory: ${{env.working-directory}}
       - name: Build
         run: dotnet build --configuration Release --no-restore


### PR DESCRIPTION
Fix for the failing GitHub action currently block PR's. Coverlet console had an update 2 days ago and it looks like it does not support .Net Core 3.1. Reverted back to the previously used version of coverlet to address this problem