### PR TITLE
Allow parent agency users and SRES users to set project agency

### DIFF
--- a/frontend/src/components/common/form/ParentSelect.tsx
+++ b/frontend/src/components/common/form/ParentSelect.tsx
@@ -32,6 +32,8 @@ interface IParentSelect {
   onChange?: (vals: any) => void;
   /** get the component to select the item with closest label match to the input provided */
   selectClosest?: boolean;
+  /** Transform value */
+  convertValue?: (value: any) => any;
 }
 
 /** Component used to group children items with their parent.
@@ -50,6 +52,7 @@ export const ParentSelect: React.FC<IParentSelect> = ({
   label,
   onChange,
   selectClosest,
+  convertValue = value => value,
 }) => {
   const { setFieldValue } = useFormikContext();
   /** used to trigger onBlur so menu disappears on custom header click */
@@ -65,7 +68,7 @@ export const ParentSelect: React.FC<IParentSelect> = ({
 
   /** function that gets called when menu header is clicked */
   const handleMenuHeaderClick = (vals: SelectOption) => {
-    setFieldValue(field, vals.value);
+    setFieldValue(field, convertValue(vals.value));
     /** trigger ref in Typeahead to call onBlur so menu closes */
     setClear(true);
     onChange?.([vals]);
@@ -76,7 +79,7 @@ export const ParentSelect: React.FC<IParentSelect> = ({
     setMultiSelections(vals);
     setFieldValue(
       field,
-      vals.map((x: any) => x.value),
+      vals.map((x: any) => convertValue(x.value)),
     );
     setClear(true);
     onChange?.(vals);
@@ -109,10 +112,10 @@ export const ParentSelect: React.FC<IParentSelect> = ({
             setMultiSelections(vals);
             setFieldValue(
               field,
-              vals.map((x: any) => x.value),
+              vals.map((x: any) => convertValue(x.value)),
             );
           } else {
-            setFieldValue(field, getIn(vals[0], 'value') ?? vals[0]);
+            setFieldValue(field, convertValue(getIn(vals[0], 'value')) ?? convertValue(vals[0]));
           }
           onChange?.(vals);
         }}

--- a/frontend/src/features/projects/common/components/FilterBar.tsx
+++ b/frontend/src/features/projects/common/components/FilterBar.tsx
@@ -47,12 +47,13 @@ export interface IFilterBarState {
 
 type FilterBarProps = {
   onChange: (value: IFilterBarState) => void;
+  defaultFilter: IFilterBarState;
 };
 
 /**
  * Filter bar for the Property List view
  */
-const FilterBar: React.FC<FilterBarProps> = ({ onChange }) => {
+const FilterBar: React.FC<FilterBarProps> = ({ onChange, defaultFilter }) => {
   const lookupCode = useCodeLookups();
   //restrict available agencies to user agencies.
   const agencies = lookupCode.getOptionsByType(API.AGENCY_CODE_SET_NAME);
@@ -65,17 +66,7 @@ const FilterBar: React.FC<FilterBarProps> = ({ onChange }) => {
 
   return (
     <Formik<IFilterBarState>
-      initialValues={{
-        searchBy: 'address',
-        pid: '',
-        address: '',
-        administrativeArea: '',
-        projectNumber: '',
-        agencies: '',
-        classificationId: '',
-        minLotSize: '',
-        maxLotSize: '',
-      }}
+      initialValues={defaultFilter}
       onSubmit={(values, { setSubmitting }) => {
         setSubmitting(true);
         onChange?.({ ...values });

--- a/frontend/src/features/projects/common/forms/ProjectDraftForm.tsx
+++ b/frontend/src/features/projects/common/forms/ProjectDraftForm.tsx
@@ -1,13 +1,37 @@
 import './ProjectDraftForm.scss';
-import React from 'react';
-import { Container } from 'react-bootstrap';
+import React, { useMemo } from 'react';
+import { Col, Container } from 'react-bootstrap';
 import { Form, Input, TextArea } from 'components/common/form';
 import { IStepProps, projectNoDescription, EditButton } from '..';
 import styled from 'styled-components';
+import useCodeLookups from 'hooks/useLookupCodes';
+import * as API from 'constants/API';
+import { ParentSelect } from 'components/common/form/ParentSelect';
+import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
+import { mapSelectOptionWithParent } from 'utils';
+import { Claims } from 'constants/claims';
 
 const ItalicText = styled.div`
   font-family: 'BCSans-Italic', Fallback, sans-serif;
   font-size: 12px;
+`;
+
+const AgencyCol = styled(Col)`
+  display: flex;
+  .form-group {
+    width: 100%;
+    .rbt {
+      width: 100%;
+      div {
+        input {
+          width: 100% !important;
+        }
+      }
+      .rbt-menu {
+        width: 370px !important;
+      }
+    }
+  }
 `;
 
 interface IProjectDraftFormProps {
@@ -24,6 +48,32 @@ const ProjectDraftForm = ({
   title,
   setIsReadOnly,
 }: IStepProps & IProjectDraftFormProps) => {
+  const { getOptionsByType } = useCodeLookups();
+  const keycloak = useKeycloakWrapper();
+  const agencies = getOptionsByType(API.AGENCY_CODE_SET_NAME);
+  const userAgency = agencies.find(a => Number(a.value) === Number(keycloak.agencyId));
+
+  const isUserAgencyAParent = useMemo(() => {
+    return !!userAgency && !userAgency.parentId;
+  }, [userAgency]);
+
+  const isSRES = useMemo(() => {
+    return (
+      keycloak.hasClaim(Claims.PROJECT_VIEW) ||
+      keycloak.hasClaim(Claims.DISPOSE_APPROVE) ||
+      keycloak.hasClaim(Claims.ADMIN_PROJECTS)
+    );
+  }, [keycloak]);
+
+  const agencyOptions = useMemo(() => {
+    const items = agencies.filter(a => {
+      return (
+        isSRES || a.value === userAgency?.value || Number(a.parentId) === Number(userAgency?.value)
+      );
+    });
+    return items.map(c => mapSelectOptionWithParent(c, agencies));
+  }, [userAgency, agencies, isSRES]);
+
   return (
     <Container fluid className="ProjectDraftForm">
       <Form.Row>
@@ -55,6 +105,19 @@ const ProjectDraftForm = ({
           required
         />
       </Form.Row>
+      {(isSRES || isUserAgencyAParent) && (
+        <Form.Row className="col-md-10">
+          <Form.Label className="col-md-1">Project Agency</Form.Label>
+          <AgencyCol className="col-md-5">
+            <ParentSelect
+              field={'agencyId'}
+              options={agencyOptions}
+              filterBy={['code', 'label', 'parent']}
+              convertValue={Number}
+            />
+          </AgencyCol>
+        </Form.Row>
+      )}
       <Form.Row>
         <TextArea
           data-testid="project-description"

--- a/frontend/src/features/projects/dispose/hooks/useStepper.ts
+++ b/frontend/src/features/projects/dispose/hooks/useStepper.ts
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router-dom';
 import { IGenericNetworkAction } from 'actions/genericActions';
 import { ProjectActions } from 'constants/actionTypes';
 import { ReviewWorkflowStatus } from '../../common/interfaces';
+import { useKeycloakWrapper } from 'hooks/useKeycloakWrapper';
 
 /**
  * Get the status after the current status in this workflow. Return undefined if there is no next step.
@@ -102,11 +103,15 @@ export const getLastCompletedStatus = (
  */
 const useStepper = () => {
   const history = useHistory();
+  const keycloak = useKeycloakWrapper();
   const { currentStatus, setCurrentStatus, disposeWorkflowStatuses } = useContext(StepperContext);
-  const project: any =
-    useSelector<RootState, IProjectWrapper>(state => state.project).project || initialValues;
-  const workflowTasks: IProjectTask[] =
-    useSelector<RootState, IProjectTask[]>(state => state.tasks) || initialValues;
+  const project: any = useSelector<RootState, IProjectWrapper>(state => state.project).project || {
+    ...initialValues,
+    agencyId: keycloak.agencyId!,
+  };
+  const workflowTasks: IProjectTask[] = useSelector<RootState, IProjectTask[]>(
+    state => state.tasks,
+  ) || { ...initialValues, agencyId: keycloak.agencyId! };
   const getProjectRequest = useSelector<RootState, IGenericNetworkAction>(
     state => (state.network as any)[ProjectActions.GET_PROJECT] as any,
   );

--- a/frontend/src/features/projects/dispose/steps/ProjectDraftStep.test.tsx
+++ b/frontend/src/features/projects/dispose/steps/ProjectDraftStep.test.tsx
@@ -31,6 +31,7 @@ const history = createMemoryHistory();
 
 const store = mockStore({
   [reducerTypes.ProjectReducers.PROJECT]: { agencyId: 1 },
+  [reducerTypes.LOOKUP_CODE]: { lookupCodes: [] },
   [reducerTypes.NETWORK]: {
     [ProjectActions.GET_PROJECT]: {},
   },

--- a/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.tsx
+++ b/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.tsx
@@ -25,6 +25,7 @@ const LinkButton = styled(Button)`
  * @param param0 {isReadOnly formikRef} formikRef allow remote formik access, isReadOnly toggle to prevent updates.
  */
 const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
+  const { project } = useStepper();
   // Filtering and pagination state
   const [filter, setFilter] = useState<IFilterBarState>({
     searchBy: 'address',
@@ -32,7 +33,7 @@ const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
     address: '',
     administrativeArea: '',
     projectNumber: '',
-    agencies: '',
+    agencies: project.agencyId,
     classificationId: Classifications.SurplusActive.toString(),
     minLotSize: '',
     maxLotSize: '',
@@ -48,7 +49,6 @@ const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
   }, [filter]);
   const [pageIndex, setPageIndex] = useState(0);
   const { onSubmit, canUserEditForm } = useStepForm();
-  const { project } = useStepper();
 
   // Update internal state whenever the filter bar state changes
   const handleFilterChange = useCallback(
@@ -90,7 +90,7 @@ const SelectProjectPropertiesStep = ({ isReadOnly, formikRef }: IStepProps) => {
         <>
           <Container fluid className="filter-container border-bottom">
             <Container className="px-0">
-              <FilterBar onChange={handleFilterChange} />
+              <FilterBar defaultFilter={filter} onChange={handleFilterChange} />
             </Container>
           </Container>
           <div className="small-filter">

--- a/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
+++ b/frontend/src/features/projects/dispose/steps/__snapshots__/SelectProjectPropertiesStep.test.tsx.snap
@@ -88,7 +88,6 @@ exports[`renders correctly 1`] = `
                 name="agencies"
                 onBlur={[Function]}
                 onChange={[Function]}
-                value=""
               >
                 <option
                   value=""
@@ -110,7 +109,7 @@ exports[`renders correctly 1`] = `
                 name="classificationId"
                 onBlur={[Function]}
                 onChange={[Function]}
-                value=""
+                value="2"
               >
                 <option
                   value=""

--- a/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`GRE Transfer Step renders correctly 1`] = `
   font-family: 'BCSans',Fallback,sans-serif;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20,6 +20,29 @@ exports[`GRE Transfer Step renders correctly 1`] = `
   -webkit-flex-flow: column;
   -ms-flex-flow: column;
   flex-flow: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 .form-group {
+  width: 100%;
+}
+
+.c3 .form-group .rbt {
+  width: 100%;
+}
+
+.c3 .form-group .rbt div input {
+  width: 100% !important;
+}
+
+.c3 .form-group .rbt .rbt-menu {
+  width: 370px !important;
 }
 
 .c2 {
@@ -138,6 +161,82 @@ exports[`GRE Transfer Step renders correctly 1`] = `
             onMouseOver={[Function]}
             value="my project"
           />
+        </div>
+      </div>
+      <div
+        className="col-md-10 form-row"
+      >
+        <label
+          className="col-md-1 form-label"
+        >
+          Project Agency
+        </label>
+        <div
+          className="c3 col-md-5 col"
+        >
+          <div
+            className="form-group"
+          >
+            <div
+              className="rbt"
+              style={
+                Object {
+                  "outline": "none",
+                  "position": "relative",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "flex": 1,
+                    "height": "100%",
+                    "position": "relative",
+                  }
+                }
+              >
+                <input
+                  aria-autocomplete="both"
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
+                  autoComplete="off"
+                  className="rbt-input-main form-control rbt-input"
+                  id="agencyId-field"
+                  name="agencyId"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  role="combobox"
+                  type="text"
+                  value=""
+                />
+                <input
+                  aria-hidden={true}
+                  className="rbt-input-hint"
+                  readOnly={true}
+                  style={
+                    Object {
+                      "backgroundColor": "transparent",
+                      "borderColor": "transparent",
+                      "boxShadow": "none",
+                      "color": "rgba(0, 0, 0, 0.35)",
+                      "left": 0,
+                      "pointerEvents": "none",
+                      "position": "absolute",
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                  tabIndex={-1}
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -757,7 +856,7 @@ exports[`GRE Transfer Step renders correctly 1`] = `
                   title=""
                 >
                   <div
-                    className="c3"
+                    className="c4"
                   />
                 </div>
                 <div


### PR DESCRIPTION
On submit and edit project the ability to change the projects agency so that I can submit properties on their behalf 

User has to be at the Ministry Level to be able to do this. They can only select their agency or sub agency

OR 

If they are SRES they can select any agency or sub agency 

PROPERTIES in the list must belong to the selected agency 