### PR TITLE
"Add new building": ensure form is empty

### DIFF
--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
@@ -6,7 +6,6 @@ import { ParcelPIDPIN } from './ParcelPIDPIN';
 import ParcelAttributes from './ParcelAttributes';
 import './InfoSlideOut.scss';
 import BuildingAttributes from './BuildingAttributes';
-import { ReactElement } from 'react';
 import styled from 'styled-components';
 import { ThreeColumnItem } from './ThreeColumnItem';
 import variables from '_variables.module.scss';
@@ -32,12 +31,8 @@ interface IInfoContent {
   propertyInfo: IParcel | IBuilding | null;
   /** The property type [Parcel, Building] */
   propertyTypeId: PropertyTypes | null;
-  /** ReactElement used to display a link for adding an associated building */
-  addAssociatedBuildingLink: ReactElement;
   /** whether the user has the correct agency/permissions to view all the details */
   canViewDetails: boolean;
-  /** whether the user has the correct agency/permissions to edit property details */
-  canEditDetails: boolean;
 }
 
 export const OuterRow = styled(Row)`
@@ -75,14 +70,11 @@ const getHeading = (propertyTypeId: PropertyTypes | null) => {
  * @param {IInfoContent} propertyInfo the selected property
  * @param {IInfoContent} propertyTypeId the property type [Parcel, Building]
  * @param canViewDetails user can view all property details
- * @param canEditDetails user can edit property details
  */
 export const InfoContent: React.FC<IInfoContent> = ({
   propertyInfo,
   propertyTypeId,
-  addAssociatedBuildingLink,
   canViewDetails,
-  canEditDetails,
 }) => {
   return (
     <>

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.tsx
@@ -173,7 +173,7 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
           }),
         }}
       >
-        Add a Building
+        Add a new Building
       </Link>
     </>
   );
@@ -199,9 +199,7 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
             <InfoContent
               propertyInfo={popUpContext.propertyInfo}
               propertyTypeId={popUpContext.propertyTypeID}
-              addAssociatedBuildingLink={addAssociatedBuildingLink}
               canViewDetails={canViewProperty}
-              canEditDetails={canEditProperty}
             />
           </>
         );

--- a/frontend/src/features/mapSideBar/hooks/useSideBarBuildingLoader.tsx
+++ b/frontend/src/features/mapSideBar/hooks/useSideBarBuildingLoader.tsx
@@ -42,7 +42,7 @@ const useSideBarBuildingLoader = ({
     };
     if (showSideBar && !!buildingId && buildingId !== cachedBuildingDetail?.id) {
       loadBuilding();
-    } else if (!buildingId && buildingId !== 0 && !!cachedBuildingDetail) {
+    } else if (!buildingId && !!cachedBuildingDetail) {
       setCachedBuildingDetail(null);
     }
   }, [dispatch, buildingId, disabled, showSideBar]);


### PR DESCRIPTION
- Fixes bug where clicking 'Add a building" after viewing a building loaded the old building values