### PR TITLE
PIMS inventory features loading performance optimization

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4765,7 +4765,6 @@
       "version": "3.4.6",
       "resolved": "https://registry.npmjs.org/@types/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.4.6.tgz",
       "integrity": "sha512-3vrWrPNb2G+ieyWB1VtEPZH6E4NBcd2cVsacb6oUhBNU/D/ZYnUqnbmeTIKzIVXqEkdPtgARG45W1x7tUV9DGA==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -4843,7 +4842,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@types/react-responsive/-/react-responsive-8.0.2.tgz",
       "integrity": "sha512-DTvm3Hb77v0hme7L4GYzRjLQqlZP+zNImFBzdKbSH7CsQ5c7QebGnSQX2Xf3BaA0rm/TQE57eFMhMGLcMe/A9w==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -21715,6 +21713,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "tiles-in-bbox": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiles-in-bbox/-/tiles-in-bbox-1.0.2.tgz",
+      "integrity": "sha512-LTV5BK/9yb73DtS6C+2Y0J4fCPfu/hXW5BjH8DR7yeaE+ykWqaZmHVAKjCp7oL8ZkDxrxeLQhoq9FFYDHyyOzA=="
+    },
     "timers-browserify": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
@@ -22385,6 +22388,7 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -22422,6 +22426,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -22430,6 +22435,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -22480,6 +22486,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -22553,6 +22560,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "styled-components": "5.1.0",
     "supercluster": "7.1.0",
     "text-mask-addons": "3.8.0",
+    "tiles-in-bbox": "1.0.2",
     "tiny-invariant": "1.1.0",
     "typescript": "3.8.3",
     "yup": "0.28.3"

--- a/frontend/src/components/maps/leaflet/InventoryLayer.tsx
+++ b/frontend/src/components/maps/leaflet/InventoryLayer.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { IPropertyDetail } from 'actions/parcelsActions';
 import { IGeoSearchParams } from 'constants/API';
-import { BBox, Feature } from 'geojson';
+import { BBox } from 'geojson';
 import useDeepCompareEffect from 'hooks/useDeepCompareEffect';
 import { LatLngBounds } from 'leaflet';
 import { useLeaflet } from 'react-leaflet';
@@ -9,9 +9,11 @@ import { toast } from 'react-toastify';
 import { PointFeature } from '../types';
 import PointClusterer from './PointClusterer';
 import { useApi } from 'hooks/useApi';
-import _ from 'lodash';
 import { useSelector } from 'react-redux';
 import { RootState } from 'reducers/rootReducer';
+import { flatten, uniqBy } from 'lodash';
+import { tilesInBbox } from 'tiles-in-bbox';
+import { useFilterContext } from '../providers/FIlterProvider';
 
 export type InventoryLayerProps = {
   /** Latitude and Longitude boundary of the layer. */
@@ -43,18 +45,81 @@ const getBbox = (bounds: LatLngBounds): BBox => {
   ] as BBox;
 };
 
+interface ITilePoint {
+  // x axis of the tile
+  x: number;
+  // y axis of the tile
+  y: number;
+  // zoom state of the tile
+  z: number;
+}
+
+interface ITile {
+  // Tile point {x, y, z}
+  point: ITilePoint;
+  // unique id of the file
+  key: string;
+  // bbox of the tile
+  bbox: string;
+  // tile data status
+  processed?: boolean;
+  // tile data, a list of properties in the tile
+  datum?: PointFeature[];
+  // tile bounds
+  latlngBounds: LatLngBounds;
+}
+
 /**
- * Get a new instance of a BBox from the specified 'bounds'.
- * @param bounds The latitude longitude boundary.
+ * Generate tiles for current bounds and zoom
+ * @param bounds
+ * @param zoom
  */
