### PR TITLE
PA-2491: Add Surplus Active back

### DIFF
--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.tsx
@@ -91,12 +91,9 @@ export const ClassificationForm: React.FC<IClassificationFormProps> = ({
   let classId = getIn(formikProps.values, field);
 
   let filteredClassifications = classifications;
-  /** users not allowed to select disposed or surplus active at this stage, but display these values if one of these classifications has already been selected. */
+  /** users not allowed to select disposed, but display these values if one of these classifications has already been selected. */
   filteredClassifications = classifications.filter(
-    c =>
-      (Number(c.value) !== Classifications.SurplusActive &&
-        Number(c.value) !== Classifications.Disposed) ||
-      +c.value === +classId,
+    c => Number(c.value) !== Classifications.Disposed || +c.value === +classId,
   );
 
   const renderInfo = () => {


### PR DESCRIPTION
Picking some low hanging fruit while I'm figuring out the others..

- add `Surplus Active` back as an option on the `Classification Form`

![image](https://user-images.githubusercontent.com/15724124/105403539-b9eab980-5bdd-11eb-9ff5-6593843ff8ae.png)
