### PR TITLE
PA-2707 Fixed Property Classifications

### DIFF
--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -61,7 +61,6 @@ export type MapProps = {
   zoom?: number;
   properties: IProperty[];
   agencies: ILookupCode[];
-  propertyClassifications: ILookupCode[];
   administrativeAreas: ILookupCode[];
   lotSizes: number[];
   mapRef: React.RefObject<ReactLeafletMap<LeafletMapProps, LeafletMap>>;
@@ -161,7 +160,6 @@ const Map: React.FC<MapProps> = ({
   lng,
   zoom: zoomProp,
   agencies,
-  propertyClassifications,
   administrativeAreas,
   lotSizes,
   selectedProperty,
@@ -339,7 +337,6 @@ const Map: React.FC<MapProps> = ({
                     }}
                     agencyLookupCodes={agencies}
                     adminAreaLookupCodes={administrativeAreas}
-                    propertyClassifications={propertyClassifications}
                     onChange={handleMapFilterChange}
                     showAllAgencySelect={true}
                   />

--- a/frontend/src/constants/propertyTypeNames.ts
+++ b/frontend/src/constants/propertyTypeNames.ts
@@ -1,7 +1,9 @@
-/** Property type enum */
+/** Property type name enum */
 export enum PropertyTypeNames {
   /** The property is land. */
   Land = 'Land',
   /** The property is a building. */
   Building = 'Building',
+  /** The property is a subdivision. */
+  Subdivision = 'Subdivision',
 }

--- a/frontend/src/features/mapSideBar/SidebarContents/AssociatedLandForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/AssociatedLandForm.tsx
@@ -193,9 +193,9 @@ const Form: React.FC<IAssociatedLandForm> = ({
   const formikProps = useFormikContext<ISteppedFormValues<IAssociatedLand>>();
 
   // lookup codes that will be used by subforms
-  const { getOptionsByType } = useCodeLookups();
+  const { getOptionsByType, getPropertyClassificationOptions } = useCodeLookups();
   const agencies = getOptionsByType(API.AGENCY_CODE_SET_NAME);
-  const classifications = getOptionsByType(API.PROPERTY_CLASSIFICATION_CODE_SET_NAME);
+  const classifications = getPropertyClassificationOptions();
   const currentParcelNameSpace = `data.parcels.${stepper.currentTab}`;
   useDraftMarkerSynchronizer(`data.parcels.${stepper.currentTab}`);
   useParcelLayerData({

--- a/frontend/src/features/mapSideBar/SidebarContents/BuildingForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/BuildingForm.tsx
@@ -143,11 +143,11 @@ const Form: React.FC<IBuildingForm> = ({
       ? +(formikProps.values.data.agencyId as any).value
       : +formikProps.values.data.agencyId,
   });
-  const { getOptionsByType } = useCodeLookups();
+  const { getOptionsByType, getPropertyClassificationOptions } = useCodeLookups();
   const isViewOrUpdate = !!formikProps.values?.data?.id;
 
   const agencies = getOptionsByType(API.AGENCY_CODE_SET_NAME);
-  const classifications = getOptionsByType(API.PROPERTY_CLASSIFICATION_CODE_SET_NAME);
+  const classifications = getPropertyClassificationOptions();
   const predominateUses = getOptionsByType(API.PREDOMINATE_USE_CODE_SET_NAME);
   const constructionType = getOptionsByType(API.CONSTRUCTION_CODE_SET_NAME);
   const occupancyType = getOptionsByType(API.OCCUPANT_TYPE_CODE_SET_NAME);

--- a/frontend/src/features/mapSideBar/SidebarContents/LandForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/LandForm.tsx
@@ -166,9 +166,9 @@ const Form: React.FC<ILandForm> = ({
   const isViewOrUpdate = !!initialValues.id;
 
   // lookup codes that will be used by subforms
-  const { getOptionsByType } = useCodeLookups();
+  const { getOptionsByType, getPropertyClassificationOptions } = useCodeLookups();
   const agencies = getOptionsByType(API.AGENCY_CODE_SET_NAME);
-  const classifications = getOptionsByType(API.PROPERTY_CLASSIFICATION_CODE_SET_NAME);
+  const classifications = getPropertyClassificationOptions();
   useDraftMarkerSynchronizer('data');
 
   const render = (): React.ReactNode => {

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.test.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.test.tsx
@@ -1,16 +1,102 @@
 import React from 'react';
-import { ClassificationForm } from './ClassificationForm';
 import renderer from 'react-test-renderer';
-import { Formik } from 'formik';
-import { Classifications } from 'constants/classifications';
 import { cleanup, fireEvent, render, wait } from '@testing-library/react';
+import { Formik } from 'formik';
 import { noop } from 'lodash';
+import axios from 'axios';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { useKeycloak } from '@react-keycloak/web';
+import { ClassificationForm } from './ClassificationForm';
+import { Classifications } from 'constants/classifications';
+import { SelectOption, SelectOptions } from 'components/common/form';
+import * as API from 'constants/API';
+import * as reducerTypes from 'constants/reducerTypes';
+import { ILookupCode } from 'actions/lookupActions';
 
+jest.mock('axios');
+jest.mock('@react-keycloak/web');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 const mockClassifications = [
-  { value: Classifications.CoreOperational, label: 'Core Operational' },
-  { value: Classifications.CoreStrategic, label: 'Core Strategic' },
-  { value: Classifications.SurplusEncumbered, label: 'Surplus Encumbered' },
-];
+  { value: Classifications.CoreOperational, label: 'Core Operational' } as SelectOption,
+  { value: Classifications.CoreStrategic, label: 'Core Strategic' } as SelectOption,
+  { value: Classifications.SurplusEncumbered, label: 'Surplus Encumbered' } as SelectOption,
+] as SelectOptions;
+
+const mockKeycloak = (claims: string[]) => {
+  (useKeycloak as jest.Mock).mockReturnValue({
+    keycloak: {
+      subject: 'test',
+      userInfo: {
+        roles: claims,
+        agencies: ['1'],
+      },
+    },
+  });
+};
+const mockStore = configureMockStore([thunk]);
+let history = createMemoryHistory();
+
+const lCodes = {
+  lookupCodes: [
+    { name: 'agencyVal', id: '1', isDisabled: false, type: API.AGENCY_CODE_SET_NAME },
+    { name: 'disabledAgency', id: '2', isDisabled: true, type: API.AGENCY_CODE_SET_NAME },
+    { name: 'roleVal', id: '1', isDisabled: false, type: API.ROLE_CODE_SET_NAME },
+    { name: 'disabledRole', id: '2', isDisabled: true, type: API.ROLE_CODE_SET_NAME },
+    {
+      name: 'Core Operational',
+      id: '0',
+      isDisabled: false,
+      type: API.PROPERTY_CLASSIFICATION_CODE_SET_NAME,
+    },
+    {
+      name: 'Core Strategic',
+      id: '1',
+      isDisabled: false,
+      type: API.PROPERTY_CLASSIFICATION_CODE_SET_NAME,
+    },
+    {
+      name: 'Surplus Active',
+      id: '2',
+      isDisabled: false,
+      type: API.PROPERTY_CLASSIFICATION_CODE_SET_NAME,
+    },
+    {
+      name: 'Surplus Encumbered',
+      id: '3',
+      isDisabled: false,
+      type: API.PROPERTY_CLASSIFICATION_CODE_SET_NAME,
+    },
+    {
+      name: 'Disposed',
+      id: '4',
+      isDisabled: false,
+      type: API.PROPERTY_CLASSIFICATION_CODE_SET_NAME,
+    },
+    {
+      name: 'Demolished',
+      id: '5',
+      isDisabled: false,
+      type: API.PROPERTY_CLASSIFICATION_CODE_SET_NAME,
+    },
+    {
+      name: 'Subdivided',
+      id: '6',
+      isDisabled: false,
+      type: API.PROPERTY_CLASSIFICATION_CODE_SET_NAME,
+    },
+  ] as ILookupCode[],
+};
+
+const getStore = () =>
+  mockStore({
+    [reducerTypes.PROPERTY_NAMES]: ['test'],
+    [reducerTypes.LOOKUP_CODE]: lCodes,
+  });
 
 it('renders correctly', () => {
   const tree = renderer.create(form).toJSON();
@@ -18,12 +104,25 @@ it('renders correctly', () => {
 });
 
 const form = (
-  <Formik onSubmit={noop} initialValues={{ classificationId: '' }}>
-    <ClassificationForm classifications={mockClassifications} field="classificationId" />
-  </Formik>
+  <Provider store={getStore()}>
+    <Router history={history}>
+      <Formik onSubmit={noop} initialValues={{ classificationId: '' }}>
+        <ClassificationForm
+          classifications={mockClassifications}
+          field="classificationId"
+          encumbranceField="test"
+        />
+      </Formik>
+    </Router>
+  </Provider>
 );
 
 describe('renders definitions correctly', () => {
+  mockedAxios.get.mockImplementationOnce(() => Promise.resolve({}));
+
+  beforeEach(() => {
+    mockKeycloak([]);
+  });
   afterEach(() => {
     cleanup();
     jest.clearAllMocks();

--- a/frontend/src/features/mapSideBar/hooks/useQueryParamSideBar.tsx
+++ b/frontend/src/features/mapSideBar/hooks/useQueryParamSideBar.tsx
@@ -52,7 +52,7 @@ interface IMapSideBar {
 }
 
 /** control the state of the side bar via query params. */
-const useQueryParamSideBar = (formikRef?: any): IMapSideBar => {
+export const useQueryParamSideBar = (formikRef?: any): IMapSideBar => {
   const [showSideBar, setShowSideBar] = useState(false);
   const [contextName, setContextName] = useState<SidebarContextType>(
     SidebarContextType.ADD_PROPERTY_TYPE_SELECTOR,

--- a/frontend/src/features/projects/common/components/FilterBar.tsx
+++ b/frontend/src/features/projects/common/components/FilterBar.tsx
@@ -3,10 +3,12 @@ import './FilterBar.scss';
 import React from 'react';
 import { Col } from 'react-bootstrap';
 import { Formik, useFormikContext } from 'formik';
-import { ILookupCode } from 'actions/lookupActions';
-import { Form, Select, SelectOption, InputGroup, Input } from 'components/common/form';
+import { Form, Select, InputGroup, Input } from 'components/common/form';
 import ResetButton from 'components/common/form/ResetButton';
 import SearchButton from 'components/common/form/SearchButton';
+import { useCodeLookups } from 'hooks/useLookupCodes';
+import * as API from 'constants/API';
+import { Classifications } from 'constants/classifications';
 
 const SearchBar: React.FC = () => {
   const state: { placeholders: Record<string, string> } = {
@@ -44,26 +46,22 @@ export interface IFilterBarState {
 }
 
 type FilterBarProps = {
-  agencyLookupCodes: ILookupCode[];
-  propertyClassifications: ILookupCode[];
   onChange: (value: IFilterBarState) => void;
 };
 
 /**
  * Filter bar for the Property List view
  */
-const FilterBar: React.FC<FilterBarProps> = ({
-  agencyLookupCodes,
-  propertyClassifications,
-  onChange,
-}) => {
-  const mapLookupCode = (code: ILookupCode): SelectOption => ({
-    label: code.name,
-    value: code.id.toString(),
-  });
+const FilterBar: React.FC<FilterBarProps> = ({ onChange }) => {
+  const lookupCode = useCodeLookups();
   //restrict available agencies to user agencies.
-  const agencies = (agencyLookupCodes ?? []).map(c => mapLookupCode(c));
-  const classifications = (propertyClassifications ?? []).map(c => mapLookupCode(c));
+  const agencies = lookupCode.getOptionsByType(API.AGENCY_CODE_SET_NAME);
+  const classifications = lookupCode.getPropertyClassificationOptions(
+    c =>
+      +c.value !== Classifications.Demolished &&
+      +c.value !== Classifications.Disposed &&
+      +c.value !== Classifications.Subdivided,
+  );
 
   return (
     <Formik<IFilterBarState>

--- a/frontend/src/features/projects/common/components/columns.tsx
+++ b/frontend/src/features/projects/common/components/columns.tsx
@@ -30,7 +30,7 @@ const sumFinancialRows = (properties: IProperty[], key: string): string => {
 };
 
 const getEditableClassificationCell = (limitLabels?: string[]) => (cellInfo: any) => {
-  const classifications = useCodeLookups().getOptionsByType('PropertyClassification');
+  const classifications = useCodeLookups().getPropertyClassificationOptions();
   const context = useFormikContext();
   return (
     <FastSelect

--- a/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.tsx
@@ -1,6 +1,6 @@
 import './SelectProjectPropertiesStep.scss';
 
-import React, { useMemo, useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { Button, Container } from 'react-bootstrap';
 import { Formik } from 'formik';
 import { useStepper, SelectProjectPropertiesStepYupSchema } from '..';
@@ -11,11 +11,8 @@ import {
   useStepForm,
   SelectProjectPropertiesForm,
 } from '../../common';
-import { ILookupCode } from 'actions/lookupActions';
-import * as API from 'constants/API';
 import styled from 'styled-components';
 import { Classifications } from 'constants/classifications';
-import useCodeLookups from 'hooks/useLookupCodes';
 
 /** contains the link text for Show Surplus and Show All classification filter */
 const LinkButton = styled(Button)`
@@ -28,7 +25,6 @@ const LinkButton = styled(Button)`
  * @param param0 {isReadOnly formikRef} formikRef allow remote formik access, isReadOnly toggle to prevent updates.
  */
 const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
-  const lookupCodes = useCodeLookups();
   // Filtering and pagination state
   const [filter, setFilter] = useState<IFilterBarState>({
     searchBy: 'address',
@@ -53,13 +49,6 @@ const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
   const [pageIndex, setPageIndex] = useState(0);
   const { onSubmit, canUserEditForm } = useStepForm();
   const { project } = useStepper();
-  const agencies = useMemo(() => lookupCodes.getByType(API.AGENCY_CODE_SET_NAME), [lookupCodes]);
-  const filterByParent = useCodeLookups().filterByParent;
-  const filteredAgencies: ILookupCode[] = useMemo(
-    () => filterByParent(agencies, project.agencyId),
-    [agencies, filterByParent, project.agencyId],
-  );
-  const propertyClassifications = lookupCodes.getByType(API.PROPERTY_CLASSIFICATION_CODE_SET_NAME);
 
   // Update internal state whenever the filter bar state changes
   const handleFilterChange = useCallback(
@@ -101,11 +90,7 @@ const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
         <>
           <Container fluid className="filter-container border-bottom">
             <Container className="px-0">
-              <FilterBar
-                agencyLookupCodes={filteredAgencies}
-                propertyClassifications={propertyClassifications}
-                onChange={handleFilterChange}
-              />
+              <FilterBar onChange={handleFilterChange} />
             </Container>
           </Container>
           <div className="small-filter">

--- a/frontend/src/features/properties/components/forms/strings.ts
+++ b/frontend/src/features/properties/components/forms/strings.ts
@@ -8,6 +8,8 @@ export const Demolished = 'The building has been demolished.';
 
 export const Subdivided = 'The property has been subdivided.';
 
+export const Disposed = 'The property has been diposed.';
+
 export const CoreStrategic =
   'Core Strategic – assets that are uniquely integral to a larger long-term service delivery \n' +
   'strategy and/or are functionally and financially effective relative to critical service \n' +

--- a/frontend/src/features/properties/filter/__snapshots__/PropertyFilter.test.tsx.snap
+++ b/frontend/src/features/properties/filter/__snapshots__/PropertyFilter.test.tsx.snap
@@ -413,12 +413,6 @@ exports[`MapFilterBar renders correctly 1`] = `
           >
             Surplus Encumbered
           </option>
-          <option
-            className="option"
-            value="4"
-          >
-            Disposed
-          </option>
         </select>
       </div>
     </div>

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -247,10 +247,9 @@ const PropertyListView: React.FC = () => {
   const agenciesList = agencies.filter(a => !a.parentId).map(mapLookupCode);
   const subAgencies = agencies.filter(a => !!a.parentId).map(mapLookupCode);
 
-  const propertyClassifications = useMemo(
-    () => lookupCodes.getByType(API.PROPERTY_CLASSIFICATION_CODE_SET_NAME),
-    [lookupCodes],
-  );
+  const propertyClassifications = useMemo(() => lookupCodes.getPropertyClassificationOptions(), [
+    lookupCodes,
+  ]);
   const administrativeAreas = useMemo(
     () => lookupCodes.getByType(API.AMINISTRATIVE_AREA_CODE_SET_NAME),
     [lookupCodes],
@@ -428,7 +427,6 @@ const PropertyListView: React.FC = () => {
           <PropertyFilter
             defaultFilter={defaultFilterValues}
             agencyLookupCodes={agencies}
-            propertyClassifications={propertyClassifications}
             adminAreaLookupCodes={administrativeAreas}
             onChange={handleFilterChange}
             sort={sorting}

--- a/frontend/src/features/properties/list/columns.tsx
+++ b/frontend/src/features/properties/list/columns.tsx
@@ -54,7 +54,7 @@ export const columns = (
   agencyOptions: SelectOption[],
   subAgencies: SelectOption[],
   municipalities: ILookupCode[],
-  propertyClassifications: ILookupCode[],
+  propertyClassifications: SelectOption[],
   propertyType: number,
   editable?: boolean,
 ): ColumnWithProps<IProperty>[] => [
@@ -128,7 +128,7 @@ export const columns = (
         name: 'classificationId',
         placeholder: 'Filter by class',
         className: 'location-search',
-        options: propertyClassifications.map(mapLookupCode),
+        options: propertyClassifications,
       },
     },
   },

--- a/frontend/src/features/properties/map/MapView.tsx
+++ b/frontend/src/features/properties/map/MapView.tsx
@@ -45,7 +45,6 @@ const MapView: React.FC<MapViewProps> = (props: MapViewProps) => {
     state => state.parcel.parcelDetail,
   );
   const agencies = lookupCodes.getByType(API.AGENCY_CODE_SET_NAME);
-  const propertyClassifications = lookupCodes.getByType(API.PROPERTY_CLASSIFICATION_CODE_SET_NAME);
   const administrativeAreas = lookupCodes.getByType(API.AMINISTRATIVE_AREA_CODE_SET_NAME);
 
   const lotSizes = fetchLotSizes();
@@ -78,7 +77,6 @@ const MapView: React.FC<MapViewProps> = (props: MapViewProps) => {
           properties={properties}
           selectedProperty={propertyDetail}
           agencies={agencies}
-          propertyClassifications={propertyClassifications}
           administrativeAreas={administrativeAreas}
           lotSizes={lotSizes}
           onMarkerPopupClose={() => {

--- a/frontend/src/hooks/useKeycloakWrapper.tsx
+++ b/frontend/src/hooks/useKeycloakWrapper.tsx
@@ -49,7 +49,7 @@ export interface IKeycloak {
 /**
  * Provides extension methods to interact with the `keycloak` object.
  */
-function useKeycloakWrapper(): IKeycloak {
+export function useKeycloakWrapper(): IKeycloak {
   const { keycloak } = useKeycloak();
   const userInfo = keycloak?.userInfo as IUserInfo;
 

--- a/frontend/src/hooks/useLookupCodes.tsx
+++ b/frontend/src/hooks/useLookupCodes.tsx
@@ -5,8 +5,17 @@ import { ILookupCodeState } from 'reducers/lookupCodeReducer';
 import { mapLookupCode } from 'utils';
 import _ from 'lodash';
 import { useCallback } from 'react';
+import { useKeycloakWrapper } from './useKeycloakWrapper';
+import * as API from 'constants/API';
+import { Classifications } from 'constants/classifications';
+import Claims from 'constants/claims';
+import { SelectOption } from 'components/common/form';
 
-function useCodeLookups() {
+/**
+ * Hook to return an array ILookupCode for specific types.
+ */
+export function useCodeLookups() {
+  const keycloak = useKeycloakWrapper();
   const lookupCodes = useSelector<RootState, ILookupCode[]>(
     state => (state.lookupCode as ILookupCodeState).lookupCodes,
   );
@@ -46,8 +55,33 @@ function useCodeLookups() {
   };
 
   const getOptionsByType = (type: string) => getByType(type).map(mapLookupCode);
+
+  /**
+   * Return an array of SelectOptions containing property classifications.
+   * @param filter - A filter to determine which classifications will be returned.
+   * @returns An array of SelectOptions for property classifications.
+   */
+  const getPropertyClassificationOptions = (
+    filter?: (value: SelectOption, index: number, array: SelectOption[]) => unknown,
+  ) => {
+    const classifications = getByType(API.PROPERTY_CLASSIFICATION_CODE_SET_NAME);
+    return filter
+      ? (classifications ?? []).map(c => mapLookupCode(c)).filter(filter)
+      : !keycloak.hasClaim(Claims.ADMIN_PROPERTIES)
+      ? (classifications ?? [])
+          .map(c => mapLookupCode(c))
+          .filter(
+            c =>
+              +c.value !== Classifications.Demolished &&
+              +c.value !== Classifications.Subdivided &&
+              +c.value !== Classifications.Disposed,
+          )
+      : (classifications ?? []).map(c => mapLookupCode(c));
+  };
+
   return {
     getOptionsByType,
+    getPropertyClassificationOptions,
     getCodeById,
     getByType,
     getPublicByType,

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './utils';
 export * from './numberFormatUtils';
+export * from './mapLookupCode';

--- a/frontend/src/utils/mapLookupCode.ts
+++ b/frontend/src/utils/mapLookupCode.ts
@@ -1,0 +1,20 @@
+import { ILookupCode } from 'actions/lookupActions';
+import { SelectOption } from 'components/common/form';
+
+/**
+ * Convert an ILookupCode into a SelectOption.
+ *
+ * @param {ILookupCode} code - The code value to identify this item.
+ * @param {(number | string | null)} [defaultId] - The default ID.
+ * @returns {SelectOption}
+ */
+export const mapLookupCode = (
+  code: ILookupCode,
+  defaultId?: number | string | null,
+): SelectOption => ({
+  label: code.name,
+  value: code.id.toString(),
+  selected: code.id === defaultId,
+  code: code.code,
+  parentId: code.parentId,
+});

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -78,17 +78,6 @@ export const isPositiveNumberOrZero = (input: string | number | undefined | null
   return !isNaN(Number(input)) && Number(input) > -1;
 };
 
-export const mapLookupCode = (
-  code: ILookupCode,
-  defaultId: number | string | null,
-): SelectOption => ({
-  label: code.name,
-  value: code.id.toString(),
-  selected: code.id === defaultId,
-  code: code.code,
-  parentId: code.parentId,
-});
-
 /** used for filters that need to display the string value of a parent agency agency */
 export const mapLookupCodeWithParentString = (
   code: ILookupCode,


### PR DESCRIPTION
Property Classifications will now use the commonly shared hook `useLookupCodes()`.  Additionally based on permissions the correct classifications will be displayed.