### PR TITLE
Using tiles to fetch PIMS Inventory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21699,6 +21699,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "tiles-in-bbox": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiles-in-bbox/-/tiles-in-bbox-1.0.2.tgz",
+      "integrity": "sha512-LTV5BK/9yb73DtS6C+2Y0J4fCPfu/hXW5BjH8DR7yeaE+ykWqaZmHVAKjCp7oL8ZkDxrxeLQhoq9FFYDHyyOzA=="
+    },
     "timers-browserify": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "styled-components": "5.1.0",
     "supercluster": "7.1.0",
     "text-mask-addons": "3.8.0",
+    "tiles-in-bbox": "1.0.2",
     "tiny-invariant": "1.1.0",
     "typescript": "3.8.3",
     "yup": "0.28.3"

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -38,7 +38,7 @@ import { useLayerQuery } from './LayerPopup/hooks/useLayerQuery';
 import { saveParcelLayerData } from 'reducers/parcelLayerDataSlice';
 import useActiveFeatureLayer from '../hooks/useActiveFeatureLayer';
 import LayersControl from './LayersControl';
-import { InventoryLayer } from './InventoryLayer';
+import { defaultBounds, InventoryLayer } from './InventoryLayer';
 import { PointFeature } from '../types';
 import { IGeoSearchParams } from 'constants/API';
 import { decimalOrUndefined, floatOrUndefined } from 'utils';
@@ -120,8 +120,6 @@ const getQueryParams = (filter: IPropertyFilter): IGeoSearchParams => {
     bareLandOnly: filter.bareLandOnly,
   };
 };
-
-const defaultBounds = new LatLngBounds([60.09114547, -119.49609429], [48.78370426, -139.35937554]);
 
 /**
  * Creates a Leaflet map and by default includes a number of preconfigured layers.
@@ -309,6 +307,7 @@ const Map: React.FC<MapProps> = ({
                   whenReady={() => {
                     fitMapBounds();
                   }}
+                  minZoom={5}
                   onclick={showLocationDetails}
                   closePopupOnClick={interactive}
                   onzoomend={e => setZoom(e.sourceTarget.getZoom())}

--- a/frontend/src/components/maps/leaflet/PointClusterer.tsx
+++ b/frontend/src/components/maps/leaflet/PointClusterer.tsx
@@ -15,6 +15,8 @@ import useDeepCompareEffect from 'hooks/useDeepCompareEffect';
 import { useFilterContext } from '../providers/FIlterProvider';
 
 export type PointClustererProps = {
+  // if all tiles data loading has finished
+  tilesLoaded: boolean;
   points: Array<PointFeature>;
   selected?: IPropertyDetail | null;
   bounds?: BBox;
@@ -38,6 +40,7 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
   selected,
   zoomToBoundsOnClick = true,
   spiderfyOnMaxZoom = true,
+  tilesLoaded,
 }) => {
   // state and refs
   const spiderfierRef = useRef<Spiderfier>();
@@ -119,12 +122,18 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
       const group: LeafletFeatureGroup = featureGroupRef.current.leafletElement;
       const groupBounds = group.getBounds();
 
-      if (groupBounds.isValid() && group.getBounds().isValid() && filterState.changed) {
+      if (
+        groupBounds.isValid() &&
+        group.getBounds().isValid() &&
+        filterState.changed &&
+        tilesLoaded
+      ) {
         filterState.setChanged(false);
         map.fitBounds(group.getBounds(), { maxZoom: 10 });
+        setSpider({});
       }
     }
-  }, [featureGroupRef, map, clusters]);
+  }, [featureGroupRef, map, clusters, tilesLoaded]);
 
   return (
     <FeatureGroup ref={featureGroupRef}>

--- a/frontend/src/constants/API.ts
+++ b/frontend/src/constants/API.ts
@@ -70,6 +70,7 @@ export interface IGeoSearchParams {
   floorCount?: number;
   rentableArea?: number;
   propertyType?: string;
+  tileKey?: string;
 }
 export const GEO_PROPERTIES = (params: IGeoSearchParams | null) =>
   `/properties/search/wfs?${params ? queryString.stringify(params) : ''}`; // get filtered properties or all if not specified.

--- a/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.tsx
+++ b/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.tsx
@@ -65,7 +65,6 @@ const SurplusPropertyListForm = ({
   onClickContractInPlaceUnconditional,
   onClickDisposedExternally,
 }: ISurplusPropertyListFormProps) => {
-  debugger;
   const formikProps = useFormikContext<IProject>();
   const [dispose, setDispose] = useState(false);
   const cipConditionalTasks = _.filter(formikProps.values.tasks, {

--- a/frontend/src/typings/tiles-in-bbox/index.d.ts
+++ b/frontend/src/typings/tiles-in-bbox/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'tiles-in-bbox' {
+  interface ITile {
+    x: number;
+    y: number;
+    z: number;
+  }
+
+  // get tiles in a bbox
+  export function tilesInBbox(bounds: any, zoom: number): ITile[];
+}


### PR DESCRIPTION
I used a library called `tiles-in-bbox` to generate tiles (size 256), then use the generated tiles to calculate a bbox for each tile and use it to fetch inventory markers features for the tile. The results of each tiles are merged together and passed as props to the PointCluster component for rendering (same behaviour as before). After all the files have loaded/processed, the map zooms to the results.