### PR TITLE
Delete project bug fix

### DIFF
--- a/backend/dal/Services/Concrete/ProjectService.cs
+++ b/backend/dal/Services/Concrete/ProjectService.cs
@@ -570,7 +570,7 @@ namespace Pims.Dal.Services
                 .Include(p => p.Workflow)
                 .SingleOrDefault(p => p.Id == project.Id) ?? throw new KeyNotFoundException();
 
-            if (!project.IsProjectInDraft(_options.Project))
+            if (!originalProject.IsProjectInDraft(_options.Project))
             {
                 this.ThrowIfNotAllowedToUpdate(originalProject, _options.Project);
             }


### PR DESCRIPTION
Always seems to be one liners...

`project` does not have workflow in its context while `originalProject` does. This caused `IsProjectInDraft` to throw a null workflow error everytime
