### PR TITLE
PA-2854 Disposal Project Clearance Notification

### DIFF
--- a/frontend/src/features/projects/erp/forms/EnhancedReferralCompleteForm.tsx
+++ b/frontend/src/features/projects/erp/forms/EnhancedReferralCompleteForm.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../common';
 import GenericModal from 'components/common/GenericModal';
 import { validateFormikWithCallback } from 'utils';
+import { clearanceNotificationSentOnRequired } from './erpYupSchema';
 
 const OrText = styled.div`
   margin: 0.75rem 2rem 0.75rem 2rem;
@@ -50,6 +51,9 @@ const EnhancedReferralCompleteForm = ({
   const [proceedToSpl, setProceedToSpl] = useState(false);
   const [notInSpl, setNotInSpl] = useState(false);
   const [disposeExternally, setDisposeExternally] = useState(false);
+  const isClearanceNotificationSentOnRequired = clearanceNotificationSentOnRequired(
+    formikProps.values.status?.code ?? '',
+  );
   return (
     <Container fluid className="EnhancedReferralCompleteForm">
       <h3>Enhanced Referral Process Complete</h3>
@@ -147,7 +151,11 @@ const EnhancedReferralCompleteForm = ({
             <FastDatePicker
               outerClassName="col-md-2"
               formikProps={formikProps}
-              disabled={isReadOnly || !formikProps.values.clearanceNotificationSentOn}
+              disabled={
+                isReadOnly ||
+                (isClearanceNotificationSentOnRequired &&
+                  !formikProps.values.clearanceNotificationSentOn)
+              }
               field="requestForSplReceivedOn"
             />
           </Form.Row>
@@ -159,7 +167,11 @@ const EnhancedReferralCompleteForm = ({
             <FastDatePicker
               outerClassName="col-md-2"
               formikProps={formikProps}
-              disabled={isReadOnly || !formikProps.values.clearanceNotificationSentOn}
+              disabled={
+                isReadOnly ||
+                (isClearanceNotificationSentOnRequired &&
+                  !formikProps.values.clearanceNotificationSentOn)
+              }
               field="approvedForSplOn"
             />
             {(formikProps.values.statusCode === ReviewWorkflowStatus.ApprovedForErp ||
@@ -171,7 +183,8 @@ const EnhancedReferralCompleteForm = ({
                 <Button
                   disabled={
                     isReadOnly ||
-                    !formikProps.values.clearanceNotificationSentOn ||
+                    (isClearanceNotificationSentOnRequired &&
+                      !formikProps.values.clearanceNotificationSentOn) ||
                     !formikProps.values.requestForSplReceivedOn ||
                     !formikProps.values.approvedForSplOn
                   }
@@ -185,7 +198,11 @@ const EnhancedReferralCompleteForm = ({
                   <>
                     <OrText>OR</OrText>
                     <Button
-                      disabled={isReadOnly || !formikProps.values.clearanceNotificationSentOn}
+                      disabled={
+                        isReadOnly ||
+                        (isClearanceNotificationSentOnRequired &&
+                          !formikProps.values.clearanceNotificationSentOn)
+                      }
                       onClick={() =>
                         validateFormikWithCallback(formikProps, () => setNotInSpl(true))
                       }

--- a/frontend/src/features/projects/erp/forms/EnhancedReferralCompleteForm.tsx
+++ b/frontend/src/features/projects/erp/forms/EnhancedReferralCompleteForm.tsx
@@ -19,8 +19,7 @@ import {
   disposeWarning,
 } from '../../common';
 import GenericModal from 'components/common/GenericModal';
-import { validateFormikWithCallback } from 'utils';
-import { clearanceNotificationSentOnRequired } from './erpYupSchema';
+import { clearanceNotificationSentOnRequired, validateFormikWithCallback } from 'utils';
 
 const OrText = styled.div`
   margin: 0.75rem 2rem 0.75rem 2rem;
