### PR TITLE
PA-2788: Dropdown not displaying all results

### DIFF
--- a/frontend/src/components/common/form/ParentSelect.tsx
+++ b/frontend/src/components/common/form/ParentSelect.tsx
@@ -118,6 +118,7 @@ export const ParentSelect: React.FC<IParentSelect> = ({
         }}
         multiple={enableMultiple}
         options={options}
+        maxResults={options.length}
         bsSize={'large'}
         filterBy={filterBy}
         getOptionByValue={enableMultiple ? (value: any) => value : getOptionByValue}


### PR DESCRIPTION
I originally did not think this was a bug because every agency came back when I searched for it, but by default when scrolling through (with no filter applied to the list) not every agency would show up. Mikaela created a bug for us to display everything, so all I had to do was change the `maxResults` to the length of the `options` so they get rendered within their groups all at once