### PR TITLE
Fixed edit/delete buttons

### DIFF
--- a/frontend/src/features/mapSideBar/containers/MapSideBarContainer.tsx
+++ b/frontend/src/features/mapSideBar/containers/MapSideBarContainer.tsx
@@ -287,9 +287,9 @@ const MapSideBarContainer: React.FunctionComponent<IMapSideBarContainerProps> = 
           (keycloak.hasClaim(Claims.PROPERTY_EDIT) &&
             ((parcelDetail?.agencyId && keycloak.agencyIds.includes(parcelDetail.agencyId)) ||
               (buildingDetail?.agencyId &&
-                keycloak.agencyIds.includes(buildingDetail.agencyId))) && (
-              <EditButton onClick={() => setDisabled(false)} />
-            )))}
+                keycloak.agencyIds.includes(buildingDetail.agencyId))))) && (
+          <EditButton onClick={() => setDisabled(false)} />
+        )}
     </>
   );
 
@@ -298,12 +298,14 @@ const MapSideBarContainer: React.FunctionComponent<IMapSideBarContainerProps> = 
    */
   const ConditionalDeleteButton = () => (
     <>
-      {keycloak.hasClaim(Claims.ADMIN_PROPERTIES) ||
-        (keycloak.hasClaim(Claims.PROPERTY_DELETE) &&
-          ((parcelDetail?.agencyId && keycloak.agencyIds.includes(parcelDetail.agencyId)) ||
-            (buildingDetail?.agencyId && keycloak.agencyIds.includes(buildingDetail.agencyId))) && (
-            <DeleteButton onClick={() => setShowDelete(true)} title="Delete Property" />
-          ))}
+      {true &&
+        (keycloak.hasClaim(Claims.ADMIN_PROPERTIES) ||
+          (keycloak.hasClaim(Claims.PROPERTY_DELETE) &&
+            ((parcelDetail?.agencyId && keycloak.agencyIds.includes(parcelDetail.agencyId)) ||
+              (buildingDetail?.agencyId &&
+                keycloak.agencyIds.includes(buildingDetail.agencyId))))) && (
+          <DeleteButton onClick={() => setShowDelete(true)} title="Delete Property" />
+        )}
     </>
   );
 


### PR DESCRIPTION
The delete and edit buttons were not visible for SRES users on the Inventory Forms.  This appears to have been the result of a misplaced end bracket and auto-save reformatting.

![image](https://user-images.githubusercontent.com/3180256/106770437-d251cf80-65f2-11eb-9e41-d70b76bc7e1f.png)
