### PR TITLE
PA-2679: Fix backend erroneously rounding values

### DIFF
--- a/backend/api/Areas/Property/Models/Building/BuildingEvaluationModel.cs
+++ b/backend/api/Areas/Property/Models/Building/BuildingEvaluationModel.cs
@@ -12,7 +12,7 @@ namespace Pims.Api.Areas.Property.Models.Building
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Areas/Property/Models/Building/BuildingFiscalModel.cs
+++ b/backend/api/Areas/Property/Models/Building/BuildingFiscalModel.cs
@@ -14,7 +14,7 @@ namespace Pims.Api.Areas.Property.Models.Building
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Areas/Property/Models/Parcel/BuildingEvaluationModel.cs
+++ b/backend/api/Areas/Property/Models/Parcel/BuildingEvaluationModel.cs
@@ -12,7 +12,7 @@ namespace Pims.Api.Areas.Property.Models.Parcel
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Areas/Property/Models/Parcel/BuildingFiscalModel.cs
+++ b/backend/api/Areas/Property/Models/Parcel/BuildingFiscalModel.cs
@@ -11,7 +11,7 @@ namespace Pims.Api.Areas.Property.Models.Parcel
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Areas/Property/Models/Parcel/ParcelEvaluationModel.cs
+++ b/backend/api/Areas/Property/Models/Parcel/ParcelEvaluationModel.cs
@@ -12,7 +12,7 @@ namespace Pims.Api.Areas.Property.Models.Parcel
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
 

--- a/backend/api/Areas/Property/Models/Parcel/ParcelFiscalModel.cs
+++ b/backend/api/Areas/Property/Models/Parcel/ParcelFiscalModel.cs
@@ -14,7 +14,7 @@ namespace Pims.Api.Areas.Property.Models.Parcel
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Areas/Tools/Models/Import/BuildingEvaluationModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/BuildingEvaluationModel.cs
@@ -11,7 +11,7 @@ namespace Pims.Api.Areas.Tools.Models.Import
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Areas/Tools/Models/Import/BuildingFiscalModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/BuildingFiscalModel.cs
@@ -9,7 +9,7 @@ namespace Pims.Api.Areas.Tools.Models.Import
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Areas/Tools/Models/Import/ParcelEvaluationModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/ParcelEvaluationModel.cs
@@ -11,7 +11,7 @@ namespace Pims.Api.Areas.Tools.Models.Import
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Areas/Tools/Models/Import/ParcelFiscalModel.cs
+++ b/backend/api/Areas/Tools/Models/Import/ParcelFiscalModel.cs
@@ -9,7 +9,7 @@ namespace Pims.Api.Areas.Tools.Models.Import
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Models/Building/BuildingEvaluationModel.cs
+++ b/backend/api/Models/Building/BuildingEvaluationModel.cs
@@ -11,7 +11,7 @@ namespace Pims.Api.Models.Building
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Models/Building/BuildingFiscalModel.cs
+++ b/backend/api/Models/Building/BuildingFiscalModel.cs
@@ -9,7 +9,7 @@ namespace Pims.Api.Models.Building
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Models/Parcel/BuildingEvaluationModel.cs
+++ b/backend/api/Models/Parcel/BuildingEvaluationModel.cs
@@ -11,7 +11,7 @@ namespace Pims.Api.Models.Parcel
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Models/Parcel/BuildingFiscalModel.cs
+++ b/backend/api/Models/Parcel/BuildingFiscalModel.cs
@@ -9,7 +9,7 @@ namespace Pims.Api.Models.Parcel
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion

--- a/backend/api/Models/Parcel/ParcelEvaluationModel.cs
+++ b/backend/api/Models/Parcel/ParcelEvaluationModel.cs
@@ -11,7 +11,7 @@ namespace Pims.Api.Models.Parcel
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
 

--- a/backend/api/Models/Parcel/ParcelFiscalModel.cs
+++ b/backend/api/Models/Parcel/ParcelFiscalModel.cs
@@ -9,7 +9,7 @@ namespace Pims.Api.Models.Parcel
 
         public string Key { get; set; }
 
-        public float Value { get; set; }
+        public decimal Value { get; set; }
 
         public string Note { get; set; }
         #endregion


### PR DESCRIPTION
`float` has a precision of 6-9 digits while `decimal` has 28-29 which will handle the large financial values correctly. Could always go with a `double` as well if that is preferred (15-17)