### PR TITLE
PA-2710 Separate tab for clickable building names

### DIFF
--- a/frontend/src/_variables.module.scss
+++ b/frontend/src/_variables.module.scss
@@ -26,4 +26,5 @@
   activeColor: $active-color;
   completedColor: $completed-color;
   filterBackgroundColor: $filter-background-color;
+  slideOutBlue: $slide-out-blue;
 }

--- a/frontend/src/buttons.scss
+++ b/frontend/src/buttons.scss
@@ -2,34 +2,34 @@
 
 .svg {
   fill: none;
-  stroke: #494949;
+  stroke: $text-color;
 }
 
 .svg-btn {
-  color: #494949;
+  color: $text-color;
 }
 
 .svg-btn:hover {
-  color: #3b99fc;
+  color: $icon-light-color;
   text-decoration: none;
   cursor: pointer;
 }
 
 .svg-btn:hover svg {
-  fill: #3b99fc;
+  fill: $icon-light-color;
   stroke: #fff;
 }
 
 .svg-btn.active {
-  color: #3b99fc;
+  color: $icon-light-color;
   border-bottom-style: solid;
-  border-bottom-color: #fcba19;
+  border-bottom-color: $accent-color;
   border-bottom-width: 1px;
   background-color: transparent !important;
 }
 
 .svg-btn.active svg {
-  fill: #3b99fc;
+  fill: $icon-light-color;
   stroke: #fff;
 }
 

--- a/frontend/src/colors.scss
+++ b/frontend/src/colors.scss
@@ -17,3 +17,4 @@ $icon-light-color: #3b99fc;
 $active-color: #007bff;
 $completed-color: #2e8540;
 $filter-background-color: #f2f2f2;
+$slide-out-blue: #1a5a96;

--- a/frontend/src/components/SearchBar/FilterBar.scss
+++ b/frontend/src/components/SearchBar/FilterBar.scss
@@ -1,7 +1,8 @@
 @import '../../fonts.scss';
