### PR TITLE
PA 2607 Align SPL report headers and fields

### DIFF
--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -499,8 +499,8 @@ const Table = <T extends object>(props: PropsWithChildren<TableProps<T>>): React
               >
                 {actions => (
                   <>
-                    <div className={'th reset-filter svg-btn'}>
-                      {filterable && (
+                    {filterable && (
+                      <div className={'th reset-filter svg-btn'}>
                         <TooltipWrapper
                           toolTipId="properties-list-filter-reset-tooltip"
                           toolTip="Reset Filter"
@@ -525,10 +525,10 @@ const Table = <T extends object>(props: PropsWithChildren<TableProps<T>>): React
                             variant="secondary"
                             style={{ width: 20, height: 20 }}
                             icon={<FaUndo size={10} />}
-                          ></Button>
+                          />
                         </TooltipWrapper>
-                      )}
-                    </div>
+                      </div>
+                    )}
                     {headerGroup.headers.map((column: ColumnInstanceWithProps<T>) => (
                       <div
                         {...(props.hideHeaders

--- a/frontend/src/features/admin/access/__snapshots__/ManageAccessRequests.test.tsx.snap
+++ b/frontend/src/features/admin/access/__snapshots__/ManageAccessRequests.test.tsx.snap
@@ -275,9 +275,6 @@ exports[`Manage access requests Snapshot matches 1`] = `
           }
         >
           <div
-            className="th reset-filter svg-btn"
-          />
-          <div
             className="th"
             colSpan={1}
             role="columnheader"

--- a/frontend/src/features/admin/agencies/__snapshots__/ManageAgencies.test.tsx.snap
+++ b/frontend/src/features/admin/agencies/__snapshots__/ManageAgencies.test.tsx.snap
@@ -235,9 +235,6 @@ exports[`Manage Agencies Component Snapshot matches 1`] = `
           }
         >
           <div
-            className="th reset-filter svg-btn"
-          />
-          <div
             className="th"
             colSpan={1}
             role="columnheader"

--- a/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
+++ b/frontend/src/features/admin/users/__snapshots__/ManageUsers.test.tsx.snap
@@ -284,9 +284,6 @@ exports[`Manage Users Component Snapshot matches 1`] = `
           style="display: flex; flex: 1 0 auto; min-width: 980px;"
         >
           <div
-            class="th reset-filter svg-btn"
-          />
-          <div
             class="th"
             colspan="1"
             role="columnheader"

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/__snapshots__/BuildingReviewPage.test.tsx.snap
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/__snapshots__/BuildingReviewPage.test.tsx.snap
@@ -158,7 +158,6 @@ exports[`renders correctly 1`] = `
                 <div role=\\"table\\" class=\\"table\\">
                   <div class=\\"thead thead-light\\">
                     <div role=\\"row\\" style=\\"display: flex; flex: 1 0 auto; min-width: 180px;\\" class=\\"tr\\">
-                      <div class=\\"th reset-filter svg-btn\\"></div>
                       <div colspan=\\"1\\" role=\\"columnheader\\" style=\\"box-sizing: border-box; flex: 50 0 auto; min-width: 30px; width: 50px; justify-content: flex-start; text-align: left; align-items: center; display: flex;\\" class=\\"th\\">
                         <div class=\\"sortable-column\\">Type<span style=\\"flex: 1 1 auto;\\"></span></div>
                       </div>

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/__snapshots__/BuildingValuationForm.test.tsx.snap
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/__snapshots__/BuildingValuationForm.test.tsx.snap
@@ -37,9 +37,6 @@ exports[`renders correctly 1`] = `
             style="display: flex; flex: 1 0 auto; min-width: 90px;"
           >
             <div
-              class="th reset-filter svg-btn"
-            />
-            <div
               class="th"
               colspan="3"
               role="columnheader"
@@ -60,9 +57,6 @@ exports[`renders correctly 1`] = `
             role="row"
             style="display: flex; flex: 1 0 auto; min-width: 90px;"
           >
-            <div
-              class="th reset-filter svg-btn"
-            />
             <div
               class="th"
               colspan="1"
@@ -157,9 +151,6 @@ exports[`renders correctly 1`] = `
             style="display: flex; flex: 1 0 auto; min-width: 60px;"
           >
             <div
-              class="th reset-filter svg-btn"
-            />
-            <div
               class="th"
               colspan="2"
               role="columnheader"
@@ -194,9 +185,6 @@ exports[`renders correctly 1`] = `
             role="row"
             style="display: flex; flex: 1 0 auto; min-width: 60px;"
           >
-            <div
-              class="th reset-filter svg-btn"
-            />
             <div
               class="th"
               colspan="1"

--- a/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
+++ b/frontend/src/features/projects/assess/steps/__snapshots__/ReviewApproveStep.test.tsx.snap
@@ -375,9 +375,6 @@ exports[`Review Approve Step renders correctly 1`] = `
                 style="display: flex; flex: 1 0 auto; min-width: 645px;"
               >
                 <div
-                  class="th reset-filter svg-btn"
-                />
-                <div
                   class="th"
                   colspan="1"
                   role="columnheader"

--- a/frontend/src/features/projects/common/__snapshots__/ProjectSummaryView.test.tsx.snap
+++ b/frontend/src/features/projects/common/__snapshots__/ProjectSummaryView.test.tsx.snap
@@ -462,9 +462,6 @@ exports[`Review Summary View renders approved correctly 1`] = `
                 }
               >
                 <div
-                  className="th reset-filter svg-btn"
-                />
-                <div
                   className="th"
                   colSpan={1}
                   role="columnheader"
@@ -1450,9 +1447,6 @@ exports[`Review Summary View renders denied correctly 1`] = `
                 }
               >
                 <div
-                  className="th reset-filter svg-btn"
-                />
-                <div
                   className="th"
                   colSpan={1}
                   role="columnheader"
@@ -2437,9 +2431,6 @@ exports[`Review Summary View renders submitted correctly 1`] = `
                   }
                 }
               >
-                <div
-                  className="th reset-filter svg-btn"
-                />
                 <div
                   className="th"
                   colSpan={1}

--- a/frontend/src/features/projects/common/forms/__snapshots__/UpdateInfoForm.test.tsx.snap
+++ b/frontend/src/features/projects/common/forms/__snapshots__/UpdateInfoForm.test.tsx.snap
@@ -349,9 +349,6 @@ exports[`Update Info Form Matches Snapshot 1`] = `
               }
             >
               <div
-                className="th reset-filter svg-btn"
-              />
-              <div
                 className="th"
                 colSpan={1}
                 role="columnheader"

--- a/frontend/src/features/projects/dispose/forms/__snapshots__/PropertyListViewSelect.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/forms/__snapshots__/PropertyListViewSelect.test.tsx.snap
@@ -45,9 +45,6 @@ exports[`Property List View Select renders correctly 1`] = `
           style="display: flex; flex: 1 0 auto; min-width: 675px;"
         >
           <div
-            class="th reset-filter svg-btn"
-          />
-          <div
             class="th"
             colspan="1"
             role="columnheader"
@@ -260,9 +257,6 @@ exports[`Property List View Select renders correctly 1`] = `
           role="row"
           style="display: flex; flex: 1 0 auto; min-width: 705px;"
         >
-          <div
-            class="th reset-filter svg-btn"
-          />
           <div
             class="th"
             colspan="1"

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/ReviewProjectStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/ReviewProjectStep.test.tsx.snap
@@ -407,9 +407,6 @@ exports[`renders correctly 1`] = `
                 }
               >
                 <div
-                  className="th reset-filter svg-btn"
-                />
-                <div
                   className="th"
                   colSpan={1}
                   role="columnheader"

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
@@ -284,9 +284,6 @@ exports[`renders correctly 1`] = `
               }
             >
               <div
-                className="th reset-filter svg-btn"
-              />
-              <div
                 className="th"
                 colSpan={1}
                 role="columnheader"
@@ -683,9 +680,6 @@ exports[`renders correctly 1`] = `
                 }
               }
             >
