### PR TITLE
PA-1969 Reconfigure Disposal Projects notes fields

### DIFF
--- a/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
+++ b/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
@@ -734,7 +734,7 @@ exports[`Review Approve Step renders correctly 1`] = `
           class="form-label"
           for="input-documentationNote"
         >
-          Note
+          Documentation Notes
         </label>
         <textarea
           class="col-md-auto form-control"
@@ -808,7 +808,7 @@ exports[`Review Approve Step renders correctly 1`] = `
               class="form-label"
               for="input-appraisedNote"
             >
-              Note
+              Appraisal Notes
             </label>
             <textarea
               class="col-md-auto form-control"

--- a/frontend/src/features/projects/common/forms/AppraisalCheckListForm.tsx
+++ b/frontend/src/features/projects/common/forms/AppraisalCheckListForm.tsx
@@ -33,7 +33,7 @@ const AppraisalCheckListForm: React.FunctionComponent<IAppraisalCheckListFormPro
           className="col-md-auto"
           outerClassName="col-md-12 reviewRequired"
           field="appraisedNote"
-          label="Note"
+          label="Appraisal Notes"
         />
       </Col>
     </Row>

--- a/frontend/src/features/projects/common/forms/DocumentationForm.tsx
+++ b/frontend/src/features/projects/common/forms/DocumentationForm.tsx
@@ -17,7 +17,13 @@ const DocumentationForm = ({ isReadOnly, tasks, showNote = false }: IDocumentati
     <Fragment>
       <h3>Documentation</h3>
       <TasksForm tasks={tasks ?? []} isReadOnly={isReadOnly} />
-      {showNote && <ProjectNotes label="Note" field="documentationNote" className="col-md-auto" />}
+      {showNote && (
+        <ProjectNotes
+          label="Documentation Notes"
+          field="documentationNote"
+          className="col-md-auto"
+        />
+      )}
     </Fragment>
   );
 };