+@import '../../colors.scss';
 .search-bar {
   padding: 12px;
-  background-color: #f2f2f2;
+  background-color: $filter-background-color;
   .bar-item {
     .form-group {
       padding: 0;

--- a/frontend/src/components/SearchBar/FindMorePropertiesForm.tsx
+++ b/frontend/src/components/SearchBar/FindMorePropertiesForm.tsx
@@ -11,6 +11,7 @@ import { Button, Check, Input, Select } from 'components/common/form';
 import _ from 'lodash';
 import { getIn, useFormikContext } from 'formik';
 import { TypeaheadField } from 'components/common/form/Typeahead';
+import variables from '_variables.module.scss';
 
 const StyledRow = styled(Row)`
   .form-group {
@@ -51,7 +52,7 @@ const ProjectNumber = styled(props => <Input {...props} />)`
 /** styled container with grey background to contain form contents */
 const FormSection = styled(props => <Container {...props} />)`
   margin-top: 20px;
-  background-color: #e9ecef;
+  background-color: ${variables.tableHeaderColor};
   border-radius: 5px;
 `;
 

--- a/frontend/src/components/Table/ColumnFilter.tsx
+++ b/frontend/src/components/Table/ColumnFilter.tsx
@@ -6,6 +6,7 @@ import { getIn, useFormikContext } from 'formik';
 import clsx from 'classnames';
 import { FiFilter } from 'react-icons/fi';
 import { FaFilter } from 'react-icons/fa';
+import variables from '_variables.module.scss';
 
 interface IColumnFilterProps {
   /** Column instance from react table */
@@ -31,7 +32,7 @@ const InputContainer = styled('div')`
 
   .form-control {
     border-radius: 0;
-    border-color: #606060;
+    border-color: ${variables.lightVariantColor};
   }
 `;
 

--- a/frontend/src/components/Table/ColumnSort.tsx
+++ b/frontend/src/components/Table/ColumnSort.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ColumnInstanceWithProps } from '.';
 import { IoMdArrowDropdown, IoMdArrowDropup } from 'react-icons/io';
 import styled from 'styled-components';
+import variables from '_variables.module.scss';
 
 interface IColumnSortProps<T extends object = {}> {
   column: ColumnInstanceWithProps<T>;
@@ -16,11 +17,11 @@ const Wrapper = styled('div')`
 `;
 
 const DescIcon = styled(IoMdArrowDropdown)`
-  color: #007bff;
+  color: ${variables.activeColor};
 `;
 
 const AscIcon = styled(IoMdArrowDropup)`
-  color: #007bff;
+  color: ${variables.activeColor};
 `;
 
 function ColumnSort<T extends object = {}>({ column, onSort }: IColumnSortProps<T>) {

--- a/frontend/src/components/Table/Table.scss
+++ b/frontend/src/components/Table/Table.scss
@@ -88,7 +88,7 @@
 
     .filter-wrapper {
       &.active {
-        color: $icon-light-color;
+        color: $active-color;
       }
     }
   }

--- a/frontend/src/components/Table/Table.scss
+++ b/frontend/src/components/Table/Table.scss
@@ -1,10 +1,11 @@
 @import '../../styles.scss';
+@import '../../colors.scss';
 
 .table {
   .thead-light {
     .th {
       color: #495057;
-      background-color: #e9ecef;
+      background-color: $table-header-color;
       border-color: $table-color;
     }
   }
@@ -87,7 +88,7 @@
 
     .filter-wrapper {
       &.active {
-        color: #007bff;
+        color: $icon-light-color;
       }
     }
   }

--- a/frontend/src/components/common/form/StepForm/SteppedForm.tsx
+++ b/frontend/src/components/common/form/StepForm/SteppedForm.tsx
@@ -43,7 +43,7 @@ const TabbedForm = styled(Form)`
       border: 0;
       color: white;
       svg {
-        background-color: #428bca;
+        background-color: ${variables.secondaryVariantColor};
         color: white;
       }
     }

--- a/frontend/src/components/common/form/StepForm/__snapshots__/SteppedForm.test.tsx.snap
+++ b/frontend/src/components/common/form/StepForm/__snapshots__/SteppedForm.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`SteppedForm component renders correctly 1`] = `
 }
 
 .c0 .nav-tabs .nav-item.active svg {
-  background-color: #428bca;
+  background-color: secondaryVariantColor;
   color: white;
 }
 

--- a/frontend/src/components/layout/Header/UserProfile.tsx
+++ b/frontend/src/components/layout/Header/UserProfile.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { FaSignOutAlt } from 'react-icons/fa';
 import * as API from 'constants/API';
 import { ILookupCode } from 'actions/lookupActions';
+import variables from '_variables.module.scss';
 
 /** the styling for the dropdown menu that appears after clicking the user's name */
 const StyleDropDown = styled(NavDropdown)`
@@ -21,14 +22,14 @@ const StyleDropDown = styled(NavDropdown)`
     padding: 1px;
   }
   .dropdown-item {
-    background-color: #38598a;
-    border-top: 2px solid #fcba19;
+    background-color: ${variables.primaryLightColor};
+    border-top: 2px solid ${variables.accentColor};
   }
 `;
 
 /** shaded box the users system roles will be displayed in */
 const RolesBox = styled.div`
-  background-color: #f2f2f2;
+  background-color: ${variables.filterBackgroundColor};
   margin: 5px;
 `;
 

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/AssociatedBuildingsList.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/AssociatedBuildingsList.tsx
@@ -1,0 +1,67 @@
+import { IParcel } from 'actions/parcelsActions';
+import { Label } from 'components/common/Label';
+import * as React from 'react';
+import { ReactElement } from 'react';
+import { ListGroup } from 'react-bootstrap';
+import { Link, useLocation } from 'react-router-dom';
+import queryString from 'query-string';
+
+interface IAssociatedBuildings {
+  /** the selected property information */
+  propertyInfo: IParcel | null;
+  /** link that opens the sidebar to create a new building associated to the parcel */
+  addAssociatedBuildingLink: ReactElement;
+  /** whether the user has the correct agency/permissions to edit property details */
+  canEditDetails: boolean;
+}
+
+/**
+ * Component that displays the associated buildings of a parcel
+ * as a clickable list
+ * @param propertyInfo the selected parcel
+ * @param addAssociatedBuildingLink link to create a new associated building
+ * @param canEditDetails whether the user can edit the parcel details
+ */
+export const AssociatedBuildingsList: React.FC<IAssociatedBuildings> = ({
+  propertyInfo,
+  addAssociatedBuildingLink,
+  canEditDetails,
+}) => {
+  const location = useLocation();
+  return (
+    <>
+      <ListGroup>
+        <Label className="header" style={{ margin: '5px 0px' }}>
+          Associated Buildings
+        </Label>
+        <ListGroup.Item>Click a building name to view its details</ListGroup.Item>
+        {propertyInfo?.buildings.map((building, buildingId) => (
+          <ListGroup.Item key={buildingId}>
+            <Link
+              className="styled-link"
+              to={{
+                pathname: `/mapview`,
+                search: queryString.stringify({
+                  ...queryString.parse(location.search),
+                  sidebar: true,
+                  disabled: true,
+                  loadDraft: false,
+                  buildingId: building.id,
+                }),
+              }}
+            >
+              {building.name}
+            </Link>
+          </ListGroup.Item>
+        ))}
+      </ListGroup>
+      {canEditDetails && (
+        <ListGroup>
+          <ListGroup.Item>{addAssociatedBuildingLink}</ListGroup.Item>
+        </ListGroup>
+      )}
+    </>
+  );
+};
+
+export default AssociatedBuildingsList;

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/HeaderActions.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/HeaderActions.tsx
@@ -4,9 +4,10 @@ import { Row } from 'react-bootstrap';
 import { IBuilding, IParcel, PropertyTypes } from 'actions/parcelsActions';
 import { Link, useLocation } from 'react-router-dom';
 import queryString from 'query-string';
+import variables from '_variables.module.scss';
 
 const LinkMenu = styled(Row)`
-  background-color: #f2f2f2;
+  background-color: ${variables.filterBackgroundColor};
   height: 35px;
   width: 322px;
   margin: 0px 0px 5px -10px;
@@ -14,7 +15,7 @@ const LinkMenu = styled(Row)`
   padding: 10px;
   a {
     padding: 0px 10px;
-    color: #1a5a96;
+    color: ${variables.slideOutBlue};
   }
 `;
 

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
@@ -9,6 +9,7 @@ import BuildingAttributes from './BuildingAttributes';
 import { ReactElement } from 'react';
 import styled from 'styled-components';
 import { ThreeColumnItem } from './ThreeColumnItem';
+import variables from '_variables.module.scss';
 
 /**
  * Compare two dates to evaluation which is earlier.
@@ -49,11 +50,11 @@ const ContactSres = styled(Row)`
   margin: 0px 1px 5px 1px;
 
   em {
-    color: #121212;
+    color: ${variables.darkVariantColor};
   }
 
   a {
-    color: #1a5a96;
+    color: ${variables.slideOutBlue};
   }
 `;
 
@@ -142,12 +143,7 @@ export const InfoContent: React.FC<IInfoContent> = ({
         </OuterRow>
       </ListGroup>
       {propertyTypeId === PropertyTypes.PARCEL && (
-        <ParcelAttributes
-          addAssociatedBuildingLink={addAssociatedBuildingLink}
-          parcelInfo={propertyInfo as IParcel}
-          canViewDetails={canViewDetails}
-          canEditDetails={canEditDetails}
-        />
+        <ParcelAttributes parcelInfo={propertyInfo as IParcel} canViewDetails={canViewDetails} />
       )}
       {propertyTypeId === PropertyTypes.BUILDING && (
         <BuildingAttributes

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.scss
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.scss
@@ -38,3 +38,8 @@
 .leaflet-control {
   margin-right: 0px;
 }
+
+.styled-link {
+  color: $light-variant-color !important;
+  font-weight: lighter;
+}

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.tsx
@@ -115,8 +115,8 @@ const Title = styled.p`
 export type InfoControlProps = {
   /** whether the slide out is open or closed */
   open: boolean;
-  /** set the slide out as open or closed */
-  setOpen: () => void;
+  /** set the slide out as open or closed*/
+  setOpen: (state: boolean) => void;
   /** additional action for when a link is clicked */
   onHeaderActionClick?: () => void;
 };
@@ -159,7 +159,7 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
     <>
       <FaPlusSquare color="#1a5a96" className="mr-1" />
       <Link
-        style={{ color: '#1a5a96' }}
+        style={{ color: variables.slideOutBlue }}
         to={{
           pathname: `/mapview`,
           search: queryString.stringify({
@@ -237,14 +237,14 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
             variant="outline-secondary"
             onClick={() => {
               if (!open) {
-                setOpen();
+                setOpen(true);
                 setParcelInfoOpen(true);
                 setBuildingsOpen(false);
               } else if (open && !parcelInfoOpen) {
                 setParcelInfoOpen(true);
                 setBuildingsOpen(false);
               } else {
-                setOpen(); //close the slide out
+                setOpen(false); //close the slide out
               }
             }}
             className={clsx({ open })}

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/ParcelAttributes.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/ParcelAttributes.tsx
@@ -4,32 +4,22 @@ import { IParcel } from 'actions/parcelsActions';
 import { Label } from 'components/common/Label';
 import './InfoSlideOut.scss';
 import { formatMoney } from 'utils/numberFormatUtils';
-import { ReactElement } from 'react';
 import { compareDate, OuterRow } from './InfoContent';
 import { ThreeColumnItem } from './ThreeColumnItem';
 
 interface IParcelAttributes {
   /** the selected parcel information */
   parcelInfo: IParcel;
-  addAssociatedBuildingLink: ReactElement;
   /** whether the user has the correct agency/permissions to view all the details */
   canViewDetails: boolean;
-  /** whether the user has the correct agency/permissions to edit property details */
-  canEditDetails: boolean;
 }
 
 /**
  * Displays parcel specific information needed on the information slide out
  * @param parcelInfo the selected parcel data
  * @param canViewDetails user can view all property details
- * @param canEditDetails user can edit property details
  */
-export const ParcelAttributes: React.FC<IParcelAttributes> = ({
-  parcelInfo,
-  addAssociatedBuildingLink,
-  canViewDetails,
-  canEditDetails,
-}) => {
+export const ParcelAttributes: React.FC<IParcelAttributes> = ({ parcelInfo, canViewDetails }) => {
   let formatAssessed;
   if (parcelInfo?.assessedLand) {
     formatAssessed = formatMoney(parcelInfo?.assessedLand);
@@ -40,9 +30,6 @@ export const ParcelAttributes: React.FC<IParcelAttributes> = ({
   } else {
     formatAssessed = '';
   }
-
-  const newLength = parcelInfo.buildings?.length > 3 ? 3 : parcelInfo.buildings?.length;
-  const buildingsCopy = parcelInfo.buildings?.slice(0, newLength);
 
   return (
     <>
@@ -73,26 +60,6 @@ export const ParcelAttributes: React.FC<IParcelAttributes> = ({
               <ThreeColumnItem leftSideLabel={'Assessed value:'} rightSideItem={formatAssessed} />
             </OuterRow>
           </ListGroup>
-          {parcelInfo?.buildings && (
-            <ListGroup>
-              <Label className="header">Associated Buildings</Label>
-              {buildingsCopy.map((building, buildingId) => (
-                <ListGroup.Item key={buildingId}>
-                  <Label>{building.name}</Label>
-                </ListGroup.Item>
-              ))}
-              {parcelInfo.buildings.length > 3 && (
-                <ListGroup.Item>
-                  <Label>+ {parcelInfo.buildings.length - 3} more</Label>
-                </ListGroup.Item>
-              )}
-            </ListGroup>
-          )}
-          {canEditDetails && (
-            <ListGroup>
-              <ListGroup.Item>{addAssociatedBuildingLink}</ListGroup.Item>
-            </ListGroup>
-          )}
         </>
       )}
     </>

--- a/frontend/src/components/maps/leaflet/LayersControl/LayersControl.tsx
+++ b/frontend/src/components/maps/leaflet/LayersControl/LayersControl.tsx
@@ -8,6 +8,7 @@ import LayersTree from './LayersTree';
 import * as L from 'leaflet';
 import { useEffect } from 'react';
 import TooltipWrapper from 'components/common/TooltipWrapper';
+import variables from '_variables.module.scss';
 
 const LayersContainer = styled.div`
   margin-right: -10px;
@@ -30,7 +31,7 @@ const LayersContainer = styled.div`
 const LayersHeader = styled.div`
   width: 100%;
   height: 80px;
-  background-color: #1a5a96;
+  background-color: ${variables.slideOutBlue};
   color: #fff;
   display: flex;
   flex-direction: column;
@@ -70,8 +71,8 @@ const ControlButton = styled(Button)`
   top: 0;
   left: -51px;
   background-color: #fff;
-  color: #1a5a96;
-  border-color: #1a5a96;
+  color: ${variables.slideOutBlue};
+  border-color: ${variables.slideOutBlue};
   box-shadow: -2px 1px 4px rgba(0, 0, 0, 0.2);
   &.open {
     border-top-right-radius: 0;

--- a/frontend/src/components/maps/leaflet/LayersControl/LayersTree.tsx
+++ b/frontend/src/components/maps/leaflet/LayersControl/LayersTree.tsx
@@ -10,6 +10,7 @@ import { layersTree } from './data';
 import * as L from 'leaflet';
 import { useLeaflet } from 'react-leaflet';
 import { ILayerItem } from './types';
+import variables from '_variables.module.scss';
 
 const ParentNode = styled(ListGroup.Item)`
   display: flex;
@@ -22,7 +23,7 @@ const ParentNode = styled(ListGroup.Item)`
     .form-check {
       label {
         font-weight: bold;
-        color: #494949;
+        color: ${variables.textColor};
         font-size: 13px;
       }
     }

--- a/frontend/src/components/maps/leaflet/Legend/LegendControl.tsx
+++ b/frontend/src/components/maps/leaflet/Legend/LegendControl.tsx
@@ -7,10 +7,11 @@ import { Legend } from './Legend';
 import styled from 'styled-components';
 import { FiMapPin } from 'react-icons/fi';
 import TooltipWrapper from 'components/common/TooltipWrapper';
+import variables from '_variables.module.scss';
 
 const LegendButton = styled(Button)`
   background-color: #ffffff !important;
-  color: #121212 !important;
+  color: ${variables.darkVariantColor} !important;
   width: 40px;
   height: 40px;
   font-size: 25px;

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -377,8 +377,8 @@ const Map: React.FC<MapProps> = ({
                     />
                     <InfoSlideOut
                       open={infoOpen}
-                      setOpen={() => {
-                        setInfoOpen(!infoOpen);
+                      setOpen={(state: boolean) => {
+                        setInfoOpen(state);
                         setLayersOpen(false);
                       }}
                       onHeaderActionClick={() => {

--- a/frontend/src/components/maps/leaflet/ZoomOut/ZoomOutButton.tsx
+++ b/frontend/src/components/maps/leaflet/ZoomOut/ZoomOutButton.tsx
@@ -6,10 +6,11 @@ import styled from 'styled-components';
 import { FaExpandArrowsAlt } from 'react-icons/fa';
 import { LatLngBounds, Map as LeafletMap } from 'leaflet';
 import { MapProps as LeafletMapProps, Map as ReactLeafletMap } from 'react-leaflet';
+import variables from '_variables.module.scss';
 
 const ZoomButton = styled(Button)`
   background-color: #ffffff !important;
-  color: #121212 !important;
+  color: ${variables.darkVariantColor} !important;
   width: 40px;
   height: 40px;
 `;

--- a/frontend/src/features/account/Login.scss
+++ b/frontend/src/features/account/Login.scss
@@ -20,7 +20,7 @@
       justify-content: center;
     }
     .block {
-      background-color: #f2f2f2;
+      background-color: $filter-background-color;
       padding: 43px 0;
       max-width: 650px;
       max-height: 475px;

--- a/frontend/src/features/mapSideBar/SidebarContents/AssociatedLandForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/AssociatedLandForm.tsx
@@ -42,6 +42,7 @@ import {
 } from 'features/properties/components/forms/subforms/EvaluationForm';
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { FiscalKeys } from 'constants/fiscalKeys';
+import variables from '_variables.module.scss';
 
 const Container = styled.div`
   background-color: #fff;
@@ -70,7 +71,7 @@ const FormFooter = styled.div`
   height: 70px;
   align-items: center;
   position: sticky;
-  background-color: #f2f2f2;
+  background-color: ${variables.filterBackgroundColor};
   bottom: 25px;
 `;
 
@@ -105,7 +106,7 @@ const ProgressBar = styled.div`
   height: 10px;
   border-radius: 5px;
   margin: 10px 0px;
-  background-color: #428bca;
+  background-color: ${variables.secondaryVariantColor};
 `;
 
 export interface IAssociatedLand extends IBuilding {

--- a/frontend/src/features/mapSideBar/SidebarContents/BuildingForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/BuildingForm.tsx
@@ -42,6 +42,7 @@ import DebouncedValidation from 'features/properties/components/forms/subforms/D
 import { valuesToApiFormat as landValuesToApiFormat } from './LandForm';
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { FiscalKeys } from 'constants/fiscalKeys';
+import variables from '_variables.module.scss';
 
 const Container = styled.div`
   background-color: #fff;
@@ -70,7 +71,7 @@ const FormFooter = styled.div`
   height: 70px;
   align-items: center;
   position: sticky;
-  background-color: #f2f2f2;
+  background-color: ${variables.filterBackgroundColor};
   bottom: 25px;
 `;
 

--- a/frontend/src/features/mapSideBar/SidebarContents/LandForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/LandForm.tsx
@@ -44,6 +44,7 @@ import { IParcel } from 'actions/parcelsActions';
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { FiscalKeys } from 'constants/fiscalKeys';
 import { stringToNull } from 'utils';
+import variables from '_variables.module.scss';
 
 const Container = styled.div`
   background-color: #fff;
@@ -72,7 +73,7 @@ const FormFooter = styled.div`
   height: 70px;
   align-items: center;
   position: sticky;
-  background-color: #f2f2f2;
+  background-color: ${variables.filterBackgroundColor};
   bottom: 40px;
 `;
 

--- a/frontend/src/features/mapSideBar/SidebarContents/SubmitPropertySelector.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/SubmitPropertySelector.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { InventoryPolicy } from '../components/InventoryPolicy';
 import { BuildingSvg, LandSvg } from 'components/common/Icons';
+import variables from '_variables.module.scss';
 
 const SidebarContent = styled.div`
   background-color: #fff;
@@ -19,7 +20,7 @@ const InventoryPolicyWrapper = styled.div`
   display: flex;
   justify-content: center;
   padding: 16px;
-  border-bottom: 1px solid #d9d9d9;
+  border-bottom: 1px solid ${variables.formBackground};
   margin-bottom: 16px;
 `;
 
@@ -37,7 +38,7 @@ const Action = styled.div`
   height: 89px;
   border-radius: 8px;
   fill: #ffffff;
-  border: 2px solid #1a5a96;
+  border: 2px solid ${variables.slideOutBlue};
   margin-bottom: 16px;
   display: flex;
   align-items: center;
@@ -54,14 +55,14 @@ const ActionLabelWrapper = styled.div`
 `;
 
 const BuildingIcon = styled(BuildingSvg)`
-  color: #494949;
+  color: ${variables.textColor};
   height: 47px;
   width: 47px;
   margin-right: 16px;
 `;
 
 const BareLandIcon = styled(LandSvg)`
-  color: #494949;
+  color: ${variables.textColor};
   height: 47px;
   width: 47px;
   margin-right: 16px;
@@ -69,12 +70,12 @@ const BareLandIcon = styled(LandSvg)`
 
 const ActionPrimaryText = styled.p`
   font-size: 21px;
-  color: #1a5a96;
+  color: ${variables.slideOutBlue};
   margin-bottom: 0px;
 `;
 const ActionSecondaryText = styled.p`
   font-size: 12px;
-  color: #494949;
+  color: ${variables.textColor};
   margin-bottom: 0px;
 `;
 

--- a/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/BuildingForm.test.tsx.snap
+++ b/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/BuildingForm.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Building Form component renders correctly 1`] = `
 }
 
 .c1 .nav-tabs .nav-item.active svg {
-  background-color: #428bca;
+  background-color: secondaryVariantColor;
   color: white;
 }
 
@@ -70,7 +70,7 @@ exports[`Building Form component renders correctly 1`] = `
 }
 
 .c5 {
-  border: 1px solid #f2f2f2;
+  border: 1px solid filterBackgroundColor;
   border-radius: 4px;
   text-align: left;
   padding: 8px 12px 10px;
@@ -127,7 +127,7 @@ exports[`Building Form component renders correctly 1`] = `
   align-items: center;
   position: -webkit-sticky;
   position: sticky;
-  background-color: #f2f2f2;
+  background-color: filterBackgroundColor;
   bottom: 25px;
 }
 

--- a/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/LandForm.test.tsx.snap
+++ b/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/LandForm.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Land Form component renders correctly 1`] = `
 }
 
 .c1 .nav-tabs .nav-item.active svg {
-  background-color: #428bca;
+  background-color: secondaryVariantColor;
   color: white;
 }
 
@@ -115,7 +115,7 @@ exports[`Land Form component renders correctly 1`] = `
   align-items: center;
   position: -webkit-sticky;
   position: sticky;
-  background-color: #f2f2f2;
+  background-color: filterBackgroundColor;
   bottom: 40px;
 }
 

--- a/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/SubmitPropertySelector.test.tsx.snap
+++ b/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/SubmitPropertySelector.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`SubmitPropertySelector component renders correctly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   padding: 16px;
-  border-bottom: 1px solid #d9d9d9;
+  border-bottom: 1px solid formBackground;
   margin-bottom: 16px;
 }
 
@@ -93,7 +93,7 @@ exports[`SubmitPropertySelector component renders correctly 1`] = `
   height: 89px;
   border-radius: 8px;
   fill: #ffffff;
-  border: 2px solid #1a5a96;
+  border: 2px solid slideOutBlue;
   margin-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -130,14 +130,14 @@ exports[`SubmitPropertySelector component renders correctly 1`] = `
 }
 
 .c6 {
-  color: #494949;
+  color: textColor;
   height: 47px;
   width: 47px;
   margin-right: 16px;
 }
 
 .c9 {
-  color: #494949;
+  color: textColor;
   height: 47px;
   width: 47px;
   margin-right: 16px;
@@ -145,13 +145,13 @@ exports[`SubmitPropertySelector component renders correctly 1`] = `
 
 .c8 {
   font-size: 21px;
-  color: #1a5a96;
+  color: slideOutBlue;
   margin-bottom: 0px;
 }
 
 .c10 {
   font-size: 12px;
-  color: #494949;
+  color: textColor;
   margin-bottom: 0px;
 }
 

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.tsx
@@ -13,6 +13,7 @@ import { getIn, useFormikContext } from 'formik';
 import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 import styled from 'styled-components';
+import variables from '_variables.module.scss';
 
 const Title = styled.h4`
   float: left;
@@ -20,7 +21,7 @@ const Title = styled.h4`
 
 /** formated information box to display the classification definitions to the right of the select */
 const InfoBox = styled.div`
-  border: 1px solid #f2f2f2;
+  border: 1px solid ${variables.filterBackgroundColor};
   border-radius: 4px;
   text-align: left;
   padding: 8px 12px 10px;

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/IdentificationForm.scss
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/IdentificationForm.scss
@@ -1,7 +1,7 @@
 @import '../../../../colors.scss';
 .identification {
   .req {
-    color: red;
+    color: $danger-color;
     font-weight: bold;
   }
   .container {
@@ -46,7 +46,7 @@
       }
       text-align: left;
       padding: 15px;
-      background-color: #e9ecef;
+      background-color: $table-header-color;
       border-radius: 5px;
     }
   }

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/LandReviewPage.scss
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/LandReviewPage.scss
@@ -1,3 +1,5 @@
+@import '../../../../colors.scss';
+
 .review-section {
   .row,
   .form-row,
@@ -79,7 +81,7 @@
     margin: 10px;
     width: 100%;
     padding: 20px;
-    background-color: #f2f2f2;
+    background-color: $filter-background-color;
     border-radius: 10px;
     font-size: small;
     .form-control,
@@ -137,6 +139,6 @@
   }
   .edit {
     cursor: pointer;
-    color: #1a5a96;
+    color: $slide-out-blue;
   }
 }

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/LandUsageForm.scss
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/LandUsageForm.scss
@@ -1,9 +1,11 @@
+@import '../../../../colors.scss';
+
 .parcel-usage {
   max-width: 900px;
   .classification {
     margin-top: 10px;
     margin-bottom: 10px;
-    background-color: #e9ecef;
+    background-color: $table-header-color;
     border-radius: 5px;
     .form-group {
       padding-top: 10px;

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/ParcelIdentificationForm.scss
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/ParcelIdentificationForm.scss
@@ -80,7 +80,7 @@
     }
     .section {
       padding: 10px 0px;
-      background-color: #f2f2f2;
+      background-color: $filter-background-color;
       border: 1px solid $light-variant-color;
       border-radius: 5px;
       margin-bottom: 20px;

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/TenancyForm.scss
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/TenancyForm.scss
@@ -1,3 +1,5 @@
+@import '../../../../colors.scss';
+
 .tenancy {
   .type-occupant {
     width: 300px;
@@ -32,7 +34,7 @@
   }
   .classification {
     padding-top: 10px;
-    background-color: #e9ecef;
+    background-color: $table-header-color;
     border-radius: 10px;
   }
   .check-field {

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/ValuationForm.scss
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/ValuationForm.scss
@@ -1,3 +1,5 @@
+@import '../../../../colors.scss';
+
 .val-table {
   .table {
     .form-group.col {
@@ -28,7 +30,7 @@
     }
     .td,
     .th {
-      border: 2px solid #dee2e6;
+      border: 2px solid $table-color;
       justify-content: center !important;
       font-size: 18px !important;
     }

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/__snapshots__/ClassificationForm.test.tsx.snap
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/__snapshots__/ClassificationForm.test.tsx.snap
@@ -14,7 +14,7 @@ Array [
     />
   </div>,
   .c0 {
-  border: 1px solid #f2f2f2;
+  border: 1px solid filterBackgroundColor;
   border-radius: 4px;
   text-align: left;
   padding: 8px 12px 10px;

--- a/frontend/src/features/mapSideBar/components/MapSideBarLayout.tsx
+++ b/frontend/src/features/mapSideBar/components/MapSideBarLayout.tsx
@@ -7,6 +7,7 @@ import { InventoryPolicy } from './InventoryPolicy';
 import { SidebarSize, SidebarContextType } from '../hooks/useQueryParamSideBar';
 import { FaWindowClose } from 'react-icons/fa';
 import './MapSideBarLayout.scss';
+import variables from '_variables.module.scss';
 
 interface IMapSideBarLayoutProps {
   show: boolean;
@@ -32,7 +33,7 @@ const HeaderRow = styled.div`
 `;
 
 const CloseIcon = styled(FaWindowClose)`
-  color: #494949;
+  color: ${variables.textColor};
   font-size: 30px;
 `;
 

--- a/frontend/src/features/mapSideBar/containers/MapSideBarContainer.tsx
+++ b/frontend/src/features/mapSideBar/containers/MapSideBarContainer.tsx
@@ -38,6 +38,7 @@ import { deleteBuilding } from 'actionCreators/buildingActionCreator';
 import useSideBarBuildingWithParcelLoader from '../hooks/useSideBarBuildingWithParcelLoader';
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { FiscalKeys } from 'constants/fiscalKeys';
+import variables from '_variables.module.scss';
 
 interface IMapSideBarContainerProps {
   refreshParcels: Function;
@@ -47,12 +48,12 @@ interface IMapSideBarContainerProps {
 
 const FloatCheck = styled(FaCheckCircle)`
   margin: 1em;
-  color: #2e8540;
+  color: ${variables.completedColor};
   float: left;
 `;
 
 const SuccessText = styled.p`
-  color: #2e8540;
+  color: ${variables.completedColor};
   margin-bottom: 0;
   font-size: 24px;
 `;
@@ -66,7 +67,7 @@ const EditButton = styled(FaEdit)`
   margin-right: 10px;
   margin-top: 5px;
   cursor: pointer;
-  color: #1a5a96;
+  color: ${variables.slideOutBlue};
   float: right;
 `;
 

--- a/frontend/src/features/projects/common/components/FilterBar.scss
+++ b/frontend/src/features/projects/common/components/FilterBar.scss
@@ -1,8 +1,9 @@
 @import '../../../../fonts.scss';
+@import '../../../../colors.scss';
 
 .ProjectDisposeView {
   .filter-container {
-    background-color: #f2f2f2;
+    background-color: $filter-background-color;
 
     .filter-bar {
       align-items: center;

--- a/frontend/src/features/splReports/components/ReportListItem.tsx
+++ b/frontend/src/features/splReports/components/ReportListItem.tsx
@@ -5,6 +5,7 @@ import ElipsisControls from './ElipsisControls';
 import { IReport } from '../interfaces';
 import { formatApiDateTime } from 'utils';
 import TooltipWrapper from 'components/common/TooltipWrapper';
+import variables from '_variables.module.scss';
 
 interface IReportListitemProps {
   /** The underlying report that this control is mapped to. */
@@ -35,7 +36,7 @@ const Report = styled(Col)`
   text-overflow: ellipsis;
 
   :hover {
-    color: #3b99fc;
+    color: ${variables.iconLightColor};
     cursor: pointer;
   }
 `;


### PR DESCRIPTION

https://user-images.githubusercontent.com/33818575/107407191-3d514980-6abe-11eb-83db-75e4c8b8e054.mp4

- Added a separate tab on the info slide out that displays a clickable list of all the associated buildings. Only viewable to owning agency
- Got a liiiittle carried away adding colour variable names to styled components, but it only took me a couple of minutes I swear