-              <div
-                className="th reset-filter svg-btn"
-              />
               <div
                 className="th"
                 colSpan={1}

--- a/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
@@ -1506,9 +1506,6 @@ exports[`ERP Approval Step renders correctly 1`] = `
                         }
                       >
                         <div
-                          className="th reset-filter svg-btn"
-                        />
-                        <div
                           className="th"
                           colSpan={1}
                           role="columnheader"

--- a/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
@@ -277,9 +277,6 @@ exports[`GRE Transfer Step renders correctly 1`] = `
               }
             >
               <div
-                className="th reset-filter svg-btn"
-              />
-              <div
                 className="th"
                 colSpan={1}
                 role="columnheader"

--- a/frontend/src/features/projects/erp/tabs/__snapshots__/EnhancedReferralTab.test.tsx.snap
+++ b/frontend/src/features/projects/erp/tabs/__snapshots__/EnhancedReferralTab.test.tsx.snap
@@ -364,9 +364,6 @@ exports[`EnhancedReferralTab renders correctly 1`] = `
                   }
                 >
                   <div
-                    className="th reset-filter svg-btn"
-                  />
-                  <div
                     className="th"
                     colSpan={1}
                     role="columnheader"
@@ -1128,9 +1125,6 @@ exports[`EnhancedReferralTab renders correctly when approved for exemption 1`] =
                     }
                   }
                 >
-                  <div
-                    className="th reset-filter svg-btn"
-                  />
                   <div
                     className="th"
                     colSpan={1}

--- a/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectApprovalRequest.test.tsx.snap
@@ -36,9 +36,6 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
           style="display: flex; flex: 1 0 auto; min-width: 875px;"
         >
           <div
-            class="th reset-filter svg-btn"
-          />
-          <div
             class="th"
             colspan="1"
             role="columnheader"
@@ -343,9 +340,6 @@ exports[`Project Approval Request list view Matches snapshot 1`] = `
                   role="row"
                   style="display: flex; flex: 1 0 auto; min-width: 980px;"
                 >