--- a/frontend/src/features/projects/common/strings.ts
+++ b/frontend/src/features/projects/common/strings.ts
@@ -43,6 +43,8 @@ export const disposeWarning = `Are you sure you want to dispose this project? Th
 export const offersReceived = `Review required for offer(s) in Tier 3 & 4.`;
 export const dateEnteredMarket = 'Date Entered Market required to change status to Marketing.';
 export const projectComments = `Please provide any variances between appraised, assessed, and sale price.`;
+export const ocgVarianceNote =
+  'Please provide an explanation for the difference between the Financial Summary amount and the OCG Gain/Loss amount (if any)';
 export const appraisalDateWarning =
   'You have entered an appraisal date that is older then the current appraisal date stored in PIMS. Are you sure that you would like to update PIMS to use this older date?';
 export const tabErrorWarning =

--- a/frontend/src/features/projects/common/tabs/ProjectInformationTab.tsx
+++ b/frontend/src/features/projects/common/tabs/ProjectInformationTab.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Container } from 'react-bootstrap';
 import {
   ProjectNotes,
-  PublicNotes,
   PrivateNotes,
   ProjectDraftForm,
   UpdateInfoForm,
@@ -32,7 +31,6 @@ const ProjectInformationTab: React.FunctionComponent<IProjectInformationTabProps
 
       <h3>Notes</h3>
       <ProjectNotes className="col-md-auto" disabled={true} label="Agency Notes" />
-      <PublicNotes className="col-md-auto" disabled={isReadOnly} />
       <PrivateNotes className="col-md-auto" disabled={isReadOnly} />
       <ProjectNotes
         label="Reporting"

--- a/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
@@ -759,9 +759,6 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
               </div>
             </div>
           </div>
-          <h3>
-            Financing Information
-          </h3>
           <div
             class="form-row"
           >
@@ -772,86 +769,7 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                 class="ProjectNotes form-row"
               >
                 <div
-                  class="col form-group col"
-                >
-                  <label
-                    class="form-label"
-                    for="input-loanTermsNote"
-                  >
-                    Loan Terms
-                  </label>
-                  <textarea
-                    class="col-md-10 form-control"
-                    id="input-loanTermsNote"
-                    name="loanTermsNote"
-                  />
-                </div>
-              </div>
-            </div>
-            <div
-              class="col-md-1"
-            />
-            <div
-              class="col"
-            >
-              <div
-                class="ProjectNotes form-row"
-              >
-                <div
-                  class="col form-group col"
-                >
-                  <label
-                    class="form-label"
-                    for="input-closeOutNote"
-                  >
-                    Close Out
-                  </label>
-                  <textarea
-                    class="col-md-10 form-control"
-                    id="input-closeOutNote"
-                    name="closeOutNote"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="form-row"
-          >
-            <div
-              class="col"
-            >
-              <div
-                class="ProjectNotes form-row"
-              >
-                <div
-                  class="col form-group col"
-                >
-                  <label
-                    class="form-label"
-                    for="input-salesHistoryNote"
-                  >
-                    Sales History Notes
-                  </label>
-                  <textarea
-                    class="col-md-10 form-control"
-                    id="input-salesHistoryNote"
-                    name="salesHistoryNote"
-                  />
-                </div>
-              </div>
-            </div>
-            <div
-              class="col-md-1"
-            />
-            <div
-              class="col"
-            >
-              <div
-                class="ProjectNotes form-row"
-              >
-                <div
-                  class="col form-group col"
+                  class="col-md-11 form-group col"
                 >
                   <label
                     class="form-label"
@@ -874,9 +792,39 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
                     </svg>
                   </label>
                   <textarea
-                    class="col-md-10 form-control"
+                    class="col-md-auto form-control"
                     id="input-comments"
                     name="comments"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <h3>
+            Financing Information
+          </h3>
+          <div
+            class="form-row"
+          >
+            <div
+              class="col"
+            >
+              <div
+                class="ProjectNotes form-row"
+              >
+                <div
+                  class="col-md-11 form-group col"
+                >
+                  <label
+                    class="form-label"
+                    for="input-closeOutNote"
+                  >
+                    Close Out
+                  </label>
+                  <textarea
+                    class="col-md-auto form-control"
+                    id="input-closeOutNote"
+                    name="closeOutNote"
                   />
                 </div>
               </div>
@@ -886,25 +834,66 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
             OCG
           </h3>
           <div
-            class="col-md-12 form-row"
+            class="form-row"
           >
-            <label
-              class="form-label col-form-label col-md-2"
-            >
-              OCG Gain / Loss
-            </label>
             <div
-              class="col-md-4 form-group col"
+              class="col"
             >
               <div
-                class="input-tooltip-wrapper"
+                class="form-row"
               >
-                <input
-                  class="form-control input-number"
-                  name="ocgFinancialStatement"
-                  placeholder=""
-                  value=""
-                />
+                <label
+                  class="form-label col-form-label col-md-2"
+                >
+                  OCG Gain / Loss
+                </label>
+                <div
+                  class="col-md-4 form-group col"
+                >
+                  <div
+                    class="input-tooltip-wrapper"
+                  >
+                    <input
+                      class="form-control input-number"
+                      name="ocgFinancialStatement"
+                      placeholder=""
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ProjectNotes form-row"
+              >
+                <div
+                  class="col-md-11 form-group col"
+                >
+                  <label
+                    class="form-label"
+                    for="input-salesHistoryNote"
+                  >
+                    OCG Variance Notes
+                    <svg
+                      class="tooltip-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                      />
+                    </svg>
+                  </label>
+                  <textarea
+                    class="col-md-auto form-control"
+                    id="input-salesHistoryNote"
+                    name="salesHistoryNote"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/features/projects/spl/forms/CloseOutFinancialSummaryForm.tsx
+++ b/frontend/src/features/projects/spl/forms/CloseOutFinancialSummaryForm.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Col } from 'react-bootstrap';
 import { getIn, useFormikContext } from 'formik';
 import { Form, FastCurrencyInput } from 'components/common/form';
-import { IProject, ProjectNotes } from 'features/projects/common';
+import { IProject, projectComments, ProjectNotes } from 'features/projects/common';
 
 interface CloseOutFinancialSummaryFormProps {
   /** Whether the form inputs will be readonly. */
@@ -161,6 +161,18 @@ const CloseOutFinancialSummaryForm = (props: CloseOutFinancialSummaryFormProps) 
             disabled={props.isReadOnly}
             outerClassName="col"
             className="col-md-10"
+          />
+        </Col>
+      </Form.Row>
+      <Form.Row>
+        <Col>
+          <ProjectNotes
+            field="comments"
+            label="Project Comments"
+            outerClassName="col-md-11"
+            className="col-md-auto"
+            tooltip={projectComments}
+            disabled={props.isReadOnly}
           />
         </Col>
       </Form.Row>

--- a/frontend/src/features/projects/spl/forms/CloseOutFinancialsForm.tsx
+++ b/frontend/src/features/projects/spl/forms/CloseOutFinancialsForm.tsx
@@ -15,22 +15,11 @@ const CloseOutFinancialsForm = (props: CloseOutFinancialsFormProps) => {
       <Form.Row>
         <Col>
           <ProjectNotes
-            data-testid="loanTermsNote"
-            field="loanTermsNote"
-            label="Loan Terms"
-            className="col-md-10"
-            outerClassName="col"
-            disabled={props.isReadOnly}
-          />
-        </Col>
-        <Col md={1}></Col>
-        <Col>
-          <ProjectNotes
             data-testid="closeOutNote"
             field="closeOutNote"
             label="Close Out"
-            className="col-md-10"
-            outerClassName="col"
+            outerClassName="col-md-11"
+            className="col-md-auto"
             disabled={props.isReadOnly}
           />
         </Col>

--- a/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.tsx
+++ b/frontend/src/features/projects/spl/forms/SurplusPropertyListForm.tsx
@@ -65,7 +65,6 @@ const SurplusPropertyListForm = ({
   onClickContractInPlaceUnconditional,
   onClickDisposedExternally,
 }: ISurplusPropertyListFormProps) => {
-  debugger;
   const formikProps = useFormikContext<IProject>();
   const [dispose, setDispose] = useState(false);
   const cipConditionalTasks = _.filter(formikProps.values.tasks, {

--- a/frontend/src/features/projects/spl/steps/SplStep.test.tsx
+++ b/frontend/src/features/projects/spl/steps/SplStep.test.tsx
@@ -362,10 +362,9 @@ describe('SPL Approval Step', () => {
 
     it('displays close out notes', () => {
       const { getByText } = render(getSplStep(store));
-      expect(getByText('Loan Terms')).toBeVisible();
       expect(getByText('Adjustment to Prior Year Sale Notes')).toBeVisible();
       expect(getByText('Project Comments')).toBeVisible();
-      expect(getByText('Sales History Notes')).toBeVisible();
+      expect(getByText('OCG Variance Notes')).toBeVisible();
     });
   });
 });

--- a/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
+++ b/frontend/src/features/projects/spl/steps/__snapshots__/SplStep.test.tsx.snap
@@ -771,9 +771,6 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
               </div>
             </div>
           </div>
-          <h3>
-            Financing Information
-          </h3>
           <div
             class="form-row"
           >
@@ -784,86 +781,7 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                 class="ProjectNotes form-row"
               >
                 <div
-                  class="col form-group col"
-                >
-                  <label
-                    class="form-label"
-                    for="input-loanTermsNote"
-                  >
-                    Loan Terms
-                  </label>
-                  <textarea
-                    class="col-md-10 form-control"
-                    id="input-loanTermsNote"
-                    name="loanTermsNote"
-                  />
-                </div>
-              </div>
-            </div>
-            <div
-              class="col-md-1"
-            />
-            <div
-              class="col"
-            >
-              <div
-                class="ProjectNotes form-row"
-              >
-                <div
-                  class="col form-group col"
-                >
-                  <label
-                    class="form-label"
-                    for="input-closeOutNote"
-                  >
-                    Close Out
-                  </label>
-                  <textarea
-                    class="col-md-10 form-control"
-                    id="input-closeOutNote"
-                    name="closeOutNote"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="form-row"
-          >
-            <div
-              class="col"
-            >
-              <div
-                class="ProjectNotes form-row"
-              >
-                <div
-                  class="col form-group col"
-                >
-                  <label
-                    class="form-label"
-                    for="input-salesHistoryNote"
-                  >
-                    Sales History Notes
-                  </label>
-                  <textarea
-                    class="col-md-10 form-control"
-                    id="input-salesHistoryNote"
-                    name="salesHistoryNote"
-                  />
-                </div>
-              </div>
-            </div>
-            <div
-              class="col-md-1"
-            />
-            <div
-              class="col"
-            >
-              <div
-                class="ProjectNotes form-row"
-              >
-                <div
-                  class="col form-group col"
+                  class="col-md-11 form-group col"
                 >
                   <label
                     class="form-label"
@@ -886,9 +804,39 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
                     </svg>
                   </label>
                   <textarea
-                    class="col-md-10 form-control"
+                    class="col-md-auto form-control"
                     id="input-comments"
                     name="comments"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <h3>
+            Financing Information
+          </h3>
+          <div
+            class="form-row"
+          >
+            <div
+              class="col"
+            >
+              <div
+                class="ProjectNotes form-row"
+              >
+                <div
+                  class="col-md-11 form-group col"
+                >
+                  <label
+                    class="form-label"
+                    for="input-closeOutNote"
+                  >
+                    Close Out
+                  </label>
+                  <textarea
+                    class="col-md-auto form-control"
+                    id="input-closeOutNote"
+                    name="closeOutNote"
                   />
                 </div>
               </div>
@@ -898,25 +846,66 @@ exports[`SPL Approval Step close out form tab renders correctly 1`] = `
             OCG
           </h3>
           <div
