### PR TITLE
Fixt slide out bug

### DIFF
--- a/frontend/src/components/maps/leaflet/InfoSlideOut/AssociatedBuildingsList.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/AssociatedBuildingsList.tsx
@@ -35,7 +35,7 @@ export const AssociatedBuildingsList: React.FC<IAssociatedBuildings> = ({
           Associated Buildings
         </Label>
         <ListGroup.Item>Click a building name to view its details</ListGroup.Item>
-        {propertyInfo?.buildings.map((building, buildingId) => (
+        {propertyInfo?.buildings?.map((building, buildingId) => (
           <ListGroup.Item key={buildingId}>
             <Link
               className="styled-link"

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.tsx
@@ -152,9 +152,9 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
   });
 
   //whether the associated buildings info is open
-  const [buildingsOpen, setBuildingsOpen] = React.useState<boolean>(false);
-  //whether the general parcel info is open
-  const [parcelInfoOpen, setParcelInfoOpen] = React.useState<boolean>(true);
+  const [asscBuildingsOpen, setAsscBuildingsOpen] = React.useState<boolean>(false);
+  //whether the general info is open
+  const [generalInfoOpen, setGeneralInfoOpen] = React.useState<boolean>(true);
 
   const addAssociatedBuildingLink = (
     <>
@@ -185,7 +185,7 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
 
   const renderContent = () => {
     if (popUpContext.propertyInfo) {
-      if (parcelInfoOpen) {
+      if (generalInfoOpen || popUpContext.propertyTypeID === PropertyTypes.BUILDING) {
         return (
           <>
             <HeaderActions
@@ -204,7 +204,11 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
             />
           </>
         );
-      } else if (buildingsOpen && canViewProperty) {
+      } else if (
+        asscBuildingsOpen &&
+        canViewProperty &&
+        popUpContext.propertyTypeID === PropertyTypes.PARCEL
+      ) {
         return (
           <AssociatedBuildingsList
             propertyInfo={popUpContext.propertyInfo as IParcel}
@@ -237,11 +241,11 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
             onClick={() => {
               if (!open) {
                 setOpen(true);
-                setParcelInfoOpen(true);
-                setBuildingsOpen(false);
-              } else if (open && !parcelInfoOpen) {
-                setParcelInfoOpen(true);
-                setBuildingsOpen(false);
+                setGeneralInfoOpen(true);
+                setAsscBuildingsOpen(false);
+              } else if (open && !generalInfoOpen) {
+                setGeneralInfoOpen(true);
+                setAsscBuildingsOpen(false);
               } else {
                 setOpen(false); //close the slide out
               }
@@ -261,8 +265,8 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
                 variant="outline-secondary"
                 className={clsx({ open })}
                 onClick={() => {
-                  setBuildingsOpen(true);
-                  setParcelInfoOpen(false);
+                  setAsscBuildingsOpen(true);
+                  setGeneralInfoOpen(false);
                 }}
               >
                 <BuildingSvg className="svg" />


### PR DESCRIPTION
Basically the problem was that if you had the associated buildings list open and then clicked a building pin, it would try to open a non-existent list of buildings for that building.
This is just a small/temporary fix, next sprint I have a story to add an associated land tab so I'll need to rethink some of the logic anyways

https://user-images.githubusercontent.com/33818575/107837521-07c68d80-6d56-11eb-87d2-295b939b054d.mp4

