### PR TITLE
PA-2463: Default to SA and ability to select all

### DIFF
--- a/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.scss
+++ b/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.scss
@@ -2,7 +2,12 @@
 .SelectProjectProperties {
   display: flex;
   flex-direction: column;
-
+  .small-filter {
+    .btn-link:focus,
+    .btn-link:active {
+      background: none !important;
+    }
+  }
   .PropertyListViewSelect {
     margin-bottom: 3rem;
     padding: 0;
@@ -10,47 +15,38 @@
       margin-bottom: 0.5rem;
     }
   }
-
   .no-rows-message {
     font-size: 14px;
   }
-
   .filter-container {
     padding: 0;
-
     .map-filter-bar {
       align-items: center;
       padding: 1rem 0;
-
       .bar-item {
         .form-group {
           padding: 0;
           margin: 0;
         }
       }
-
       .btn-warning {
         color: white;
         font-weight: bold;
       }
-
       .form-control {
         border-radius: 0;
       }
     }
   }
-
   .TableToolbar {
     display: flex;
     flex-direction: row;
     align-items: flex-end;
     padding: 0.5rem 0;
   }
-
   .ScrollContainer {
     padding: 1rem 0;
     overflow-x: auto;
-
     table {
       background-color: #fff;
     }
@@ -58,11 +54,9 @@
       background-color: $accent-color;
     }
   }
-
   .DisposeForm {
     padding: 1rem 3rem;
   }
-
   .invalid-feedback {
     text-align: right;
   }

--- a/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.tsx
@@ -1,8 +1,8 @@
 import './SelectProjectPropertiesStep.scss';
 
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useCallback, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Container } from 'react-bootstrap';
+import { Button, Container } from 'react-bootstrap';
 import { RootState } from 'reducers/rootReducer';
 import { Formik } from 'formik';
 import { useStepper, SelectProjectPropertiesStepYupSchema } from '..';
@@ -18,7 +18,14 @@ import { ILookupCodeState } from 'reducers/lookupCodeReducer';
 import * as API from 'constants/API';
 import _ from 'lodash';
 import useCodeLookups from 'hooks/useLookupCodes';
+import styled from 'styled-components';
+import { Classifications } from 'constants/classifications';
 
+/** contains the link text for Show Surplus and Show All classification filter */
+const LinkButton = styled(Button)`
+  margin-left: 0.5rem;
+  margin-bottom: 0.2rem;
+`;
 /**
  * Form to display two property list views, one for searching/selecting and one to show
  * the current list of properties associated to the project.
@@ -33,10 +40,19 @@ const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
     administrativeArea: '',
     projectNumber: '',
     agencies: '',
-    classificationId: '',
+    classificationId: Classifications.SurplusActive.toString(),
     minLotSize: '',
     maxLotSize: '',
   });
+  const [selected, setSelected] = useState({ option: '', selected: false });
+
+  useEffect(() => {
+    if (filter.classificationId === Classifications.SurplusActive.toString()) {
+      setSelected({ option: 'Surplus Only', selected: true });
+    } else {
+      setSelected({ option: 'All', selected: true });
+    }
+  }, [filter]);
   const [pageIndex, setPageIndex] = useState(0);
   const { onSubmit, canUserEditForm } = useStepForm();
   const { project } = useStepper();
@@ -68,19 +84,66 @@ const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
     [setFilter, setPageIndex],
   );
 
+  // Update filter to only show Surplus Active when clicked
+  const handleShowSurplusClick = () => {
+    setFilter({ ...filter, classificationId: Classifications.SurplusActive.toString() });
+    console.log(filter);
+  };
+
+  // Update filter to clear the classificationId when clicked
+  const handleShowAllClick = () => {
+    setFilter({
+      ...filter,
+      classificationId:
+        filter.classificationId &&
+        filter.classificationId !== Classifications.SurplusActive.toString()
+          ? filter.classificationId
+          : '',
+    });
+  };
+
+  // Check which option is seleceted for the smaller filter to keep track of which to shade the darker blue
+  const checkSelected = (option: string) => {
+    if (selected.option === option && selected.selected) {
+      return true;
+    }
+  };
+
   return isReadOnly ? null : (
     <Container fluid className="SelectProjectProperties">
       <h3 className="mr-auto">Search and select 1 or more properties for the project</h3>
       {!isReadOnly && (
-        <Container fluid className="filter-container border-bottom">
-          <Container className="px-0">
-            <FilterBar
-              agencyLookupCodes={filteredAgencies}
-              propertyClassifications={propertyClassifications}
-              onChange={handleFilterChange}
-            />
+        <>
+          <Container fluid className="filter-container border-bottom">
+            <Container className="px-0">
+              <FilterBar
+                agencyLookupCodes={filteredAgencies}
+                propertyClassifications={propertyClassifications}
+                onChange={handleFilterChange}
+              />
+            </Container>
           </Container>
-        </Container>
+          <div className="small-filter">
+            <p style={{ float: 'right' }}>
+              Show{' '}
+              <LinkButton
+                onClick={handleShowSurplusClick}
+                variant="link"
+                style={checkSelected('Surplus Only') && { color: '#1a5a96' }}
+              >
+                Surplus Only
+              </LinkButton>{' '}
+              |{' '}
+              <LinkButton
+                style={checkSelected('All') && { color: '#1a5a96' }}
+                onClick={handleShowAllClick}
+                variant="link"
+              >
+                All
+              </LinkButton>
+            </p>
+          </div>
+        </>
       )}
       <Formik
         initialValues={project}

--- a/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.tsx
@@ -131,7 +131,7 @@ const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
                 variant="link"
                 style={checkSelected('Surplus Only') && { color: '#1a5a96' }}
               >
-                Surplus Only
+                Surplus Active
               </LinkButton>{' '}
               |{' '}
               <LinkButton

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
@@ -1,6 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
+.c0 {
+  margin-left: 0.5rem;
+  margin-bottom: 0.2rem;
+}
+
 <div
   className="SelectProjectProperties container-fluid"
 >
@@ -193,6 +198,39 @@ exports[`renders correctly 1`] = `
         </div>
       </form>
     </div>
+  </div>
+  <div
+    className="small-filter"
+  >
+    <p
+      style={
+        Object {
+          "float": "right",
+        }
+      }
+    >
+      Show
+       
+      <button
+        className="c0 btn btn-link"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Surplus Only
+      </button>
+       
+      |
+       
+      <button
+        className="c0 btn btn-link"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        All
+      </button>
+    </p>
   </div>
   <form
     className=""

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
@@ -217,7 +217,7 @@ exports[`renders correctly 1`] = `
         onClick={[Function]}
         type="button"
       >
-        Surplus Only
+        Surplus Active
       </button>
        
       |


### PR DESCRIPTION
Default to Surplus Active in the Select Properties step when creating a Disposal Project with ability to select all. 

Worked through this ticket and matched up to the acceptance criteria, just wondering if it may be a little confusing having an additional classification filter below? They both work together but just had that thought when I was testing it myself. [Link to story](https://pimsteam.atlassian.net/browse/PA-2463?atlOrigin=eyJpIjoiY2FmMTZhYzFhNDFhNDgxZmIwZGJlMjIzZTg5YmRmNTYiLCJwIjoiaiJ9) 

![defaulttosa](https://user-images.githubusercontent.com/15724124/106320204-630d6180-6227-11eb-844f-bb9e75797bf3.gif)

