### PR TITLE
PA-2809, 2808, 2813, 2811, 2812, 2810: Project number link related stories 

### DIFF
--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
@@ -11,6 +11,8 @@ import { ThreeColumnItem } from './ThreeColumnItem';
 import variables from '_variables.module.scss';
 import { PropertyTypes } from 'constants/propertyTypes';
 import useCodeLookups from 'hooks/useLookupCodes';
+import { useState } from 'react';
+import { ProjectNumberLink } from './ProjectNumberLink';
 
 /**
  * Compare two dates to evaluation which is earlier.
@@ -83,6 +85,7 @@ export const InfoContent: React.FC<IInfoContent> = ({
     [PropertyTypes.PARCEL, PropertyTypes.SUBDIVISION].includes(propertyTypeId);
 
   const lookupCodes = useCodeLookups();
+  const [privateProject, setPrivateProject] = useState<boolean>(false);
 
   return (
     <>
@@ -118,8 +121,23 @@ export const InfoContent: React.FC<IInfoContent> = ({
             leftSideLabel={'Classification'}
             rightSideItem={propertyInfo?.classification}
           />
+          {!!propertyInfo?.projectNumbers?.length && (
+            <ThreeColumnItem
+              leftSideLabel={
+                propertyInfo.projectNumbers.length > 1 ? 'Project Numbers' : 'Project Number'
+              }
+              rightSideItem={propertyInfo.projectNumbers.map((projectNum: string) => (
+                <ProjectNumberLink
+                  setPrivateProject={setPrivateProject}
+                  privateProject={privateProject}
+                  agencyId={propertyInfo.agencyId}
+                  projectNumber={projectNum}
+                />
+              ))}
+            />
+          )}
         </OuterRow>
-        {!canViewDetails && (
+        {(!canViewDetails || privateProject) && (
           <ContactSres>
             <em>
               For more information on this property, contact{' '}

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
@@ -126,10 +126,12 @@ export const InfoContent: React.FC<IInfoContent> = ({
               leftSideLabel={`Project Number${propertyInfo.projectNumbers.length > 1 ? 's' : ''}`}
               rightSideItem={propertyInfo.projectNumbers.map((projectNum: string) => (
                 <ProjectNumberLink
+                  key={projectNum}
                   setPrivateProject={setPrivateProject}
                   privateProject={privateProject}
                   agencyId={propertyInfo.agencyId}
                   projectNumber={projectNum}
+                  breakLine
                 />
               ))}
             />

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoContent.tsx
@@ -123,9 +123,7 @@ export const InfoContent: React.FC<IInfoContent> = ({
           />
           {!!propertyInfo?.projectNumbers?.length && (
             <ThreeColumnItem
-              leftSideLabel={
-                propertyInfo.projectNumbers.length > 1 ? 'Project Numbers' : 'Project Number'
-              }
+              leftSideLabel={`Project Number${propertyInfo.projectNumbers.length > 1 ? 's' : ''}`}
               rightSideItem={propertyInfo.projectNumbers.map((projectNum: string) => (
                 <ProjectNumberLink
                   setPrivateProject={setPrivateProject}

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/ProjectNumberLink.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/ProjectNumberLink.tsx
@@ -1,0 +1,88 @@
+import Claims from 'constants/claims';
+import { Workflows } from 'constants/workflows';
+import { fetchProject, IProject } from 'features/projects/common';
+import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
+import React, { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+interface IProjectNumberLinkProps {
+  /** The project number to analyze */
+  projectNumber: string;
+  /** The agency ID of the property being viewed */
+  agencyId: number | '';
+  /** To determine whether the project is private to the user or not */
+  setPrivateProject: Function;
+  /** The result of setPrivateProject used in both the parent and child component */
+  privateProject: boolean;
+}
+
+/**
+ * This component is used to display project numbers and appropriate links if the user has permission.
+ * A user who belongs to the same agency and a project that has not been submitted will grant user access to a link that goes directly to the status.
+ * An admin will have access to a link that goes directly to the status.
+ * If a user belongs to the agency but the project has been submitted it will redirect you to the summary page.
+ * If a user is outside the agency they will not contain a link.
+ * @param {string} projectNumber The project number to analyze
+ * @param {number} agencyId The agency ID of the property being viewed
+ * @param {Function} setPrivateProject Will set the parent state to determine whether the project can be viewed by user
+ * @param {boolean} privateProject The resulting boolean of setPrivateProject that is used in the logic in determining whether the number will be a link
+ */
+export const ProjectNumberLink: React.FC<IProjectNumberLinkProps> = ({
+  projectNumber,
+  agencyId,
+  setPrivateProject,
+  privateProject,
+}) => {
+  const dispatch = useDispatch();
+  const keycloak = useKeycloakWrapper();
+  /** Stores the various states of the project route (summary page, project status route) */
+  const [projectRoute, setProjectRoute] = useState<string>('');
+  /** State used to determine whether further project info has been fetcehd already */
+  const [loaded, setLoaded] = useState<boolean>(false);
+
+  /** This function determines whether to display the project number as a link or just text */
+  const displayProjectNumber = () => {
+    if (privateProject) {
+      return (
+        <>
+          {projectNumber}
+          <br />
+        </>
+      );
+    } else {
+      return (
+        <>
+          <Link to={`${projectRoute}?projectNumber=${projectNumber}`}>{projectNumber}</Link>
+          <br />
+        </>
+      );
+    }
+  };
+
+  useEffect(() => {
+    if (!loaded) {
+      if (keycloak.hasAgency(+agencyId)) {
+        (dispatch(fetchProject(projectNumber)) as any).then((project: IProject) => {
+          if (
+            keycloak.hasClaim(Claims.ADMIN_PROJECTS) ||
+            (keycloak.hasAgency(project.agencyId) &&
+              project.workflowCode === Workflows.SUBMIT_DISPOSAL)
+          ) {
+            setProjectRoute(project?.status?.route!);
+          } else if (
+            project.workflowCode !== Workflows.SUBMIT_DISPOSAL &&
+            keycloak.hasAgency(project.agencyId)
+          ) {
+            setProjectRoute('/projects/summary');
+          }
+        });
+      } else {
+        setPrivateProject(true);
+      }
+      setLoaded(true);
+    }
+  }, [dispatch, projectNumber, privateProject, setPrivateProject, agencyId, keycloak, loaded]);
+
+  return displayProjectNumber();
+};

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/ThreeColumnItem.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/ThreeColumnItem.tsx
@@ -28,7 +28,7 @@ const RightCol = styled(Col)`
 
 interface IThreeColItem {
   leftSideLabel: string;
-  rightSideItem: string | number | undefined;
+  rightSideItem: string | number | React.ReactNode | undefined;
 }
 
 export const ThreeColumnItem: React.FC<IThreeColItem> = ({ leftSideLabel, rightSideItem }) => {

--- a/frontend/src/components/maps/leaflet/PointClusterer.tsx
+++ b/frontend/src/components/maps/leaflet/PointClusterer.tsx
@@ -271,7 +271,6 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
         {clusters.map((cluster, index) => {
           // every cluster point has coordinates
           const [longitude, latitude] = cluster.geometry.coordinates;
-
           const {
             cluster: isCluster,
             point_count: pointCount,
@@ -349,13 +348,18 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
             )}
             onclick={() => {
               //sets this pin as currently selected
+              const convertedProperty = convertToProperty(
+                m.properties,
+                m.position.lat,
+                m.position.lng,
+              );
               if (
                 m.properties.propertyTypeId === PropertyTypes.PARCEL ||
                 m.properties.propertyTypeId === PropertyTypes.SUBDIVISION
               ) {
-                dispatch(parcelsActions.storeParcelDetail(m.properties as IParcel));
+                dispatch(parcelsActions.storeParcelDetail(convertedProperty as IParcel));
               } else {
-                dispatch(parcelsActions.storeBuildingDetail(m.properties as IBuilding));
+                dispatch(parcelsActions.storeBuildingDetail(convertedProperty as IBuilding));
               }
               onMarkerClick(); //open information slideout
               if (keycloak.canUserViewProperty(m.properties as IProperty)) {

--- a/frontend/src/components/maps/leaflet/mapUtils.tsx
+++ b/frontend/src/components/maps/leaflet/mapUtils.tsx
@@ -244,13 +244,16 @@ export const pointToLayer = (feature: ICluster, latlng: LatLngExpression): Layer
  * Get an icon type for the specified cluster property details (type, draft, erp, spp etc)
  */
 export const getMarkerIcon = (feature: ICluster, selected?: boolean) => {
-  const { propertyTypeId, projectWorkflow, classificationId } = feature?.properties;
+  const { propertyTypeId, projectWorkflow, classificationId, parcelDetail } = feature?.properties;
   if (propertyTypeId === PropertyTypes.DRAFT_PARCEL) {
     return draftParcelIcon;
   } else if (propertyTypeId === PropertyTypes.DRAFT_BUILDING) {
     return draftBuildingIcon;
   } else if (selected) {
-    if ([Workflows.ERP, Workflows.ASSESS_EX_DISPOSAL].includes(projectWorkflow)) {
+    if (
+      [Workflows.ERP, Workflows.ASSESS_EX_DISPOSAL].includes(projectWorkflow) ||
+      [Workflows.ERP, Workflows.ASSESS_EX_DISPOSAL].includes(parcelDetail?.projectWorkflow)
+    ) {
       switch (propertyTypeId) {
         case PropertyTypes.SUBDIVISION:
           return subdivisionErpIconSelect;
@@ -260,10 +263,8 @@ export const getMarkerIcon = (feature: ICluster, selected?: boolean) => {
           return landErpIconSelect;
       }
     } else if (
-      (classificationId === Classifications.SurplusActive ||
-        classificationId === Classifications.SurplusEncumbered) &&
-      projectWorkflow &&
-      [Workflows.SPL].includes(projectWorkflow)
+      [Workflows.SPL].includes(projectWorkflow) ||
+      [Workflows.SPL].includes(parcelDetail?.projectWorkflow)
     ) {
       switch (propertyTypeId) {
         case PropertyTypes.BUILDING:

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/AssociatedLandReviewPage.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/AssociatedLandReviewPage.tsx
@@ -29,6 +29,7 @@ import { indexOfFinancial } from 'features/properties/components/forms/subforms/
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { FiscalKeys } from 'constants/fiscalKeys';
 import moment from 'moment';
+import { ProjectNumberLink } from 'components/maps/leaflet/InfoSlideOut/ProjectNumberLink';
 
 interface IReviewProps {
   nameSpace?: string;
@@ -70,12 +71,9 @@ const OtherParcel = ({ index }: any) => {
   );
 };
 
-const LinkButton = styled.span`
-  background: none;
-  border: none;
-  padding: 0;
-  color: #069;
-  text-decoration: underline;
+const StyledProjectNumbers = styled.div`
+  flex-direction: column;
+  display: flex;
 `;
 
 /**
@@ -86,6 +84,8 @@ const LinkButton = styled.span`
  */
 export const AssociatedLandReviewPage: React.FC<any> = (props: IReviewProps) => {
   const formikProps = useFormikContext<any>();
+  const [privateProject, setPrivateProject] = useState(false);
+
   const defaultEditValues = {
     identification: true,
     usage: true,
@@ -131,7 +131,9 @@ export const AssociatedLandReviewPage: React.FC<any> = (props: IReviewProps) => 
       currentYear,
     );
 
-    const projectNumber = getIn(formikProps.values, withNameSpace('projectNumber', index));
+    const projectNumbers = getIn(formikProps.values, withNameSpace('projectNumbers', index));
+    const agencyId = getIn(formikProps.values, withNameSpace('agencyId', index));
+
     if (
       getIn(formikProps.values.data, `leasedLandMetadata.${index}.type`) === LeasedLandTypes.other
     ) {
@@ -236,14 +238,20 @@ export const AssociatedLandReviewPage: React.FC<any> = (props: IReviewProps) => 
                       postText="Hectares"
                     />
                   </Row>
-                  {!!projectNumber && (
-                    <Row className="content-item">
-                      <Label>SPP</Label>
-                      <LinkButton>
-                        {
-                          projectNumber //TODO: make this a proper link when PA-1974 is fixed
-                        }
-                      </LinkButton>
+                  {!!projectNumbers?.length && (
+                    <Row style={{ marginTop: '1rem' }}>
+                      <Label>Project Number(s)</Label>
+                      <StyledProjectNumbers>
+                        {projectNumbers.map((projectNum: string) => (
+                          <ProjectNumberLink
+                            projectNumber={projectNum}
+                            key={projectNum}
+                            agencyId={agencyId}
+                            setPrivateProject={setPrivateProject}
+                            privateProject={privateProject}
+                          />
+                        ))}
+                      </StyledProjectNumbers>
                     </Row>
                   )}
                   <br></br>

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/BuildingReviewPage.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/BuildingReviewPage.tsx
@@ -27,6 +27,8 @@ import { FiscalKeys } from 'constants/fiscalKeys';
 import moment from 'moment';
 import { getAssociatedLandCols } from 'features/properties/components/forms/subforms/columns';
 import { FormikTable } from 'features/projects/common';
+import { ProjectNumberLink } from 'components/maps/leaflet/InfoSlideOut/ProjectNumberLink';
+import styled from 'styled-components';
 
 interface IReviewProps {
   nameSpace?: string;
@@ -38,6 +40,11 @@ interface IReviewProps {
   disabled: boolean;
   isPropertyAdmin: boolean;
 }
+
+const StyledProjectNumbers = styled.div`
+  flex-direction: column;
+  display: flex;
+`;
 
 export const BuildingReviewPage: React.FC<any> = (props: IReviewProps) => {
   const formikProps = useFormikContext();
@@ -56,6 +63,9 @@ export const BuildingReviewPage: React.FC<any> = (props: IReviewProps) => {
     [formikProps.isValid, props.disabled],
   );
   const [editInfo, setEditInfo] = useState(defaultEditValues);
+  const projectNumbers = getIn(formikProps.values, withNameSpace('projectNumbers'));
+  const agencyId = getIn(formikProps.values, withNameSpace('agencyId'));
+  const [privateProject, setPrivateProject] = useState(false);
   const currentYear = moment().year();
   const evaluationIndex = indexOfFinancial(
     getIn(formikProps.values, withNameSpace('evaluations')),
@@ -202,16 +212,20 @@ export const BuildingReviewPage: React.FC<any> = (props: IReviewProps) => {
                   type="number"
                 />
               </Row>
-              {(formikProps.values as any).data?.projectNumber && (
-                <Row>
-                  <Label>SPP</Label>
-                  <FastInput
-                    displayErrorTooltips
-                    className="input-small"
-                    formikProps={formikProps}
-                    disabled={editInfo.identification}
-                    field={withNameSpace('projectNumber')}
-                  />
+              {!!projectNumbers?.length && (
+                <Row style={{ marginTop: '1rem' }}>
+                  <Label>Project Number(s)</Label>
+                  <StyledProjectNumbers>
+                    {projectNumbers.map((projectNum: string) => (
+                      <ProjectNumberLink
+                        projectNumber={projectNum}
+                        key={projectNum}
+                        agencyId={agencyId}
+                        setPrivateProject={setPrivateProject}
+                        privateProject={privateProject}
+                      />
+                    ))}
+                  </StyledProjectNumbers>
                 </Row>
               )}
               <Row className="sensitive check-item">

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/IdentificationForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/IdentificationForm.tsx
@@ -17,6 +17,8 @@ import useCodeLookups from 'hooks/useLookupCodes';
 import * as API from 'constants/API';
 import GenericModal from 'components/common/GenericModal';
 import { IBuilding } from 'actions/parcelsActions';
+import styled from 'styled-components';
+import { ProjectNumberLink } from 'components/maps/leaflet/InfoSlideOut/ProjectNumberLink';
 
 interface IIdentificationProps {
   /** passed down from parent to lock/unlock designated fields */
@@ -39,6 +41,11 @@ interface IIdentificationProps {
   disabled?: boolean;
 }
 
+const StyledProjectNumbers = styled.div`
+  flex-direction: column;
+  display: flex;
+`;
+
 export const IdentificationForm: React.FC<IIdentificationProps> = ({
   formikProps,
   agencies,
@@ -59,6 +66,10 @@ export const IdentificationForm: React.FC<IIdentificationProps> = ({
     [nameSpace],
   );
   const { lookupCodes } = useCodeLookups();
+  const projectNumbers = getIn(formikProps.values, 'data.projectNumbers');
+  const agencyId = getIn(formikProps.values, `data.agencyId`);
+  const [privateProject, setPrivateProject] = useState(false);
+
   return (
     <Container>
       <Row>
@@ -114,10 +125,20 @@ export const IdentificationForm: React.FC<IIdentificationProps> = ({
               disabled={disabled}
             />
           </Row>
-          {(formikProps.values as any).data.projectNumber && (
+          {!!projectNumbers?.length && (
             <Row>
-              <Label>SPP</Label>
-              <FastInput disabled formikProps={formikProps} field="projectNumber" />
+              <Label>Project Number(s)</Label>
+              <StyledProjectNumbers>
+                {projectNumbers.map((projectNum: string) => (
+                  <ProjectNumberLink
+                    projectNumber={projectNum}
+                    key={projectNum}
+                    agencyId={agencyId}
+                    setPrivateProject={setPrivateProject}
+                    privateProject={privateProject}
+                  />
+                ))}
+              </StyledProjectNumbers>
             </Row>
           )}
           <Row>

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/LandReviewPage.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/LandReviewPage.tsx
@@ -27,6 +27,7 @@ import { indexOfFinancial } from 'features/properties/components/forms/subforms/
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { FiscalKeys } from 'constants/fiscalKeys';
 import moment from 'moment';
+import { ProjectNumberLink } from 'components/maps/leaflet/InfoSlideOut/ProjectNumberLink';
 
 interface IReviewProps {
   nameSpace?: string;
@@ -40,12 +41,9 @@ interface IReviewProps {
   isPropertyAdmin: boolean;
 }
 
-const LinkButton = styled.span`
-  background: none;
-  border: none;
-  padding: 0;
-  color: #069;
-  text-decoration: underline;
+const StyledProjectNumbers = styled.div`
+  flex-direction: column;
+  display: flex;
 `;
 
 export const LandReviewPage: React.FC<any> = (props: IReviewProps) => {
@@ -75,7 +73,10 @@ export const LandReviewPage: React.FC<any> = (props: IReviewProps) => {
       +c.value === +classId,
   );
 
-  const projectNumber = getIn(formikProps.values, withNameSpace('projectNumber'));
+  const projectNumbers = getIn(formikProps.values, withNameSpace('projectNumbers'));
+  const agencyId = getIn(formikProps.values, withNameSpace('agencyId'));
+  const [privateProject, setPrivateProject] = useState(false);
+
   const currentYear = moment().year();
   const evaluationIndex = indexOfFinancial(
     getIn(formikProps.values, withNameSpace('evaluations')),
@@ -210,14 +211,20 @@ export const LandReviewPage: React.FC<any> = (props: IReviewProps) => {
                   field={withNameSpace('longitude')}
                 />
               </Row>
-              {!!projectNumber && (
-                <Row className="content-item">
-                  <Label>SPP</Label>
-                  <LinkButton>
-                    {
-                      projectNumber //TODO: make this a proper link when PA-1974 is fixed
-                    }
-                  </LinkButton>
+              {!!projectNumbers?.length && (
+                <Row style={{ marginTop: '1rem' }}>
+                  <Label>Project Number(s)</Label>
+                  <StyledProjectNumbers>
+                    {projectNumbers.map((projectNum: string) => (
+                      <ProjectNumberLink
+                        projectNumber={projectNum}
+                        key={projectNum}
+                        agencyId={agencyId}
+                        setPrivateProject={setPrivateProject}
+                        privateProject={privateProject}
+                      />
+                    ))}
+                  </StyledProjectNumbers>
                 </Row>
               )}
               <br></br>

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/ParcelIdentificationForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/ParcelIdentificationForm.tsx
@@ -25,6 +25,8 @@ import { PropertyTypes } from 'constants/propertyTypes';
 import { withNameSpace } from 'utils/formUtils';
 import MovePinForm from './MovePinForm';
 import LandSearchForm from './LandSearchForm';
+import { ProjectNumberLink } from 'components/maps/leaflet/InfoSlideOut/ProjectNumberLink';
+import styled from 'styled-components';
 
 interface IIdentificationProps {
   /** used for changign the agency - note that only select users will be able to edit this field */
@@ -53,6 +55,11 @@ interface IIdentificationProps {
   disabled?: boolean;
 }
 
+const StyledProjectNumbers = styled.div`
+  flex-direction: column;
+  display: flex;
+`;
+
 export const ParcelIdentificationForm: React.FC<IIdentificationProps> = ({
   nameSpace,
   index,
@@ -73,6 +80,9 @@ export const ParcelIdentificationForm: React.FC<IIdentificationProps> = ({
   const agency = getIn(formikProps.values, withNameSpace(nameSpace, 'agencyId'));
   const { lookupCodes } = useCodeLookups();
   const { propertyTypeId, latitude, longitude } = getIn(formikProps.values, nameSpace);
+  const projectNumbers = getIn(formikProps.values, 'data.projectNumbers');
+  const agencyId = getIn(formikProps.values, `data.agencyId`);
+  const [privateProject, setPrivateProject] = useState(false);
 
   return (
     <Container>
@@ -212,8 +222,25 @@ export const ParcelIdentificationForm: React.FC<IIdentificationProps> = ({
               required
             />
           </Form.Row>
+          {!!projectNumbers?.length && (
+            <Form.Row>
+              <Label style={{ marginTop: '1rem' }}>Project Number(s)</Label>
+              <StyledProjectNumbers>
+                {projectNumbers.map((projectNum: string) => (
+                  <ProjectNumberLink
+                    key={projectNum}
+                    projectNumber={projectNum}
+                    agencyId={agencyId}
+                    setPrivateProject={setPrivateProject}
+                    privateProject={privateProject}
+                  />
+                ))}
+              </StyledProjectNumbers>
+            </Form.Row>
+          )}
         </Col>
       </Row>
+
       <Row>
         <Col>
           <div className="input-medium harmful">


### PR DESCRIPTION
Display appropriate project number(s) in property info panel

- if an admin clicks the link it will go to the project status route
- link goes to summary if project has been submitted and user is in the same agency
- link goes to project status route if it is still in draft and user is a part of the agency
- if user is outside of the agency and not an admin the numbers will not be clickable 

Updated:

- land, associated land, and building review pages now have project number(s) with appropriate links
- also included when viewing the info screen
- fixed bug where lat and long was not being stored when a marker was clicked
- fixed another bug where the project workflow information was not being read correctly because the data shape was changing 

![image](https://user-images.githubusercontent.com/15724124/108556618-2673d980-72ac-11eb-87f7-f478d3a901a3.png)
