### PR TITLE
Allow SRES to change on behalf of another agency

### DIFF
--- a/backend/dal/Services/Concrete/BuildingService.cs
+++ b/backend/dal/Services/Concrete/BuildingService.cs
@@ -163,9 +163,13 @@ namespace Pims.Dal.Services
 
             // A building should have a unique name within the parcel it is located on.
             building.Parcels.ForEach(pb => this.Context.ThrowIfNotUnique(pb.Parcel, building));
+            // SRES users allowed to overwrite
+            if (!this.User.HasPermission(Permissions.AdminProperties))
+            {
+                building.AgencyId = agency.Id;
+                building.Agency = agency;
+            }
 
-            building.AgencyId = agency.Id;
-            building.Agency = agency;
             building.Address.Province = this.Context.Provinces.Find(building.Address.ProvinceId);
             building.Classification = this.Context.PropertyClassifications.Find(building.ClassificationId);
             building.IsVisibleToOtherAgencies = false;

--- a/backend/dal/Services/Concrete/ParcelService.cs
+++ b/backend/dal/Services/Concrete/ParcelService.cs
@@ -182,9 +182,12 @@ namespace Pims.Dal.Services
                 throw new NotAuthorizedException("User must belong to an agency before adding parcels.");
 
             this.Context.Parcels.ThrowIfNotUnique(parcel);
-
-            parcel.AgencyId = agency.Id;
-            parcel.Agency = agency;
+            // SRES users allowed to overwrite
+            if(!this.User.HasPermission(Permissions.AdminProperties))
+            {
+                parcel.AgencyId = agency.Id;
+                parcel.Agency = agency;
+            }
             parcel.Address.Province = this.Context.Provinces.Find(parcel.Address.ProvinceId);
             parcel.Classification = this.Context.PropertyClassifications.Find(parcel.ClassificationId);
             parcel.IsVisibleToOtherAgencies = false;

--- a/frontend/src/features/mapSideBar/SidebarContents/LandForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/LandForm.tsx
@@ -314,8 +314,9 @@ const LandForm: React.FC<IParentLandForm> = (props: IParentLandForm) => {
     data: { ...getInitialValues(), ...props.initialValues },
   };
   const isViewOrUpdate = !!initialValues?.data?.id;
-
-  initialValues.data.agencyId = keycloak.agencyId ?? '';
+  initialValues.data.agencyId = initialValues.data.agencyId
+    ? initialValues.data.agencyId
+    : keycloak.agencyId;
 
   /**
    * Combines yup validation with manual validation of financial data for performance reasons.


### PR DESCRIPTION
Allow SRES users to update/add a property on behalf of another agency. Previously it was overriding the frontend with the user's agency. It now checks to see if they are an admin in ParcelService and BuildingService before locking it to the user's agency. Also initial values were previously overwriting the agency value to the keycloak value so that is now changed as well.

I found some existing bugs throughout this process that I will log and attempt to fix outside of this ticket:
- Agency dropdown for land only contains parents 
- Slide out does not always instantly populate the Owning Agency but will appear after clicking away and back 