### PR TITLE
Fix inventory list view not resetting properly

### DIFF
--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -310,7 +310,7 @@ const PropertyListView: React.FC = () => {
       <Container fluid className="filter-container border-bottom">
         <Container className="px-0">
           <PropertyFilter
-            defaultFilter={filter}
+            defaultFilter={defaultFilterValues}
             agencyLookupCodes={agencies}
             propertyClassifications={propertyClassifications}
             adminAreaLookupCodes={administrativeAreas}


### PR DESCRIPTION
Was previously passing existing filter instead of the default values so reset was not working as intended 