### PR TITLE
Delete Project Adjustments

### DIFF
--- a/backend/dal/Helpers/Extensions/ProjectExtensions.cs
+++ b/backend/dal/Helpers/Extensions/ProjectExtensions.cs
@@ -43,6 +43,7 @@ namespace Pims.Dal.Helpers.Extensions
                 .Include(p => p.TierLevel)
                 .Include(p => p.Risk)
                 .Include(p => p.Agency)
+                .Include(p => p.Workflow)
                 .Include(p => p.Agency).ThenInclude(a => a.Parent)
                 .Include(p => p.Notes)
                 .AsNoTracking();

--- a/frontend/src/constants/workflows.ts
+++ b/frontend/src/constants/workflows.ts
@@ -6,4 +6,6 @@ export enum Workflows {
   SPL = 'SPL',
   /** The Disposed externally workflow */
   ASSESS_EX_DISPOSAL = 'ASSESS-EX-DISPOSAL',
+  /** The draft workflow */
+  SUBMIT_DISPOSAL = 'SUBMIT-DISPOSAL',
 }

--- a/frontend/src/features/projects/list/ProjectListView.tsx
+++ b/frontend/src/features/projects/list/ProjectListView.tsx
@@ -222,6 +222,7 @@ const ProjectListView: React.FC<IProps> = ({ filterable, title, mode }) => {
       project.status = projectStatuses.find((x: any) => x.name === project.status)!;
       await service.deleteProject(project);
       setData(data?.filter(p => p.projectNumber !== project.projectNumber));
+      setDeleteId(undefined);
     }
   };
 

--- a/frontend/src/features/projects/list/columns.tsx
+++ b/frontend/src/features/projects/list/columns.tsx
@@ -4,6 +4,7 @@ import { formatDate, formatMoney } from 'utils';
 import { IProject } from '.';
 import { ColumnWithProps } from 'components/Table';
 import { FaTrash } from 'react-icons/fa';
+import { Workflows } from 'constants/workflows';
 // NOTE - There numbers below match the total number of columns ATM (13)
 // If additional columns are added or deleted, these numbers need tp be updated...
 const howManyColumns = 13;
@@ -41,7 +42,7 @@ export const columns = (
           <div>
             {/* delete icon will be shown only if the project is still in draft and they have the edit claim, or an admin claim, or they created the project */}
             {!!onDelete &&
-              props.row.original.workflowCode === 'SUBMIT-DISPOSAL' &&
+              props.row.original.workflowCode === Workflows.SUBMIT_DISPOSAL &&
               (projectEditClaim || isAdmin || user === props.row.original.createdBy) && (
                 <FaTrash
                   style={{ marginRight: 10, cursor: 'pointer' }}

--- a/frontend/src/features/projects/list/columns.tsx
+++ b/frontend/src/features/projects/list/columns.tsx
@@ -39,12 +39,10 @@ export const columns = (
       Cell: (props: CellProps<IProject>) => {
         return (
           <div>
-            {/* delete button is visible when on delete button function is passed, if it is in draft and they have the edit claim, they are an admin, or it is their project before submission */}
+            {/* delete icon will be shown only if the project is still in draft and they have the edit claim, or an admin claim, or they created the project */}
             {!!onDelete &&
-              ((projectEditClaim && props.row.original.projectNumber.includes('DRAFT')) ||
-                isAdmin ||
-                (user === props.row.original.updatedBy &&
-                  props.row.original.projectNumber.includes('DRAFT'))) && (
+              props.row.original.workflowCode === 'SUBMIT-DISPOSAL' &&
+              (projectEditClaim || isAdmin || user === props.row.original.createdBy) && (
                 <FaTrash
                   style={{ marginRight: 10, cursor: 'pointer' }}
                   onClick={(e: any) => {

--- a/frontend/src/features/projects/list/interfaces.ts
+++ b/frontend/src/features/projects/list/interfaces.ts
@@ -27,6 +27,7 @@ export interface IProject {
   createdBy: string;
   netBook: number;
   market: number;
+  workflowCode: string;
   zoning: string;
   zoningPotential: string;
 }


### PR DESCRIPTION
Only projects that are still in the `SUBMIT-DISPOSAL` workflow can be deleted. The delete icon will appear next to a project if that condition is satisfied AND the user 

- has a `project-edit` claim
- or an `admin-projects` claim
- or they created that project