### PR TITLE
Agency filter hotfix

### DIFF
--- a/frontend/src/components/common/form/Typeahead.tsx
+++ b/frontend/src/components/common/form/Typeahead.tsx
@@ -70,7 +70,7 @@ export function TypeaheadField<T extends TypeaheadModel>({
     setFieldTouched(name, true);
     if (
       (!getIn(name, 'value') && val !== '' && getIn(values, name) === '') ||
-      getIn(values, name) === null
+      (!getIn(values, name) && getIn(values, name) !== '')
     ) {
       const regex = new RegExp(val, 'i');
       const exact = new RegExp(`^${val}$`, 'i');

--- a/frontend/src/features/properties/filter/PropertyFilter.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilter.tsx
@@ -99,7 +99,9 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
   }, [agencies, propertyFilter, defaultFilter]);
 
   const changeFilter = (values: IPropertyFilter) => {
-    const agencyIds = values.agencies;
+    const agencyIds = (values.agencies as any).value
+      ? (values.agencies as any).value
+      : values.agencies;
     setPropertyFilter({ ...values, agencies: agencyIds });
     onChange?.({ ...values, agencies: agencyIds });
   };
@@ -155,7 +157,7 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
                 }}
                 ref={ref}
                 onBlur={(e: any) =>
-                  getIn(values, 'name') === '' && setFieldValue('name', e.target.value)
+                  getIn(values, 'name') !== e.target.value && setFieldValue('name', e.target.value)
                 }
               />
             </Col>


### PR DESCRIPTION
Fix that ensures the `agency.value` is being sent on subsequent requests with the filter, ensure that name is changed on subsequent requests when the value is not equal to the existing formik value, account for various other scenarios where subsequent requests were previously causing bugs 


