### PR TITLE
PA-2807 Removed link to project properties

### DIFF
--- a/backend/api/Areas/Tools/Helpers/ImportProjectsHelper.cs
+++ b/backend/api/Areas/Tools/Helpers/ImportProjectsHelper.cs
@@ -185,37 +185,7 @@ namespace Pims.Api.Areas.Tools.Helpers
             // Extract properties from PID note.
             var pidNote = model.Notes?.FirstOrDefault(n => n.Key == "PID").Value;
             var pids = Regex.Matches(pidNote ?? "", "[0-9]{3}-[0-9]{3}-[0-9]{3}").Select(m => m.Value).NotNull().Distinct();
-            if (!String.IsNullOrWhiteSpace(pidNote))
-            {
-                // Need to load any properties currently linked to this project.
-                if (project.Id > 0)
-                {
-                    var existingProject = _service.Project.Get(project.ProjectNumber);
-
-                    pids.ForEach(pid =>
-                    {
-                        // If the parcel has not already been added, add it to the project.
-                        var addProperty = true;
-                        foreach (var property in existingProject.Properties.Where(p => p.PropertyType == Entity.PropertyTypes.Land))
-                        {
-                            var parcel = _service.Parcel.Get(property.ParcelId.Value);
-                            if (parcel.ParcelIdentity == pid)
-                            {
-                                addProperty = false;
-                                break;
-                            }
-                        }
-                        if (addProperty) AddProperty(project, pid);
-                    });
-
-                }
-                else
-                {
-                    pids.ForEach(pid => AddProperty(project, pid));
-                }
-            }
-
-            project.TierLevel = GetTier(model.Market, pids.Any() ? pids.Count() : project.Properties.Count()); // Most projects have no properties linked.
+            project.TierLevel = GetTier(model.Market, project.Properties.Any() ? project.Properties.Count() : pids.Count()); // Most projects have no properties linked.
             project.TierLevelId = project.TierLevel.Id;
             project.Risk = GetRisk(model.Risk);
             project.RiskId = project.Risk.Id;


### PR DESCRIPTION
Originally the project import would attempt to link projects to properties by parsing the notes.  The import will no longer do this as it wasn't adding value.