### PR TITLE
PA-2528: Export additional fields for SRES

### DIFF
--- a/backend/api/Areas/Reports/Controllers/PropertyController.cs
+++ b/backend/api/Areas/Reports/Controllers/PropertyController.cs
@@ -2,7 +2,6 @@ using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
-using Pims.Api.Areas.Reports.Models.Property;
 using Pims.Api.Helpers.Constants;
 using Pims.Api.Helpers.Exceptions;
 using Pims.Api.Helpers.Extensions;
@@ -67,24 +66,6 @@ namespace Pims.Api.Areas.Reports.Controllers
         }
 
         /// <summary>
-        /// Exports properties with all fields as an Excel file, only available for SRES
-        /// Include 'Accept' header to request the appropriate export
-        /// </summary>
-        /// <param name="all"></param>
-        /// <returns></returns>
-        [HttpGet("allfields")]
-        [HasPermission(Permissions.AdminProperties)]
-        [Produces(ContentTypes.CONTENT_TYPE_EXCELX)]
-        [ProducesResponseType(200)]
-        [SwaggerOperation(Tags = new[] { "property", "report" })]
-        public IActionResult ExportPropertiesAllFields(bool all = false)
-        {
-            var uri = new Uri(this.Request.GetDisplayUrl());
-            var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
-            return ExportPropertiesAllFields(new Property.Models.Search.PropertyFilterModel(query), all);
-        }
-
-        /// <summary>
         /// Exports properties as CSV or Excel file.
         /// Include 'Accept' header to request the appropriate export -
         ///     ["text/csv", "application/application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"]
@@ -117,6 +98,26 @@ namespace Pims.Api.Areas.Reports.Controllers
             };
 
         }
+
+        #region Return All Properties
+        /// <summary>
+        /// Exports properties with all fields as an Excel file, only available for SRES
+        /// Include 'Accept' header to request the appropriate export
+        /// </summary>
+        /// <param name="all"></param>
+        /// <returns></returns>
+        [HttpGet("all/fields")]
+        [HasPermission(Permissions.AdminProperties)]
+        [Produces(ContentTypes.CONTENT_TYPE_EXCELX)]
+        [ProducesResponseType(200)]
+        [SwaggerOperation(Tags = new[] { "property", "report" })]
+        public IActionResult ExportPropertiesAllFields(bool all = false)
+        {
+            var uri = new Uri(this.Request.GetDisplayUrl());
+            var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+            return ExportPropertiesAllFields(new Property.Models.Search.PropertyFilterModel(query), all);
+        }
+
         /// <summary>
         /// Exports properties as Excel file. Has more fields than default export.
         /// Only available for SRES
@@ -125,8 +126,8 @@ namespace Pims.Api.Areas.Reports.Controllers
         /// <param name="filter"></param>
         /// <param name="all"></param>
         /// <returns></returns>
-        [HttpPost("filter/allfields")]
-        [HasPermission(Permissions.AdminProjects)]
+        [HttpPost("all/fields/filter")]
+        [HasPermission(Permissions.AdminProperties)]
         [Produces(ContentTypes.CONTENT_TYPE_EXCELX)]
         [ProducesResponseType(200)]
         [SwaggerOperation(Tags = new[] { "property", "report" })]
@@ -145,6 +146,7 @@ namespace Pims.Api.Areas.Reports.Controllers
 
             return ReportHelper.GenerateExcel(report.Items, "PIMS");
         }
+        #endregion
         #endregion
         #endregion
     }

--- a/backend/api/Areas/Reports/Controllers/PropertyController.cs
+++ b/backend/api/Areas/Reports/Controllers/PropertyController.cs
@@ -67,8 +67,26 @@ namespace Pims.Api.Areas.Reports.Controllers
         }
 
         /// <summary>
+        /// Exports properties with all fields as an Excel file, only available for SRES
+        /// Include 'Accept' header to request the appropriate export
+        /// </summary>
+        /// <param name="all"></param>
+        /// <returns></returns>
+        [HttpGet("allfields")]
+        [HasPermission(Permissions.AdminProperties)]
+        [Produces(ContentTypes.CONTENT_TYPE_EXCELX)]
+        [ProducesResponseType(200)]
+        [SwaggerOperation(Tags = new[] { "property", "report" })]
+        public IActionResult ExportPropertiesAllFields(bool all = false)
+        {
+            var uri = new Uri(this.Request.GetDisplayUrl());
+            var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+            return ExportPropertiesAllFields(new Property.Models.Search.PropertyFilterModel(query), all);
+        }
+
+        /// <summary>
         /// Exports properties as CSV or Excel file.
