### PR TITLE
PA-2482 Allow row increase in select properties

### DIFF
--- a/frontend/src/components/Table/PageSizeSelector.tsx
+++ b/frontend/src/components/Table/PageSizeSelector.tsx
@@ -2,6 +2,12 @@ import { Menu, IMenuItemProps } from 'components/menu/Menu';
 import React from 'react';
 import { Form } from 'react-bootstrap';
 import { noop } from 'lodash';
+import styled from 'styled-components';
+
+/** align text to middle of size input */
+const StyledText = styled.span`
+  margin-top: 0.2rem;
+`;
 
 interface IProps {
   options: number[];
@@ -28,7 +34,7 @@ export const TablePageSizeSelector: React.FC<IProps> = ({ options, value, onChan
   return (
     <Menu options={pageSizeOptions} width="60px" alignTop={alignTop}>
       <div style={{ display: 'flex' }}>
-        <span>Show</span>
+        <StyledText>Show</StyledText>
         <Form.Control
           size="sm"
           value={`${selected}`}
@@ -36,7 +42,7 @@ export const TablePageSizeSelector: React.FC<IProps> = ({ options, value, onChan
           style={{ width: 50, marginLeft: 10, marginRight: 10 }}
           onChange={noop}
         />
-        <span>Entries</span>
+        <StyledText>Entries</StyledText>
       </div>
     </Menu>
   );

--- a/frontend/src/components/Table/Table.scss
+++ b/frontend/src/components/Table/Table.scss
@@ -1,6 +1,5 @@
 @import '../../styles.scss';
 @import '../../colors.scss';
-
 .table {
   .thead-light {
     .th {
@@ -9,7 +8,6 @@
       border-color: $table-color;
     }
   }
-
   .thead {
     .th {
       vertical-align: bottom;
@@ -18,11 +16,9 @@
       font-size: 11px;
     }
   }
-
   .tbody {
     .tr-wrapper {
       border-bottom: 1px solid $table-color;
-
       .tr {
         &:hover {
           background-color: $table-color;
@@ -36,7 +32,6 @@
       }
     }
   }
-
   .table-loading,
   .no-rows-message {
     display: flex;
@@ -47,37 +42,30 @@
     margin-top: 5px;
     margin-bottom: 5px;
   }
-
   .td,
   .th {
     padding: 5px;
     vertical-align: top;
     border-top: 1px solid $table-color;
-
     &.svg-btn.expander:hover,
     &.svg-btn.expander:hover svg {
       fill: $accent-color;
     }
-
     &.svg-btn.reset-filter:hover,
     &.svg-btn.reset-filter:hover svg {
       fill: $accent-color;
     }
-
     &.expander,
     &.reset-filter {
       display: flex;
       align-items: center;
     }
-
     &.clickable {
       cursor: pointer;
     }
-
     .expand-button:focus {
       background: none !important;
     }
-
     .sortable-column {
       display: flex;
       width: 100%;
@@ -85,7 +73,6 @@
       align-items: center;
       justify-content: flex-start;
     }
-
     .filter-wrapper {
       &.active {
         color: $active-color;
@@ -98,9 +85,9 @@
   display: flex;
   flex-direction: row-reverse;
   align-content: center;
-
   div {
     .Menu-root {
+      margin-top: 5px;
       margin-right: 30px;
     }
   }

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -119,7 +119,7 @@ export interface TableProps<T extends object = {}> extends TableOptions<T> {
   filterable?: boolean;
   filter?: { [key in keyof T]?: any };
   onFilterChange?: (values: any) => void;
-  /** have menu drop-up to avoid contianer growing in some scenraios */
+  /** have page selection menu drop-up to avoid contianer growing in some scenraios */
   dropUp?: boolean;
 }
 

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -120,7 +120,7 @@ export interface TableProps<T extends object = {}> extends TableOptions<T> {
   filter?: { [key in keyof T]?: any };
   onFilterChange?: (values: any) => void;
   /** have page selection menu drop-up to avoid container growing in some scenarios */
-  dropUp?: boolean;
+  pageSizeMenuDropUp?: boolean;
 }
 
 const IndeterminateCheckbox = React.forwardRef(({ indeterminate, ...rest }: any, ref) => {
@@ -559,7 +559,9 @@ const Table = <T extends object>(props: PropsWithChildren<TableProps<T>>): React
               options={props.pageSizeOptions || DEFAULT_PAGE_SELECTOR_OPTIONS}
               value={props.pageSize || DEFAULT_PAGE_SIZE}
               onChange={onPageSizeChange}
-              alignTop={props.dropUp ? props.dropUp : props.data.length >= 20}
+              alignTop={
+                props.pageSizeMenuDropUp ? props.pageSizeMenuDropUp : props.data.length >= 20
+              }
             />
           )}
         </div>

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -119,6 +119,8 @@ export interface TableProps<T extends object = {}> extends TableOptions<T> {
   filterable?: boolean;
   filter?: { [key in keyof T]?: any };
   onFilterChange?: (values: any) => void;
+  /** have menu drop-up to avoid contianer growing in some scenraios */
+  dropUp?: boolean;
 }
 
 const IndeterminateCheckbox = React.forwardRef(({ indeterminate, ...rest }: any, ref) => {
@@ -557,7 +559,7 @@ const Table = <T extends object>(props: PropsWithChildren<TableProps<T>>): React
               options={props.pageSizeOptions || DEFAULT_PAGE_SELECTOR_OPTIONS}
               value={props.pageSize || DEFAULT_PAGE_SIZE}
               onChange={onPageSizeChange}
-              alignTop={props.data.length >= 20}
+              alignTop={props.dropUp ? props.dropUp : props.data.length >= 20}
             />
           )}
         </div>

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -119,7 +119,7 @@ export interface TableProps<T extends object = {}> extends TableOptions<T> {
   filterable?: boolean;
   filter?: { [key in keyof T]?: any };
   onFilterChange?: (values: any) => void;
-  /** have page selection menu drop-up to avoid contianer growing in some scenraios */
+  /** have page selection menu drop-up to avoid container growing in some scenarios */
   dropUp?: boolean;
 }
 

--- a/frontend/src/components/Table/__snapshots__/PageSizeSelector.test.tsx.snap
+++ b/frontend/src/components/Table/__snapshots__/PageSizeSelector.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Page size selector Snapshot matches 1`] = `
+.c0 {
+  margin-top: 0.2rem;
+}
+
 <div>
   <div>
     <div
@@ -17,7 +21,9 @@ exports[`Page size selector Snapshot matches 1`] = `
             }
           }
         >
-          <span>
+          <span
+            className="c0"
+          >
             Show
           </span>
           <input
@@ -33,7 +39,9 @@ exports[`Page size selector Snapshot matches 1`] = `
             type="number"
             value="1"
           />
-          <span>
+          <span
+            className="c0"
+          >
             Entries
           </span>
         </div>

--- a/frontend/src/features/admin/access/__snapshots__/ManageAccessRequests.test.tsx.snap
+++ b/frontend/src/features/admin/access/__snapshots__/ManageAccessRequests.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Manage access requests Snapshot matches 1`] = `
+.c0 {
+  margin-top: 0.2rem;
+}
+
 <div
   className="manage-access-requests"
 >
@@ -903,7 +907,9 @@ exports[`Manage access requests Snapshot matches 1`] = `
                 }
               }
             >
-              <span>
+              <span
+                className="c0"
+              >
                 Show
               </span>
               <input
@@ -919,7 +925,9 @@ exports[`Manage access requests Snapshot matches 1`] = `
                 type="number"
                 value="10"
               />
-              <span>
+              <span
+                className="c0"
+              >
                 Entries
               </span>
             </div>

--- a/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Manage Users Component Snapshot matches 1`] = `
+.c2 {
+  margin-top: 0.2rem;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1070,7 +1074,9 @@ exports[`Manage Users Component Snapshot matches 1`] = `
             <div
               style="display: flex;"
             >
-              <span>
+              <span
+                class="c2"
+              >
                 Show
               </span>
               <input
@@ -1079,7 +1085,9 @@ exports[`Manage Users Component Snapshot matches 1`] = `
                 type="number"
                 value="10"
               />
-              <span>
+              <span
+                class="c2"
+              >
                 Entries
               </span>
             </div>

--- a/frontend/src/features/projects/common/components/PropertyListViewSelect.tsx
+++ b/frontend/src/features/projects/common/components/PropertyListViewSelect.tsx
@@ -94,6 +94,10 @@ export const PropertyListViewSelect: React.FC<InputProps> = ({
     [project],
   );
 
+  const onPageSizeChanged = useCallback(size => {
+    setPageSize(size);
+  }, []);
+
   // const [loading, setLoading] = useState(false);
   const fetchIdRef = useRef(0);
   const fetchData = useTable({ fetchIdRef, setData, setPageCount });
@@ -155,7 +159,7 @@ export const PropertyListViewSelect: React.FC<InputProps> = ({
             name="SelectPropertiesTable"
             columns={columns}
             data={data}
-            lockPageSize
+            dropUp
             pageSize={pageSize}
             onRequestData={handleRequestData}
             pageCount={pageCount}
@@ -163,6 +167,7 @@ export const PropertyListViewSelect: React.FC<InputProps> = ({
             setSelectedRows={setSelectedProperties}
             clickableTooltip={clickableTooltip}
             onRowClick={onRowClick}
+            onPageSizeChange={onPageSizeChanged}
           />
         </div>
       )}

--- a/frontend/src/features/projects/common/components/PropertyListViewSelect.tsx
+++ b/frontend/src/features/projects/common/components/PropertyListViewSelect.tsx
@@ -159,7 +159,7 @@ export const PropertyListViewSelect: React.FC<InputProps> = ({
             name="SelectPropertiesTable"
             columns={columns}
             data={data}
-            dropUp
+            pageSizeMenuDropUp
             pageSize={pageSize}
             onRequestData={handleRequestData}
             pageCount={pageCount}

--- a/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.scss
+++ b/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.scss
@@ -47,6 +47,7 @@
   .ScrollContainer {
     padding: 1rem 0;
     overflow-x: auto;
+    overflow-y: inherit;
     table {
       background-color: #fff;
     }

--- a/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Project Approval Request list view Matches snapshot 1`] = `
+.c0 {
+  margin-top: 0.2rem;
+}
+
 <div
   class="ProjectListView container-fluid"
 >
@@ -726,7 +730,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
             <div
               style="display: flex;"
             >
-              <span>
+              <span
+                class="c0"
+              >
                 Show
               </span>
               <input
@@ -735,7 +741,9 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                 type="number"
                 value="10"
               />
-              <span>
+              <span
+                class="c0"
+              >
                 Entries
               </span>
             </div>


### PR DESCRIPTION
Originally had just implemented a **Show All** option like the story suggested; however, there was no way to get back from Show All state to reduce the list size (based off UI) so I thought it may be better to just allow them to choose from multiple options with the `PageSelector's` existing functionality in case they want to jump between sizes. 

Confirmed this was ok with Bobbi!

![PageSizeSelection](https://user-images.githubusercontent.com/15724124/107570508-79f47200-6b9e-11eb-821a-b6ad1836e272.gif)
