### PR TITLE
PA-2115: Project status filter Fix

### DIFF
--- a/frontend/src/components/common/form/ParentSelect.tsx
+++ b/frontend/src/components/common/form/ParentSelect.tsx
@@ -146,7 +146,7 @@ export const ParentSelect: React.FC<IParentSelect> = ({
                     onClick={() =>
                       enableMultiple
                         ? handleMultiSelectHeaderClick(
-                            results.filter(x => x.parentId?.toString() === parentId),
+                            results.filter(x => x.parentId === +parentId),
                           )
                         : handleMenuHeaderClick(results.find(x => x.value === parentId)!)
                     }
@@ -154,7 +154,7 @@ export const ParentSelect: React.FC<IParentSelect> = ({
                     <b style={{ cursor: 'pointer' }}>
                       {/* project statuses has a different way of selecting parent value*/}
                       {field === 'statusId'
-                        ? results.find(x => x.parentId?.toString() === parentId)?.parent
+                        ? results.find(x => x.parentId === +parentId)?.parent
                         : results.find(x => x.value === parentId)?.label}
                     </b>
                   </Menu.Header>

--- a/frontend/src/components/common/form/ParentSelect.tsx
+++ b/frontend/src/components/common/form/ParentSelect.tsx
@@ -127,7 +127,8 @@ export const ParentSelect: React.FC<IParentSelect> = ({
         hideValidation
         required={required}
         renderMenu={(results, menuProps) => {
-          const parents = groupBy(
+          /** group the results by their desired parents */
+          const resultGroup = groupBy(
             results.map((x: SelectOption) => {
               return {
                 ...x,
@@ -136,28 +137,30 @@ export const ParentSelect: React.FC<IParentSelect> = ({
             }),
             x => x.parentId,
           );
-          const items = Object.keys(parents)
+          const items = Object.keys(resultGroup)
             .sort()
-            .map(parent => (
-              <Fragment key={parent}>
-                {!!results.find((x: SelectOption) => x.value === parent) && (
+            .map(parentId => (
+              <Fragment key={parentId}>
+                {!!results.find((x: SelectOption) => x.parentId === +parentId) && (
                   <Menu.Header
                     onClick={() =>
                       enableMultiple
                         ? handleMultiSelectHeaderClick(
-                            results.filter(x => x.parentId?.toString() === parent),
+                            results.filter(x => x.parentId?.toString() === parentId),
                           )
-                        : handleMenuHeaderClick(results.find(x => x.value === parent)!)
+                        : handleMenuHeaderClick(results.find(x => x.value === parentId)!)
                     }
                   >
                     <b style={{ cursor: 'pointer' }}>
+                      {/* project statuses has a different way of selecting parent value*/}
                       {field === 'statusId'
-                        ? results.find(x => x.parentId?.toString() === parent)?.parent
-                        : results.find(x => x.value === parent)?.label}
+                        ? results.find(x => x.parentId?.toString() === parentId)?.parent
+                        : results.find(x => x.value === parentId)?.label}
                     </b>
                   </Menu.Header>
                 )}
-                {sortBy(parents[parent], (x: SelectOption) => x.value).map((i, index) => {
+                {/* sorting results by value of the dropdown item */}
+                {sortBy(resultGroup[parentId], (x: SelectOption) => x.value).map((i, index) => {
                   if (i.parent) {
                     return (
                       <MenuItem key={index + 1} option={i} position={index + 1}>


### PR DESCRIPTION
So there was a line tucked away that was checking the value of the status against the `parentId` instead of the value of the item's parent. It just happened to work still because those values shared the same number id's as the parent. But caused that weird bug we were seeing before. The headers will now correctly stay in place.

Highlights the readability issues of this component, not a huge fan of my implementation. Adjusted some variable names to try and be more clear.

![statuses](https://user-images.githubusercontent.com/15724124/107827442-ac87a180-6d3b-11eb-900d-375a17577ec1.gif)