-            class="col-md-12 form-row"
+            class="form-row"
           >
-            <label
-              class="form-label col-form-label col-md-2"
-            >
-              OCG Gain / Loss
-            </label>
             <div
-              class="col-md-4 form-group col"
+              class="col"
             >
               <div
-                class="input-tooltip-wrapper"
+                class="form-row"
               >
-                <input
-                  class="form-control input-number"
-                  name="ocgFinancialStatement"
-                  placeholder=""
-                  value=""
-                />
+                <label
+                  class="form-label col-form-label col-md-2"
+                >
+                  OCG Gain / Loss
+                </label>
+                <div
+                  class="col-md-4 form-group col"
+                >
+                  <div
+                    class="input-tooltip-wrapper"
+                  >
+                    <input
+                      class="form-control input-number"
+                      name="ocgFinancialStatement"
+                      placeholder=""
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ProjectNotes form-row"
+              >
+                <div
+                  class="col-md-11 form-group col"
+                >
+                  <label
+                    class="form-label"
+                    for="input-salesHistoryNote"
+                  >
+                    OCG Variance Notes
+                    <svg
+                      class="tooltip-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                      />
+                    </svg>
+                  </label>
+                  <textarea
+                    class="col-md-auto form-control"
+                    id="input-salesHistoryNote"
+                    name="salesHistoryNote"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/features/projects/spl/tabs/CloseOutFormTab.tsx
+++ b/frontend/src/features/projects/spl/tabs/CloseOutFormTab.tsx
@@ -8,7 +8,7 @@ import {
   CloseOutSignaturesForm,
   CloseOutAdjustmentForm,
 } from '..';
