### PR TITLE
Logic fix for filter changed

### DIFF
--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -237,11 +237,7 @@ const Map: React.FC<MapProps> = ({
   const handleMapFilterChange = async (filter: IPropertyFilter) => {
     const compareValues = (objValue: any, othValue: any) => {
       return whitelistedFilterKeys.reduce((acc, key) => {
-        return (
-          (isEqual(objValue[key], othValue[key]) ||
-            (isEmpty(objValue[key]) && isEmpty(othValue[key]))) &&
-          acc
-        );
+        return (isEqual(objValue[key], othValue[key]) || (!objValue[key] && !othValue[key])) && acc;
       }, true);
     };
     if (!isEqualWith(geoFilter, filter, compareValues)) {


### PR DESCRIPTION
`isEmpty(true)` returns `true` which caused an issue for when we set our filter changed state. The issue would occur when either the ERP or SPL checkbox was checked as even if the first half of code resulted in them not being equal, the second half would evaluate to true even though they are not "empty". i.e) `isEmpty(true) && isEmpty(undefined)` evaluates to true