### PR TITLE
Fixed RowVersion on Second Submit

### DIFF
--- a/backend/api/Areas/Property/Controllers/ParcelController.cs
+++ b/backend/api/Areas/Property/Controllers/ParcelController.cs
@@ -130,10 +130,8 @@ namespace Pims.Api.Areas.Property.Controllers
         {
             var entity = _mapper.Map<Entity.Parcel>(model);
 
-            _pimsService.Parcel.Update(entity); // TODO: Update related properties (i.e. Address).
-            var parcel = _mapper.Map<Model.ParcelModel>(entity);
-
-            return new JsonResult(parcel);
+            var parcel = _pimsService.Parcel.Update(entity);
+            return new JsonResult(_mapper.Map<Model.ParcelModel>(parcel));
         }
 
         /// <summary>

--- a/backend/dal/Services/Concrete/ParcelService.cs
+++ b/backend/dal/Services/Concrete/ParcelService.cs
@@ -409,7 +409,7 @@ namespace Pims.Dal.Services
 
             this.Context.SaveChanges();
             this.Context.CommitTransaction();
-            return parcel;
+            return Get(parcel.Id);
         }
 
         /// <summary>

--- a/backend/tests/unit/dal/Services/ParcelServiceTest.cs
+++ b/backend/tests/unit/dal/Services/ParcelServiceTest.cs
@@ -754,7 +754,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.AdminProperties).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.AdminProperties).AddAgency(1);
             var init = helper.InitializeDatabase(user);
             var parcel = init.CreateParcel(1);
             init.SaveChanges();
@@ -1013,7 +1013,7 @@ namespace Pims.Dal.Test.Services
             Assert.False(result);
         }
         #endregion
-        
+
         #region Check PIN available
 
         /// <summary>

--- a/frontend/src/actionCreators/parcelsActionCreator.spec.ts
+++ b/frontend/src/actionCreators/parcelsActionCreator.spec.ts
@@ -197,7 +197,7 @@ describe('updateParcel action creator', () => {
     return updateParcel(parcel)(dispatch).then(() => {
       expect(requestSpy).toHaveBeenCalledTimes(1);
       expect(successSpy).toHaveBeenCalledTimes(1);
-      expect(dispatch).toHaveBeenCalledTimes(5);
+      expect(dispatch).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/frontend/src/actionCreators/parcelsActionCreator.ts
+++ b/frontend/src/actionCreators/parcelsActionCreator.ts
@@ -123,7 +123,6 @@ export const updateParcel = (parcel: IParcel) => async (dispatch: Function) => {
       parcel,
     );
     dispatch(success(actionTypes.UPDATE_PARCEL, status));
-    dispatch(fetchParcelDetail(data));
     dispatch(hideLoading());
     return data;
   } catch (axiosError) {

--- a/frontend/src/actions/parcelsActions.ts
+++ b/frontend/src/actions/parcelsActions.ts
@@ -120,6 +120,7 @@ export interface IParcel extends IProperty {
   buildings: IBuilding[];
   evaluations: IEvaluation[];
   fiscals: IFiscal[];
+  rowVersion?: string;
 }
 
 export interface IParcelDetail {

--- a/frontend/src/features/properties/containers/ParcelDetailFormContainer.tsx
+++ b/frontend/src/features/properties/containers/ParcelDetailFormContainer.tsx
@@ -194,8 +194,10 @@ const ParcelDetailForm: React.FunctionComponent<IParcelPropertyProps> = ({
               if (!values.id) {
                 const data = await createParcel(apiValues)(dispatch);
                 persistCallback(data);
+                values.rowVersion = data.rowVersion;
               } else {
-                await updateParcel(apiValues)(dispatch);
+                const data = await updateParcel(apiValues)(dispatch);
+                values.rowVersion = data.rowVersion;
               }
             } catch (error) {
               //TODO: For now, swallow the exception.


### PR DESCRIPTION
Presently it is impossible to click the Submit button a second time when saving properties because the `rowVersion` isn't updated correctly.

- Note: this does not fix a more complex problem when attempting to save financial values in the second submit.