-        /// Include 'Accept' header to request the appropriate expor -
+        /// Include 'Accept' header to request the appropriate export -
         ///     ["text/csv", "application/application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"]
         /// </summary>
         /// <param name="filter"></param>
@@ -98,6 +116,34 @@ namespace Pims.Api.Areas.Reports.Controllers
                 _ => ReportHelper.GenerateExcel(report.Items, "PIMS")
             };
 
+        }
+        /// <summary>
+        /// Exports properties as Excel file. Has more fields than default export.
+        /// Only available for SRES
+        /// Include 'Accept' header to request the appropriate expor
+        /// </summary>
+        /// <param name="filter"></param>
+        /// <param name="all"></param>
+        /// <returns></returns>
+        [HttpPost("filter/allfields")]
+        [HasPermission(Permissions.AdminProjects)]
+        [Produces(ContentTypes.CONTENT_TYPE_EXCELX)]
+        [ProducesResponseType(200)]
+        [SwaggerOperation(Tags = new[] { "property", "report" })]
+        public IActionResult ExportPropertiesAllFields([FromBody] Property.Models.Search.PropertyFilterModel filter, bool all = true)
+        {
+            filter.ThrowBadRequestIfNull($"The request must include a filter.");
+            if (!filter.IsValid()) throw new BadRequestException("Property filter must contain valid values.");
+            var accept = (string)this.Request.Headers["Accept"] ?? throw new BadRequestException($"HTTP request header 'Accept' is required.");
+
+            if (accept != ContentTypes.CONTENT_TYPE_EXCEL && accept != ContentTypes.CONTENT_TYPE_EXCELX)
+                throw new BadRequestException($"Invalid HTTP request header 'Accept:{accept}'.");
+
+            filter.Quantity = all ? _pimsService.Property.Count() : filter.Quantity;
+            var page = _pimsService.Property.GetPage((AllPropertyFilter)filter);
+            var report = _mapper.Map<Api.Models.PageModel<Models.AllPropertyFields.AllFieldsPropertyModel>>(page);
+
+            return ReportHelper.GenerateExcel(report.Items, "PIMS");
         }
         #endregion
         #endregion