-import { ProjectNotes, projectComments, IProject } from 'features/projects/common';
+import { ProjectNotes, IProject, ocgVarianceNote } from 'features/projects/common';
 import { Col, Container, Form } from 'react-bootstrap';
 import './CloseOutFormTab.scss';
 import { FastCurrencyInput } from 'components/common/form';
@@ -33,39 +33,29 @@ const CloseOutFormTab: React.FunctionComponent<ICloseOutFormTabProps> = ({
       <CloseOutSaleInformationForm isReadOnly={isReadOnly} />
       <CloseOutFinancialSummaryForm isReadOnly={isReadOnly} />
       <CloseOutFinancialsForm isReadOnly={isReadOnly} />
+      <h3>OCG</h3>
       <Form.Row>
         <Col>
+          <Form.Row>
+            <Form.Label column md={2}>
+              OCG Gain / Loss
+            </Form.Label>
+            <FastCurrencyInput
+              formikProps={formikProps}
+              disabled={isReadOnly}
+              outerClassName="col-md-4"
+              field="ocgFinancialStatement"
+            />
+          </Form.Row>
           <ProjectNotes
             field="salesHistoryNote"
-            label="Sales History Notes"
-            className="col-md-10"
-            outerClassName="col"
+            label="OCG Variance Notes"
+            outerClassName="col-md-11"
+            className="col-md-auto"
             disabled={isReadOnly}
+            tooltip={ocgVarianceNote}
           />
         </Col>
-        <Col md={1}></Col>
-        <Col>
-          <ProjectNotes
-            field="comments"
-            label="Project Comments"
-            className="col-md-10"
-            outerClassName="col"
-            tooltip={projectComments}
-            disabled={isReadOnly}
-          />
-        </Col>
-      </Form.Row>
-      <h3>OCG</h3>
-      <Form.Row className="col-md-12">
-        <Form.Label column md={2}>
-          OCG Gain / Loss
-        </Form.Label>
-        <FastCurrencyInput
-          formikProps={formikProps}
-          disabled={isReadOnly}
-          outerClassName="col-md-4"
-          field="ocgFinancialStatement"
-        />
       </Form.Row>
       <CloseOutSignaturesForm isReadOnly={isReadOnly} />
       <CloseOutAdjustmentForm isReadOnly={isReadOnly} />

--- a/frontend/src/features/projects/spl/tabs/SurplusPropertyInformationTab.tsx
+++ b/frontend/src/features/projects/spl/tabs/SurplusPropertyInformationTab.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Container } from 'react-bootstrap';
 import {
-  PublicNotes,
   PrivateNotes,
   ProjectNotes,
   ProjectDraftForm,
@@ -32,7 +31,6 @@ const SurplusPropertyInformationTab: React.FunctionComponent<ISurplusPropertyInf
 
       <h3>Notes</h3>
       <ProjectNotes className="col-md-auto" disabled={true} label="Agency Notes" />
-      <PublicNotes className="col-md-auto" disabled={isReadOnly} />
       <PrivateNotes className="col-md-auto" disabled={isReadOnly} />
       <ProjectNotes
         label="Reporting"


### PR DESCRIPTION
- Remove "Loan Terms" 
- Rename "Sales History Notes" to "OCG Variance Notes", move to OCG section, add tooltip
- Move "Project Comments" to Financial Summary section
- rename "Appraisal Notes"
- Remove "Shared Notes"
![image](https://user-images.githubusercontent.com/33818575/105110610-cd7a1100-5a73-11eb-8f5b-0eae8904f515.png)