-                  <div
-                    class="th reset-filter svg-btn"
-                  />
                   <div
                     class="th"
                     colspan="1"

--- a/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
@@ -291,9 +291,6 @@ exports[`Project list view tests Matches snapshot 1`] = `
           style="display: flex; flex: 1 0 auto; min-width: 875px;"
         >
           <div
-            class="th reset-filter svg-btn"
-          />
-          <div
             class="th"
             colspan="1"
             role="columnheader"

--- a/frontend/src/features/splReports/columns.tsx
+++ b/frontend/src/features/splReports/columns.tsx
@@ -72,7 +72,7 @@ export const columns: any[] = [
   {
     Header: 'CMV',
     accessor: 'market',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,
@@ -83,7 +83,7 @@ export const columns: any[] = [
   {
     Header: 'NBV',
     accessor: 'netBook',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,
@@ -94,7 +94,7 @@ export const columns: any[] = [
   {
     Header: 'Sales Cost',
     accessor: 'salesCost',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,
@@ -105,7 +105,7 @@ export const columns: any[] = [
   {
     Header: 'Program Cost',
     accessor: 'programCost',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,
@@ -116,7 +116,7 @@ export const columns: any[] = [
   {
     Header: 'Gain Loss',
     accessor: 'gainLoss',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,
@@ -127,7 +127,7 @@ export const columns: any[] = [
   {
     Header: 'OCG Fin. Stmts.',
     accessor: 'ocgFinancialStatements',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,
@@ -138,7 +138,7 @@ export const columns: any[] = [
   {
     Header: 'Interest Comp.',
     accessor: 'interestComponent',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,
@@ -149,7 +149,7 @@ export const columns: any[] = [
   {
     Header: 'Net Proceeds',
     accessor: 'netProceeds',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,
@@ -160,7 +160,7 @@ export const columns: any[] = [
   {
     Header: 'Baseline Integrity',
     accessor: 'baselineIntegrity',
-    align: 'right',
+    align: 'left',
     responsive: true,
     width: spacing.small,
     minWidth: 80,

--- a/frontend/src/features/splReports/components/ReportForm.tsx
+++ b/frontend/src/features/splReports/components/ReportForm.tsx
@@ -21,7 +21,7 @@ const ReportForm: React.FunctionComponent<IReportFormProps> = ({ currentReport, 
       data={data}
       loading={snapshots === undefined}
       hideToolbar
-    ></Table>
+    />
   );
 };
 

--- a/frontend/src/features/splReports/components/SplReportLayout.scss
+++ b/frontend/src/features/splReports/components/SplReportLayout.scss
@@ -1,10 +1,15 @@
 @import '../../../variables';
 @import '../../../colors.scss';
 .spl-reports {
+  .row {
+    flex-wrap: nowrap;
+  }
+
   .side-bar.side-bar-show {
     transform: translateX(0);
     width: 300px;
   }
+
   div.active.row {
     background-color: $accent-color;
   }


### PR DESCRIPTION
Rather than try to build some workaround to get only the headers to align right, I just aligned the columns left
![image](https://user-images.githubusercontent.com/33818575/108571659-8165fa80-72c5-11eb-81ca-c71afcfcf836.png)