--- a/backend/api/Areas/Reports/Mapping/Property/AllFieldsPropertyMap.cs
+++ b/backend/api/Areas/Reports/Mapping/Property/AllFieldsPropertyMap.cs
@@ -1,0 +1,55 @@
+using Mapster;
+using Entity = Pims.Dal.Entities;
+using Model = Pims.Api.Areas.Reports.Models.AllPropertyFields;
+
+namespace Pims.Api.Areas.Reports.Mapping.AllPropertyFields
+{
+    public class AllFieldsPropertyMap : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<Entity.Views.Property, Model.AllFieldsPropertyModel>()
+                .Map(dest => dest.Type, src => src.PropertyTypeId)
+                .Map(dest => dest.ProjectNumbers, src => src.ProjectNumbers)
+                .Map(dest => dest.Classification, src => src.Classification)
+                .Map(dest => dest.Name, src => src.Name)
+                .Map(dest => dest.Description, src => src.Description)
+                .Map(dest => dest.Agency, src => src.Agency)
+                .Map(dest => dest.AgencyCode, src => src.AgencyCode)
+                .Map(dest => dest.SubAgency, src => src.SubAgency)
+                .Map(dest => dest.SubAgencyCode, src => src.SubAgencyCode)
+                .Map(dest => dest.Address, src => src.Address)
+                .Map(dest => dest.Province, src => src.Province)
+                .Map(dest => dest.AdministrativeArea, src => src.AdministrativeArea)
+                .Map(dest => dest.Postal, src => src.Postal)
+                .Map(dest => dest.Latitude, src => src.Location.Y)
+                .Map(dest => dest.Longitude, src => src.Location.X)
+                .Map(dest => dest.IsSensitive, src => src.IsSensitive)
+                .Map(dest => dest.IsVisibleToOtherAgencies, src => src.IsVisibleToOtherAgencies)
+
+                .Map(dest => dest.Market, src => src.Market)
+                .Map(dest => dest.MarketFiscalYear, src => src.MarketFiscalYear)
+                .Map(dest => dest.AssessedLand, src => src.AssessedLand)
+                .Map(dest => dest.AssessedLandDate, src => src.AssessedLandDate)
+                .Map(dest => dest.AssessedBuilding, src => src.AssessedBuilding)
+                .Map(dest => dest.AssessedBuildingDate, src => src.AssessedBuildingDate)
+                .Map(dest => dest.NetBook, src => src.NetBook)
+                .Map(dest => dest.NetBookFiscalYear, src => src.NetBookFiscalYear)
+
+                .Map(dest => dest.PID, src => src.ParcelIdentity)
+                .Map(dest => dest.PIN, src => src.PIN)
+                .Map(dest => dest.LandArea, src => src.LandArea)
+                .Map(dest => dest.LandLegalDescription, src => src.LandLegalDescription)
+                .Map(dest => dest.Zoning, src => src.Zoning)
+
+                .Map(dest => dest.BuildingConstructionType, src => src.BuildingConstructionType)
+                .Map(dest => dest.BuildingPredominateUse, src => src.BuildingPredominateUse)
+                .Map(dest => dest.BuildingOccupantType, src => src.BuildingOccupantType)
+                .Map(dest => dest.BuildingTenancy, src => src.BuildingTenancy)
+                .Map(dest => dest.RentableArea, src => src.RentableArea)
+                .Map(dest => dest.OccupantName, src => src.OccupantName)
+                .Map(dest => dest.LeaseExpiry, src => src.LeaseExpiry)
+                .Map(dest => dest.TransferLeaseOnSale, src => src.TransferLeaseOnSale);
+        }
+    }
+}

