### PR TITLE
Default to includeAllProperties in Surplust Filter

### DIFF
--- a/frontend/src/features/properties/filter/PropertyFilter.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilter.tsx
@@ -114,7 +114,7 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
   }, [defaultFilter, propertyFilter, agencies]);
 
   const changeFilter = (values: IPropertyFilter) => {
-    const agencyIds = (values.agencies as any).value
+    const agencyIds = (values.agencies as any)?.value
       ? (values.agencies as any).value
       : values.agencies;
     setPropertyFilter({ ...values, agencies: agencyIds });
@@ -149,6 +149,8 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
               onEnter={() => {
                 setFindMoreOpen(true);
                 setFieldValue('surplusFilter', true);
+                setFieldValue('includeAllProperties', true);
+                !keycloak.hasClaim(Claims.ADMIN_PROPERTIES) && setFieldValue('agencies', undefined);
               }}
               onExit={() => {
                 setFindMoreOpen(false);


### PR DESCRIPTION
- Non sres user cannot specify which agency just set it to undefined and `includeAllProperties` when searching surplus filter 
- If sres user they can adjust the agency filter with `includeAllProperties` set to true

Something to confirm, will a user (ex. REM) want to do the SPL/ERP filter with `includeAllProperties = false`? Will have to adjust if this is the case. The Surplus Filter and Property Filter have the same initial values so some more logic will have to be added.