### PR TITLE
Fixing DevOps Jenkins configuration

### DIFF
--- a/openshift/3.11/MULTIPLE_INSTANCES.md
+++ b/openshift/3.11/MULTIPLE_INSTANCES.md
@@ -198,7 +198,7 @@ GITHUB_WEBHOOK_SECRET=
 GENERIC_WEBHOOK_SECRET=
 GIT_URL=https://github.com/{REPO NAME}/PIMS.git
 GIT_REF={BRANCH NAME}
-JENKINSFILE_PATH=openshift/pipelines/Jenkinsfile.cicd
+JENKINSFILE_PATH=openshift/3.11/pipelines/Jenkinsfile.cicd
 
 APP_URI=https://pims-{ENV_NAME}{INSTANCE IDENTITY}.pathfinder.gov.bc.ca/
 ENV_NAME={ENV_NAME}

--- a/openshift/3.11/PIPELINES.md
+++ b/openshift/3.11/PIPELINES.md
@@ -10,7 +10,7 @@ This project makes use of several pipelines. For each one, use the generic pipel
 2. Create a **`.env`** file that contains the values for the parameters within the template
    ```
    NAME=cicd
-   JENKINSFILE_PATH=openshift/pipelines/Jenkinsfile.cicd
+   JENKINSFILE_PATH=openshift/3.11/pipelines/Jenkinsfile.cicd
    ```
 3. Create the pipeline objects `oc process --param-file=[.env] -f openshift/templates/jenkins/generic-pipeline.yaml | oc create -f -`
 

--- a/openshift/3.11/pipelines/Jenkinsfile.cicd
+++ b/openshift/3.11/pipelines/Jenkinsfile.cicd
@@ -64,8 +64,8 @@ pipeline {
       steps {
         script {
           // load supporting functions from external script files
-          commonPipeline = load "openshift/pipelines/scripts/common.groovy"
-          notify = load "openshift/pipelines/scripts/notify.groovy"
+          commonPipeline = load "openshift/3.11/pipelines/scripts/common.groovy"
+          notify = load "openshift/3.11/pipelines/scripts/notify.groovy"
 
           // Cancel any running builds in progress
           timeout(time: 10, unit: 'MINUTES') {

--- a/openshift/3.11/pipelines/Jenkinsfile.dev-to-test
+++ b/openshift/3.11/pipelines/Jenkinsfile.dev-to-test
@@ -38,8 +38,8 @@ pipeline {
       steps {
         script {
           // load supporting functions from external script files
-          cli = load "openshift/pipelines/scripts/common.groovy"
-          notify = load "openshift/pipelines/scripts/notify.groovy"
+          cli = load "openshift/3.11/pipelines/scripts/common.groovy"
+          notify = load "openshift/3.11/pipelines/scripts/notify.groovy"
 
           // ensure required secrets and credentials are available in the CI environment
           // [add more secrets here if needed...]

--- a/openshift/3.11/pipelines/Jenkinsfile.test-to-prod
+++ b/openshift/3.11/pipelines/Jenkinsfile.test-to-prod
@@ -59,8 +59,8 @@ pipeline {
       steps {
         script {
           // load supporting functions from external script files
-          commonPipeline = load "openshift/pipelines/scripts/common.groovy"
-          notify = load "openshift/pipelines/scripts/notify.groovy"
+          commonPipeline = load "openshift/3.11/pipelines/scripts/common.groovy"
+          notify = load "openshift/3.11/pipelines/scripts/notify.groovy"
 
           // ensure required secrets and credentials are available in the CI environment
           // [add more secrets here if needed...]

--- a/openshift/3.11/templates/jenkins/generic-pipeline.yaml
+++ b/openshift/3.11/templates/jenkins/generic-pipeline.yaml
@@ -49,48 +49,48 @@ objects:
       lastVersion: 0
 parameters:
   - name: NAME
-    displayName: Pipeline Name
-    description: Name of the pipeline, e.g cicd, promote-to-test, sonarqube. A -pipeline suffix will be appended to the name provided.
+    displayName: "Pipeline Name"
+    description: "Name of the pipeline, e.g cicd, promote-to-test, sonarqube. A -pipeline suffix will be appended to the name provided."
     required: true
   - name: GITHUB_WEBHOOK_SECRET
-    displayName: GitHub Webhook Secret
-    description: A secret string used to configure the GitHub webhook.
+    displayName: "GitHub Webhook Secret"
+    description: "A secret string used to configure the GitHub webhook."
     generate: "expression"
     from: "[a-zA-Z0-9]{40}"
   - name: GENERIC_WEBHOOK_SECRET
-    displayName: Generic Webhook Secret
-    description: A secret string used to configure the Generic webhook.
+    displayName: "Generic Webhook Secret"
+    description: "A secret string used to configure the Generic webhook."
     generate: "expression"
     from: "[a-zA-Z0-9]{40}"
   - name: GIT_URL
-    displayName: Git Repository URL
-    description: The URL of the repository containing the Jenkinsfile the pipeline buildconfig will use.
+    displayName: "Git Repository URL"
+    description: "The URL of the repository containing the Jenkinsfile the pipeline buildconfig will use."
     value: https://github.com/bcgov/PIMS.git
     required: true
   - name: GIT_REF
-    displayName: Git Reference
-    description: Set this to a branch name, tag or other ref of your repository if you are not using the default branch.
-    value: dev
+    displayName: "Git Reference"
+    description: "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+    value: "dev"
   - name: JENKINSFILE_PATH
-    displayName: Jenkinsfile path
-    description: Set this to the path to your Jenkinsfile (include the filename), relative to the contextDir.
-    value: openshift/pipelines/Jenkinsfile
+    displayName: "Jenkinsfile path"
+    description: "Set this to the path to your Jenkinsfile (include the filename), relative to the contextDir."
+    value: "openshift/3.11/pipelines/Jenkinsfile"
   - name: APP_URI
-    displayName: Application URI
-    description: The URI to the application being deployed.
+    displayName: "Application URI"
+    description: "The URI to the application being deployed."
     required: true
     value: "https://pims-dev.pathfinder.gov.bc.ca/"
   - name: ENV_NAME
-    displayName: Environment name
-    description: The name for the environment that the build will be deployed to [dev, test, prod]
+    displayName: "Environment name"
+    description: "The name for the environment that the build will be deployed to [dev, test, prod]"
     required: true
-    value: dev
+    value: "dev"
   - name: OC_JOB_NAME
-    displayName: Job Branch Name
-    description: Job identifier (i.e. 'pr-5' OR 'dev' OR 'master')
+    displayName: "Job Branch Name"
+    description: "Job identifier (i.e. 'pr-5' OR 'dev' OR 'master')"
     required: true
-    value: dev
+    value: "dev"
   - name: ENABLE_VERSION_PROMPT
-    displayName: Enable Version Prompt
-    description: To force asking for a release version before running the pipeline, set to "true"
-    value: false
+    displayName: "Enable Version Prompt"
+    description: "To force asking for a release version before running the pipeline, set to 'true'"
+    value: "false"


### PR DESCRIPTION
Moving jenkins files around to prepare for OCP4.0 broke the 3.11 pipelines.  These updates should resolve them.