@@ -51,9 +50,9 @@ const EnhancedReferralCompleteForm = ({
   const [proceedToSpl, setProceedToSpl] = useState(false);
   const [notInSpl, setNotInSpl] = useState(false);
   const [disposeExternally, setDisposeExternally] = useState(false);
-  const isClearanceNotificationSentOnRequired = clearanceNotificationSentOnRequired(
-    formikProps.values.status?.code ?? '',
-  );
+  const isClearanceNotificationSentOnRequired =
+    !formikProps.values.clearanceNotificationSentOn &&
+    clearanceNotificationSentOnRequired(formikProps.values.status?.code ?? '');
   return (
     <Container fluid className="EnhancedReferralCompleteForm">
       <h3>Enhanced Referral Process Complete</h3>
@@ -151,11 +150,7 @@ const EnhancedReferralCompleteForm = ({
             <FastDatePicker
               outerClassName="col-md-2"
               formikProps={formikProps}
-              disabled={
-                isReadOnly ||
-                (isClearanceNotificationSentOnRequired &&
-                  !formikProps.values.clearanceNotificationSentOn)
-              }
+              disabled={isReadOnly || isClearanceNotificationSentOnRequired}
               field="requestForSplReceivedOn"
             />
           </Form.Row>
@@ -167,11 +162,7 @@ const EnhancedReferralCompleteForm = ({
             <FastDatePicker
               outerClassName="col-md-2"
               formikProps={formikProps}
-              disabled={
-                isReadOnly ||
-                (isClearanceNotificationSentOnRequired &&
-                  !formikProps.values.clearanceNotificationSentOn)
-              }
+              disabled={isReadOnly || isClearanceNotificationSentOnRequired}
               field="approvedForSplOn"
             />
             {(formikProps.values.statusCode === ReviewWorkflowStatus.ApprovedForErp ||
@@ -183,8 +174,7 @@ const EnhancedReferralCompleteForm = ({
                 <Button
                   disabled={
                     isReadOnly ||
-                    (isClearanceNotificationSentOnRequired &&
-                      !formikProps.values.clearanceNotificationSentOn) ||
+                    isClearanceNotificationSentOnRequired ||
                     !formikProps.values.requestForSplReceivedOn ||
                     !formikProps.values.approvedForSplOn
                   }
@@ -198,11 +188,7 @@ const EnhancedReferralCompleteForm = ({
                   <>
                     <OrText>OR</OrText>
                     <Button
-                      disabled={
-                        isReadOnly ||
-                        (isClearanceNotificationSentOnRequired &&
-                          !formikProps.values.clearanceNotificationSentOn)
-                      }
+                      disabled={isReadOnly || isClearanceNotificationSentOnRequired}
                       onClick={() =>
                         validateFormikWithCallback(formikProps, () => setNotInSpl(true))
                       }

--- a/frontend/src/features/projects/erp/forms/ExemptionEnhancedReferralCompleteForm.tsx
+++ b/frontend/src/features/projects/erp/forms/ExemptionEnhancedReferralCompleteForm.tsx
@@ -81,16 +81,12 @@ const ExemptionEnhancedReferralCompleteForm = ({
         <FastDatePicker
           outerClassName="col-md-2"
           formikProps={formikProps}
-          disabled={isReadOnly || !formikProps.values.clearanceNotificationSentOn}
+          disabled={isReadOnly}
           field="transferredWithinGreOn"
         />
         <div className="col-md-6">
           <Button
-            disabled={
-              isReadOnly ||
-              !formikProps.values.clearanceNotificationSentOn ||
-              !formikProps.values.transferredWithinGreOn
-            }
+            disabled={isReadOnly || !formikProps.values.transferredWithinGreOn}
             onClick={onClickGreTransferred}
           >
             Update Property Information
@@ -105,7 +101,7 @@ const ExemptionEnhancedReferralCompleteForm = ({
         <FastDatePicker
           outerClassName="col-md-2"
           formikProps={formikProps}
-          disabled={isReadOnly || !formikProps.values.clearanceNotificationSentOn}
+          disabled={isReadOnly}
           field="requestForSplReceivedOn"
         />
       </Form.Row>
@@ -116,13 +112,12 @@ const ExemptionEnhancedReferralCompleteForm = ({
         <FastDatePicker
           outerClassName="col-md-2"
           formikProps={formikProps}
-          disabled={isReadOnly || !formikProps.values.clearanceNotificationSentOn}
+          disabled={isReadOnly}
           field="approvedForSplOn"
         />
         <Button
           disabled={
             isReadOnly ||
-            !formikProps.values.clearanceNotificationSentOn ||
             !formikProps.values.requestForSplReceivedOn ||
             !formikProps.values.approvedForSplOn
           }
@@ -133,10 +128,7 @@ const ExemptionEnhancedReferralCompleteForm = ({
         {formikProps.values.statusCode !== ReviewWorkflowStatus.NotInSpl && (
           <>
             <OrText>OR</OrText>
-            <Button
-              disabled={isReadOnly || !formikProps.values.clearanceNotificationSentOn}
-              onClick={onClickNotInSpl}
-            >
+            <Button disabled={isReadOnly} onClick={onClickNotInSpl}>
               Not Included in the SPL
             </Button>
           </>
@@ -145,10 +137,7 @@ const ExemptionEnhancedReferralCompleteForm = ({
       <h3>Option 3: Add to Enhanced Referral Process</h3>
       <Form.Row>
         <div className="justify-content-center add-space-below">
-          <Button
-            disabled={isReadOnly || !formikProps.values.clearanceNotificationSentOn}
-            onClick={() => onClickAddToErp()}
-          >
+          <Button disabled={isReadOnly} onClick={() => onClickAddToErp()}>
             Add to Enhanced Referral Process
           </Button>
         </div>

--- a/frontend/src/features/projects/erp/forms/erpYupSchema.ts
+++ b/frontend/src/features/projects/erp/forms/erpYupSchema.ts
@@ -1,14 +1,6 @@
 import * as Yup from 'yup';
-import _ from 'lodash';
 import { IStatus } from 'features/projects/common';
-
-/**
- * Determine if the specified project status code requires a clearance notification sent on value.
- * @param statusCode The project status code.
- */
-export const clearanceNotificationSentOnRequired = (statusCode: string) => {
-  return _.includes(['ERP-ON', 'ERP-OH'], statusCode); // ERP-ON, ERP-OH
-};
+import { clearanceNotificationSentOnRequired } from 'utils';
 
 export const EnhancedReferralExemptionApprovedForSplSchema = Yup.object().shape({
   clearanceNotificationSentOn: Yup.date().when('status', (status: IStatus, schema: any) =>

--- a/frontend/src/features/projects/erp/forms/erpYupSchema.ts
+++ b/frontend/src/features/projects/erp/forms/erpYupSchema.ts
@@ -1,6 +1,18 @@
 import * as Yup from 'yup';
+import _ from 'lodash';
+import { IStatus } from 'features/projects/common';
+
+/**
+ * Determine if the specified project status code requires a clearance notification sent on value.
+ * @param statusCode The project status code.
+ */
+export const clearanceNotificationSentOnRequired = (statusCode: string) => {
+  return _.includes(['ERP-ON', 'ERP-OH'], statusCode); // ERP-ON, ERP-OH
+};
 
 export const EnhancedReferralExemptionApprovedForSplSchema = Yup.object().shape({
-  clearanceNotificationSentOn: Yup.date().required('Required'),
+  clearanceNotificationSentOn: Yup.date().when('status', (status: IStatus, schema: any) =>
+    clearanceNotificationSentOnRequired(status.code) ? schema.required('Required') : schema,
+  ),
   requestForSplReceivedOn: Yup.date().required('Required'),
 });

--- a/frontend/src/features/projects/erp/steps/ErpStep.test.tsx
+++ b/frontend/src/features/projects/erp/steps/ErpStep.test.tsx
@@ -105,7 +105,7 @@ describe('ERP Approval Step', () => {
       const { getByText } = render(getApprovalStep());
       const proceedToSplButton = getByText(/Not Included in the SPL/);
       expect(proceedToSplButton).toBeVisible();
-      expect(proceedToSplButton).toBeDisabled();
+      expect(proceedToSplButton).toBeEnabled();
     });
     it('correct form fields are disabled', () => {
       const { queryAllByRole } = render(getApprovalStep());
@@ -114,7 +114,7 @@ describe('ERP Approval Step', () => {
         expect(textbox).toBeVisible();
         if (textbox.id.includes('Spl')) {
           //only disabled textboxes are SPL related datepickers and erp emails text
-          expect(textbox).toBeDisabled();
+          expect(textbox).toBeEnabled();
         } else {
           if (textbox.id.includes('[22]')) {
             expect(textbox).toBeDisabled();
@@ -188,7 +188,7 @@ describe('ERP Approval Step', () => {
       project.workflowCode = DisposalWorkflows.Erp;
       const component = render(getApprovalStep(getStore(project)));
       const proceedToSplButton = component.queryByText(/Not Included in the SPL/);
-      expect(proceedToSplButton).toBeDisabled();
+      expect(proceedToSplButton).toBeEnabled();
     });
     it('correct form fields are disabled', () => {
       const component = render(getApprovalStep(getStore(project)));
@@ -197,7 +197,7 @@ describe('ERP Approval Step', () => {
         expect(textbox).toBeVisible();
         if (textbox.id.includes('Spl')) {
           //only disabled textboxes are SPL related datepickers and erp emails text
-          expect(textbox).toBeDisabled();
+          expect(textbox).toBeEnabled();
         } else {
           if (textbox.id.includes('[22]')) {
             expect(textbox).toBeDisabled();

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -327,3 +327,11 @@ export function emptyStringToNull(value: any, originalValue: any) {
   }
   return value;
 }
+
+/**
+ * Determine if the specified project status code requires a clearance notification sent on value.
+ * @param statusCode The project status code.
+ */
+export const clearanceNotificationSentOnRequired = (statusCode: string) => {
+  return ['ERP-ON', 'ERP-OH'].includes(statusCode);
+};


### PR DESCRIPTION
Disposal Projects will only require the `ClearanceNotificationSentOn` date if they are in ERP.

Disposal Projects that are in other status like **Not in SPL** will not require the value.

This should allow some historical projects to bypass this validation.