### PR TITLE
PA-2640 Fixed Delete Property

### DIFF
--- a/backend/dal/Services/Concrete/BuildingService.cs
+++ b/backend/dal/Services/Concrete/BuildingService.cs
@@ -375,7 +375,7 @@ namespace Pims.Dal.Services
         /// <returns></returns>
         public void Remove(Building building)
         {
-            building.ThrowIfNotAllowedToEdit(nameof(building), this.User, new[] { Permissions.PropertyEdit, Permissions.AdminProperties });
+            building.ThrowIfNotAllowedToEdit(nameof(building), this.User, new[] { Permissions.PropertyDelete, Permissions.AdminProperties });
             var isAdmin = this.User.HasPermission(Permissions.AdminProperties);
 
             var existingBuilding = this.Context.Buildings.Include(b => b.Evaluations).Include(b => b.Fiscals).Include(b => b.Parcels).FirstOrDefault(b => b.Id == building.Id) ?? throw new KeyNotFoundException();

--- a/backend/dal/Services/Concrete/ParcelService.cs
+++ b/backend/dal/Services/Concrete/ParcelService.cs
@@ -183,7 +183,7 @@ namespace Pims.Dal.Services
 
             this.Context.Parcels.ThrowIfNotUnique(parcel);
             // SRES users allowed to overwrite
-            if(!this.User.HasPermission(Permissions.AdminProperties))
+            if (!this.User.HasPermission(Permissions.AdminProperties))
             {
                 parcel.AgencyId = agency.Id;
                 parcel.Agency = agency;

--- a/frontend/src/features/mapSideBar/containers/MapSideBarContainer.tsx
+++ b/frontend/src/features/mapSideBar/containers/MapSideBarContainer.tsx
@@ -270,8 +270,9 @@ const MapSideBarContainer: React.FunctionComponent<IMapSideBarContainerProps> = 
       {disabled &&
         (keycloak.hasClaim(Claims.ADMIN_PROPERTIES) ||
           (keycloak.hasClaim(Claims.PROPERTY_EDIT) &&
-            (keycloak.agencyId === parcelDetail?.agencyId ||
-              keycloak.agencyId === buildingDetail?.agencyId) && (
+            ((parcelDetail?.agencyId && keycloak.agencyIds.includes(parcelDetail.agencyId)) ||
+              (buildingDetail?.agencyId &&
+                keycloak.agencyIds.includes(buildingDetail.agencyId))) && (
               <EditButton onClick={() => setDisabled(false)} />
             )))}
     </>
@@ -282,13 +283,12 @@ const MapSideBarContainer: React.FunctionComponent<IMapSideBarContainerProps> = 
    */
   const ConditionalDeleteButton = () => (
     <>
-      {disabled &&
-        (keycloak.hasClaim(Claims.ADMIN_PROPERTIES) ||
-          (keycloak.hasClaim(Claims.PROPERTY_DELETE) &&
-            (keycloak.agencyId === parcelDetail?.agencyId ||
-              keycloak.agencyId === buildingDetail?.agencyId) && (
-              <DeleteButton onClick={() => setShowDelete(true)} title="Delete Property" />
-            )))}
+      {keycloak.hasClaim(Claims.ADMIN_PROPERTIES) ||
+        (keycloak.hasClaim(Claims.PROPERTY_DELETE) &&
+          ((parcelDetail?.agencyId && keycloak.agencyIds.includes(parcelDetail.agencyId)) ||
+            (buildingDetail?.agencyId && keycloak.agencyIds.includes(buildingDetail.agencyId))) && (
+            <DeleteButton onClick={() => setShowDelete(true)} title="Delete Property" />
+          ))}
     </>
   );
 


### PR DESCRIPTION
Users can now delete properties from sub-agencies.
The delete button should appear during view and edit.
Corrected permission on building delete from `property-edit` to `property-delete`.

Please note that there are still some issues that revolve around the map, info side-bar and the submitting of new properties and deleting of properties.  They are often out of sync for a minute or two.  Clicking around and retrying solves this.  This indicates implementation issues with one or more of the following - caching or state.  This is a larger problem and can't be resolved before Sprint Review however.