-const getApiBbox = (bounds: LatLngBounds): BBox => {
-  return [
-    bounds.getSouthWest().lng,
-    bounds.getNorthEast().lng,
-    bounds.getSouthWest().lat,
-    bounds.getNorthEast().lat,
-  ] as BBox;
+export const getTiles = (bounds: LatLngBounds, zoom: number): ITile[] => {
+  const bbox = {
+    bottom: bounds.getSouth(),
+    left: bounds.getWest(),
+    top: bounds.getNorth(),
+    right: bounds.getEast(),
+  };
+
+  const tiles = tilesInBbox(bbox, zoom);
+
+  // convert tile x axis to longitude
+  const tileToLong = (x: number, z: number) => {
+    return (x / Math.pow(2, z)) * 360 - 180;
+  };
+
+  // convert tile y axis to longitude
+  const tileToLat = (y: number, z: number) => {
+    const n = Math.PI - (2 * Math.PI * y) / Math.pow(2, z);
+
+    return (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+  };
+
+  return tiles.map(({ x, y, z }) => {
+    const SW_long = tileToLong(x, z);
+
+    const SW_lat = tileToLat(y + 1, z);
+
+    const NE_long = tileToLong(x + 1, z);
+
+    const NE_lat = tileToLat(y, z);
+
+    return {
+      key: `${x}:${y}:${z}`,
+      bbox: SW_long + ',' + NE_long + ',' + SW_lat + ',' + NE_lat,
+      point: { x, y, z },
+      datum: [],
+      latlngBounds: new LatLngBounds({ lat: SW_lat, lng: SW_long }, { lat: NE_lat, lng: NE_long }),
+    };
+  });
 };
+
+// default BC map bounds
+export const defaultBounds = new LatLngBounds(
+  [60.09114547, -119.49609429],
+  [48.78370426, -139.35937554],
+);
 
 /**
  * Displays the search results onto a layer with clustering.
@@ -69,9 +134,11 @@ export const InventoryLayer: React.FC<InventoryLayerProps> = ({
   onMarkerClick,
   selected,
 }) => {
-  const [features, setFeatures] = React.useState<Array<PointFeature>>([]);
   const { map } = useLeaflet();
+  const [features, setFeatures] = useState<PointFeature[]>([]);
+  const [loadingTiles, setLoadingTiles] = useState(false);
   const { loadProperties } = useApi();
+  const { changed: filterChanged } = useFilterContext();
   const draftProperties: PointFeature[] = useSelector<RootState, PointFeature[]>(
     state => state.parcel.draftParcels,
   );
@@ -80,14 +147,21 @@ export const InventoryLayer: React.FC<InventoryLayerProps> = ({
     throw new Error('<InventoryLayer /> must be used under a <Map> leaflet component');
   }
 
-  const bbox = getBbox(bounds);
+  const bbox = useMemo(() => getBbox(bounds), [bounds]);
+  useEffect(() => {
+    if (filterChanged) {
+      map.fitBounds(defaultBounds, { maxZoom: 5 });
+    }
+  }, [map, filterChanged]);
 
   minZoom = minZoom ?? 0;
   maxZoom = maxZoom ?? 18;
 
-  const params = useMemo<IGeoSearchParams>(
-    () => ({
-      bbox: getApiBbox(bounds ?? map.getBounds()).toString(),
+  const params = useMemo((): any => {
+    const tiles = getTiles(defaultBounds, 5);
+
+    return tiles.map(tile => ({
+      bbox: tile.bbox,
       address: filter?.address,
       administrativeArea: filter?.administrativeArea,
       pid: filter?.pid,
@@ -104,45 +178,57 @@ export const InventoryLayer: React.FC<InventoryLayerProps> = ({
       name: filter?.name,
       bareLandOnly: filter?.bareLandOnly,
       rentableArea: filter?.rentableArea,
-    }),
-    [filter, map, bounds],
-  );
+    }));
+  }, [filter]);
 
-  const search = React.useCallback(
-    _.debounce(
-      (filter: IGeoSearchParams) => {
-        loadProperties(filter)
-          .then(async (data: Feature[]) => {
-            const points = data
-              .filter(feature => {
-                return !(
-                  feature.properties!.propertyTypeId === selected?.propertyTypeId &&
-                  feature.properties!.id === selected?.parcelDetail?.id
-                );
-              })
-              .map(f => {
-                return {
-                  ...f,
-                } as PointFeature;
-              });
-            setFeatures(points);
-          })
-          .catch(error => {
-            toast.error((error as Error).message, { autoClose: 7000 });
-            console.error(error);
-          });
-      },
-      500,
-      { leading: true },
-    ),
-    [],
-  );
+  const loadTile = async (filter: IGeoSearchParams) => {
+    return loadProperties(filter);
+  };
+
+  const search = async (filters: IGeoSearchParams[]) => {
+    try {
+      const data = flatten(await Promise.all(filters.map(x => loadTile(x))))
+        .filter(feature => {
+          return !(
+            feature?.properties!.propertyTypeId === selected?.propertyTypeId &&
+            feature?.properties!.id === selected?.parcelDetail?.id
+          );
+        })
+        .map(f => {
+          return {
+            ...f,
+          } as PointFeature;
+        });
+
+      const items = uniqBy(
+        data,
+        point => `${point?.properties.id}-${point?.properties.propertyTypeId}`,
+      );
+
+      const hasBuildings = (property: any) => {
+        return items.find(
+          ({ properties }: any) =>
+            properties.propertyTypeId === 1 && properties.parcelId === property.parcelId,
+        );
+      };
+
+      setFeatures(
+        items.filter(({ properties }: any) => {
+          return properties.propertyTypeId === 1 || !hasBuildings(properties);
+        }) as any,
+      );
+      setLoadingTiles(false);
+    } catch (error) {
+      toast.error((error as Error).message, { autoClose: 7000 });
+      console.error(error);
+    }
+  };
 
   // Fetch the geoJSON collection of properties.
   useDeepCompareEffect(() => {
+    setLoadingTiles(true);
     search(params);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params, bbox, selected, map]);
+  }, [params]);
 
   return (
     <PointClusterer
@@ -154,6 +240,7 @@ export const InventoryLayer: React.FC<InventoryLayerProps> = ({
       zoomToBoundsOnClick={true}
       spiderfyOnMaxZoom={true}
       selected={selected}
+      tilesLoaded={!loadingTiles}
     />
   );
 };

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -334,7 +334,7 @@ const Map: React.FC<MapProps> = ({
                   onclick={showLocationDetails}
                   closePopupOnClick={interactive}
                   onzoomend={e => setZoom(e.sourceTarget.getZoom())}
-                  ondragend={handleBounds}
+                  onmoveend={handleBounds}
                 >
                   {activeBasemap && (
                     <TileLayer

--- a/frontend/src/components/maps/leaflet/PointClusterer.tsx
+++ b/frontend/src/components/maps/leaflet/PointClusterer.tsx
@@ -30,6 +30,7 @@ export type PointClustererProps = {
   /** When you click a cluster at the bottom zoom level we spiderfy it so you can see all of its markers. Default: true */
   spiderfyOnMaxZoom?: boolean;
   onMarkerClick?: (point: PointFeature, position?: [number, number]) => void;
+  tilesLoaded: boolean;
 };
 
 export const PointClusterer: React.FC<PointClustererProps> = ({
@@ -43,6 +44,7 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
   selected,
   zoomToBoundsOnClick = true,
   spiderfyOnMaxZoom = true,
+  tilesLoaded,
 }) => {
   // state and refs
   const spiderfierRef = useRef<Spiderfier>();
@@ -137,6 +139,7 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
         supercluster.getClusterExpansionZoom(cluster_id as number),
         maxZoom as number,
       );
+
       // already at maxZoom, need to spiderfy child markers
       if (expansionZoom === maxZoom && spiderfyOnMaxZoom) {
         const res = spiderfierRef.current.spiderfy(cluster);
@@ -176,13 +179,16 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
         groupBounds.isValid() &&
         group.getBounds().isValid() &&
         filterState.changed &&
-        !selected
+        !selected &&
+        tilesLoaded
       ) {
         filterState.setChanged(false);
         map.fitBounds(group.getBounds(), { maxZoom: 10 });
       }
+      setSpider({});
+      spiderfierRef.current?.unspiderfy();
     }
