### PR TITLE
Fixed v01.06.01 DB Migration

### DIFF
--- a/backend/dal/Migrations/v01.06.01/Down/PreDown/RemoveRolesAndClaims.sql
+++ b/backend/dal/Migrations/v01.06.01/Down/PreDown/RemoveRolesAndClaims.sql
@@ -1,3 +1,4 @@
-DELETE FROM dbo.[RoleClaims] where RoleId IN ('6238c23d-933e-4c4a-954e-48bae3ce2080', '5C6CEA5B-9B7C-47E8-852C-693E90ED815E', '090bc341-af0f-45c9-8e0a-6d99024b52c1');
-DELETE FROM dbo.[Roles] where Id = '5C6CEA5B-9B7C-47E8-852C-693E90ED815E';
-DELETE FROM dbo.[Claims] where Id = '81DED21C-ED32-4694-8F33-79EF17833F2B';
+DELETE FROM dbo.[RoleClaims] where RoleId = '5c6cea5b-9b7c-47e8-852c-693e90ed815e';
+DELETE FROM dbo.[RoleClaims] where ClaimId = '81ded21c-ed32-4694-8f33-79ef17833f2b';
+DELETE FROM dbo.[Roles] where Id = '5c6cea5b-9b7c-47e8-852c-693e90ed815e';
+DELETE FROM dbo.[Claims] where Id = '81ded21c-ed32-4694-8f33-79ef17833f2b';

--- a/backend/dal/Migrations/v01.06.01/Up/PostUp/AddRoleAndClaims.sql
+++ b/backend/dal/Migrations/v01.06.01/Up/PostUp/AddRoleAndClaims.sql
@@ -13,29 +13,31 @@ INSERT INTO
     )
 VALUES
     (
-        '5C6CEA5B-9B7C-47E8-852C-693E90ED815E',
+        '5c6cea5b-9b7c-47e8-852c-693e90ed815e',
         'SRES Financial Reporter',
         'The SRES Financial Reporter can view, create, and delete non-final SPL reports.',
         0,
         0,
         0,
-        '5C6CEA5B-9B7C-47E8-852C-693E90ED815E'
+        '5c6cea5b-9b7c-47e8-852c-693e90ed815e'
     );
 
-PRINT 'Adding Claim' 
+PRINT 'Adding Claim'
+
 --Adding new claim for the SRES Financial Manager
 INSERT INTO
     dbo.[Claims] ([Id], [Name], [Description], [IsDisabled], [KeycloakRoleId])
 VALUES
 (
-    '81DED21C-ED32-4694-8F33-79EF17833F2B',
+    '81ded21c-ed32-4694-8f33-79ef17833f2b',
     'reports-spl-admin',
     'Ability to view, create, and delete Final reports.',
     0,
-    '81DED21C-ED32-4694-8F33-79EF17833F2B' 
+    '81ded21c-ed32-4694-8f33-79ef17833f2b'
 );
 
 PRINT 'Adding RoleClaims'
+
 --Adding mapping for the new reports-spl-admin claim to the SRES Financial Manager
 INSERT INTO dbo.[RoleClaims]
     (
@@ -44,14 +46,14 @@ INSERT INTO dbo.[RoleClaims]
     )
 VALUES
 (
-    '6238c23d-933e-4c4a-954e-48bae3ce2080'     -- SRES Financial Manager
-    , '81DED21C-ED32-4694-8F33-79EF17833F2B'   -- reports-spl-admin
+    'd416f362-1e6f-4e24-a561-c6bb45a35194'     -- SRES Financial Manager
+    , '81ded21c-ed32-4694-8f33-79ef17833f2b'   -- reports-spl-admin
 ),
 (
-    '5C6CEA5B-9B7C-47E8-852C-693E90ED815E'     -- SRES Financial Reporter
-    , '0FBD370D-6CDE-41E7-9039-F05AE60D75DA'   -- reports-spl
+    '5c6cea5b-9b7c-47e8-852c-693e90ed815e'     -- SRES Financial Reporter
+    , '0fbd370d-6cde-41e7-9039-f05ae60d75da'   -- reports-spl
 ),
 (
-    '090bc341-af0f-45c9-8e0a-6d99024b52c1'     -- SRES Financial Reporter
-    , 'E13D1C7D-F350-4AEE-808E-C9603C29479B'   -- reports-view
+    '5c6cea5b-9b7c-47e8-852c-693e90ed815e'     -- SRES Financial Reporter
+    , 'e13d1c7d-f350-4aee-808e-c9603c29479b'   -- reports-view
 );


### PR DESCRIPTION
The DB Migration v01.06.01 scripts were invalid.  I have updated them to resolve the issue.

You may not need to refresh your DB, or perhaps you may.