--- a/backend/api/Areas/Reports/Models/Property/AllFieldsPropertyModel.cs
+++ b/backend/api/Areas/Reports/Models/Property/AllFieldsPropertyModel.cs
@@ -1,0 +1,277 @@
+using Pims.Dal.Entities;
+using System;
+using System.ComponentModel;
+
+namespace Pims.Api.Areas.Reports.Models.AllPropertyFields
+{
+    public class AllFieldsPropertyModel
+    {
+        #region Properties
+        /// <summary>
+        /// get/set - The type of property [Land, Building].
+        /// </summary>
+        /// <value></value>
+        public PropertyTypes Type { get; set; }
+
+        /// <summary>
+        /// get/set - The status of the property.
+        /// </summary>
+        public string Status { get; set; }
+
+        /// <summary>
+        /// get/set - The project number
+        /// </summary>
+        [DisplayName("Project Number")]
+        [CsvHelper.Configuration.Attributes.Name("Project Number")]
+        public string ProjectNumbers { get; set; }
+
+        /// <summary>
+        /// get/set - The current classification.
+        /// </summary>
+        public string Classification { get; set; }
+
+        /// <summary>
+        /// get/set - The name of the property.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// get/set - A description of the property.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// get/set - The owning agency full name.
+        /// </summary>
+        public string Agency { get; set; }
+
+        /// <summary>
+        /// get/set - The owning agency code.
+        /// </summary>
+        [DisplayName("Agency Code")]
+        [CsvHelper.Configuration.Attributes.Name("Agency Code")]
+        public string AgencyCode { get; set; }
+
+        /// <summary>
+        /// get/set - The sub-agency full name.
+        /// </summary>
+        [DisplayName("Sub Agency")]
+        [CsvHelper.Configuration.Attributes.Name("Sub Agency")]
+        public string SubAgency { get; set; }
+
+        /// <summary>
+        /// get/set - The sub-agency code.
+        /// </summary>
+        [DisplayName("Sub Agency Code")]
+        [CsvHelper.Configuration.Attributes.Name("Sub Agency Code")]
+        public string SubAgencyCode { get; set; }
+
+        /// <summary>
+        /// get/set - The civic address of the property.
+        /// </summary>
+        public string Address { get; set; }
+
+        /// <summary>
+        /// get/set - The location of the property (city, municipality, district, etc)
+        /// </summary>
+        [DisplayName("Location")]
+        [CsvHelper.Configuration.Attributes.Name("Location")]
+        public string AdministrativeArea { get; set; }
+
+        /// <summary>
+        /// get/set - The province of the property
+        /// </summary>
+        public string Province { get; set; }
+
+        /// <summary>
+        /// get/set - The postal code.
+        /// </summary>
+        public string Postal { get; set; }
+
+        /// <summary>
+        /// get/set - The latitude location.
+        /// </summary>
+        public double Latitude { get; set; }
+
+        /// <summary>
+        /// get/set - The longitude location.
+        /// </summary>
+        public double Longitude { get; set; }
+
+        /// <summary>
+        /// get/set - Whether the property is sensitive.
+        /// </summary>
+        [DisplayName("Sensitive")]
+        [CsvHelper.Configuration.Attributes.Name("Sensitive")]
+        public bool IsSensitive { get; set; }
+
+        /// <summary>
+        /// get/set - Whether the property is visible to other agencies outside the owning one.
+        /// </summary>
+        [DisplayName("Visible to Other Agencies")]
+        [CsvHelper.Configuration.Attributes.Name("Visible to Other Agencies")]
+        public bool IsVisibleToOtherAgencies { get; set; }
+
+        #region Financials
+        /// <summary>
+        /// get/set - The most recent assessed land value.
+        /// </summary>
+        [DisplayName("Assessed Land Value")]
+        [CsvHelper.Configuration.Attributes.Name("Assessed Land Value")]
+        public decimal? AssessedLand { get; set; }
+
+        /// <summary>
+        /// get/set - When the most recent assessment was taken.
+        /// </summary>
+        [DisplayName("Assessed Land Date")]
+        [CsvHelper.Configuration.Attributes.Name("Assessed Land Date")]
+        public DateTime? AssessedLandDate { get; set; }
+
+        /// <summary>
+        /// get/set - The most recent assessed building value.
+        /// </summary>
+        [DisplayName("Assessed Building Value")]
+        [CsvHelper.Configuration.Attributes.Name("Assessed Building Value")]
+        public decimal? AssessedBuilding { get; set; }
+
+        /// <summary>
+        /// get/set - When the most recent assessment was taken.
+        /// </summary>
+        [DisplayName("Assessed Building Date")]
+        [CsvHelper.Configuration.Attributes.Name("Assessed Building Date")]
+        public DateTime? AssessedBuildingDate { get; set; }
+
+        /// <summary>
+        /// get/set - The most recent market value.
+        /// </summary>
+        [DisplayName("Market Value")]
+        [CsvHelper.Configuration.Attributes.Name("Market Value")]
+        public decimal Market { get; set; }
+
+        /// <summary>
+        /// get/set - The fiscal year for the market value.
+        /// </summary>
+        [DisplayName("Market Fiscal Year")]
+        [CsvHelper.Configuration.Attributes.Name("Market Fiscal Year")]
+        public int? MarketFiscalYear { get; set; }
+
+        /// <summary>
+        /// get/set - The most recent netbook value.
+        /// </summary>
+        [DisplayName("Net Book Value")]
+        [CsvHelper.Configuration.Attributes.Name("Net Book Value")]
+        public decimal? NetBook { get; set; }
+
+        /// <summary>
+        /// get/set - The fiscal year netbook value.
+        /// </summary>
+        [DisplayName("Net Book Fiscal Year")]
+        [CsvHelper.Configuration.Attributes.Name("Net Book Fiscal Year")]
+        public int? NetBookFiscalYear { get; set; }
+        #endregion
+
+        #region Parcel Properties
+        /// <summary>
+        /// get/set - The parcel PID.
+        /// </summary>
+        public string PID { get; set; }
+
+        /// <summary>
+        /// get/set - The PIN if the parcel is not titled.
+        /// </summary>
+        public int? PIN { get; set; }
+
+        /// <summary>
+        /// get/set - The land area.
+        /// </summary>
+        [DisplayName("Land Area")]
+        [CsvHelper.Configuration.Attributes.Name("Land Area")]
+        public float LandArea { get; set; }
+
+        /// <summary>
+        /// get/set - The land legal description.
+        /// </summary>
+        [DisplayName("Legal Description")]
+        [CsvHelper.Configuration.Attributes.Name("Legal Description")]
+        public string LandLegalDescription { get; set; }
+
+        /// <summary>
+        /// get/set - The current zoning.
+        /// </summary>
+        public string Zoning { get; set; }
+
+        /// <summary>
+        /// get/set - Potential future Parcel zoning information
+        /// </summary>
+        [DisplayName("Zoning Potential")]
+        [CsvHelper.Configuration.Attributes.Name("Zoning Potential")]
+        public string ZoningPotential { get; set; }
+        #endregion
+
+        #region Building Properties
+        /// <summary>
+        /// get/set - The building construction type.
+        /// </summary>
+        [DisplayName("Construction Type")]
+        [CsvHelper.Configuration.Attributes.Name("Construction Type")]
+        public string BuildingConstructionType { get; set; }
+
+        /// <summary>
+        /// get/set - The parent parcel Id.
+        /// </summary>
+        [DisplayName("Parcel Id")]
+        [CsvHelper.Configuration.Attributes.Name("Parcel Id")]
+        public int? ParcelId { get; set; }
+
+        /// <summary>
+        /// get/set - The building predominate use.
+        /// </summary>
+        [DisplayName("Predominate Use")]
+        [CsvHelper.Configuration.Attributes.Name("Predominate Use")]
+        public string BuildingPredominateUse { get; set; }
+
+        /// <summary>
+        /// get/set - The building occupant type.
+        /// </summary>
+        [DisplayName("Occupant Type")]
+        [CsvHelper.Configuration.Attributes.Name("Occupant Type")]
+        public string BuildingOccupantType { get; set; }
+
+        /// <summary>
+        /// get/set - The building tenancy.
+        /// </summary>
+        [DisplayName("Tenancy")]
+        [CsvHelper.Configuration.Attributes.Name("Tenancy")]
+        public string BuildingTenancy { get; set; }
+
+        /// <summary>
+        /// get/set - The building rentable area.
+        /// </summary>
+        [DisplayName("Rentable Area")]
+        [CsvHelper.Configuration.Attributes.Name("Rentable Area")]
+        public float RentableArea { get; set; }
+
+        /// <summary>
+        /// get/set - The building occupant name.
+        /// </summary>
+        [DisplayName("Occupant")]
+        [CsvHelper.Configuration.Attributes.Name("Occupant")]
+        public string OccupantName { get; set; }
+
+        /// <summary>
+        /// get/set - The building lease expiry date.
+        /// </summary>
+        [DisplayName("Lease Expiry")]
+        [CsvHelper.Configuration.Attributes.Name("Lease Expiry")]
+        public DateTime? LeaseExpiry { get; set; }
+
+        /// <summary>
+        /// get/set - Whether the lease on the building will transfer on sale.
+        /// </summary>
+        [DisplayName("Transfer Lease on Sale")]
+        [CsvHelper.Configuration.Attributes.Name("Transfer Lease on Sale")]
+        public bool TransferLeaseOnSale { get; set; }
+        #endregion
+        #endregion
+    }
+}

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -47,7 +47,7 @@ const getPropertyReportUrl = (filter: IPropertyQueryParams) =>
   `${ENVIRONMENT.apiUrl}/reports/properties?${filter ? queryString.stringify(filter) : ''}`;
 
 const getAllFieldsPropertyReportUrl = (filter: IPropertyQueryParams) =>
-  `${ENVIRONMENT.apiUrl}/reports/properties/allfields?${
+  `${ENVIRONMENT.apiUrl}/reports/properties/all/fields?${
     filter ? queryString.stringify(filter) : ''
   }`;
 


### PR DESCRIPTION
New export button and report for SRES/SRES Financial Manager. This report contains some additional fields that the basic report does not.

Few things to note: 

- The story asked for all information we had, I did not include the numeric values for classifications etc as I assumed this was not desired. Please correct me otherwise!
- I believe I have pulled in all relevant fields outside of what I mentioned above - hard to confirm as I did not have a list to reference other than the property entity itself (did my best to choose what is relevant). So if one looks like it's missing let me know

![exportall](https://user-images.githubusercontent.com/15724124/107845215-cc948080-6d8e-11eb-940a-1a5a3a5df6fe.gif)