-  }, [featureGroupRef, map, clusters]);
+  }, [featureGroupRef, map, clusters, tilesLoaded]);
   return (
     <>
       <FeatureGroup ref={draftFeatureGroupRef}>

--- a/frontend/src/components/maps/leaflet/Spiderfier.ts
+++ b/frontend/src/components/maps/leaflet/Spiderfier.ts
@@ -72,6 +72,7 @@ export class Spiderfier {
     // only one cluster expanded at a time
     if (this.cluster === cluster || cluster == null) {
       this.cluster = null;
+      this.unspiderfy();
       return {};
     }
     this.unspiderfy();
@@ -109,20 +110,16 @@ export class Spiderfier {
     points: Array<PointFeature>,
     positions: Array<LeafletPoint>,
   ): { lines?: any[]; markers?: any[] } {
-    const { spiderLegPolylineOptions: legOptions, pointToLayer } = this.options;
+    const { spiderLegPolylineOptions: legOptions } = this.options;
     const centerLatLng = this.map.layerPointToLatLng(centerXY);
 
     let newPos: LatLng;
     let geojson: PointFeature;
-    let m: Marker & AnyProps; // the pins within an expanded cluster
     const markers: any[] = [];
     const lines: any[] = [];
     for (let i = 0; i < points.length; i++) {
       newPos = this.map.layerPointToLatLng(positions[i]);
       geojson = points[i];
-
-      m = pointToLayer(geojson, newPos) as Marker;
-      m.feature = GeoJSON.asFeature(geojson) as PointFeature;
       markers.push({ ...geojson, position: newPos });
       lines.push({ coords: [centerLatLng, newPos], options: legOptions });
     }

--- a/frontend/src/typings/tiles-in-bbox/index.d.ts
+++ b/frontend/src/typings/tiles-in-bbox/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'tiles-in-bbox' {
+  interface ITile {
+    x: number;
+    y: number;
+    z: number;
+  }
+
+  // get tiles in a bbox
+  export function tilesInBbox(bounds: any, zoom: number): ITile[];
+}


### PR DESCRIPTION
- Only make api request when filter is changed and use full bc map bounds to calculate tiles for the filter
- Using map onmoveend to track bbox used to calculate clusters in supercluster (fix bottom 10-15% data not showing and Victoria are data)
- Hide parcel pins that have buildings