### PR TITLE
Fixed Local Config

### DIFF
--- a/backend/api/appsettings.Local.json
+++ b/backend/api/appsettings.Local.json
@@ -25,6 +25,7 @@
   },
   "Keycloak": {
     "Authority": "http://localhost:8080/auth/realms/pims",
+    "Secret": "",
     "Admin": {
       "Authority": "http://localhost:8080/auth/admin/realms/pims"
     }


### PR DESCRIPTION
Just discovered that the `.env` files that have blank values (i.e. `Key=`) are ignored for some reason.  This ensures the secret value is blank for debugging locally.