### PR TITLE
Database DC changed Rolling to Recreate

### DIFF
--- a/openshift/4.0/templates/api/deploy.yaml
+++ b/openshift/4.0/templates/api/deploy.yaml
@@ -122,6 +122,11 @@ parameters:
     description: "Readiness health check api path."
     value: "/health/ready"
 
+  - name: REPLICAS
+    displayName: "Pod Replicas"
+    description: "Number of pod replicas to run"
+    value: "2"
+
   - name: CPU_REQUEST
     displayName: "CPU Request"
     description: "Starting amount of CPU the container can use."
@@ -386,7 +391,7 @@ objects:
               kind: ImageStreamTag
               namespace: "${PROJECT_NAMESPACE}-tools"
               name: "${APP_NAME}-${ROLE_NAME}:${IMAGE_TAG}"
-      replicas: 1
+      replicas: ${{REPLICAS}}
       selector:
         app: ${APP_NAME}
         role: ${ROLE_NAME}

--- a/openshift/4.0/templates/app/deploy.yaml
+++ b/openshift/4.0/templates/app/deploy.yaml
@@ -91,6 +91,11 @@ parameters:
     required: true
     value: "/api"
 
+  - name: REPLICAS
+    displayName: "Pod Replicas"
+    description: "Number of pod replicas to run"
+    value: "2"
+
   - name: CPU_REQUEST
     displayName: "CPU Request"
     description: "Starting amount of CPU the container can use."
@@ -173,7 +178,7 @@ objects:
         role: ${ROLE_NAME}
         env: ${ENV_NAME}
     spec:
-      replicas: 1
+      replicas: ${{REPLICAS}}
       selector:
         name: ${APP_NAME}-${ROLE_NAME}${INSTANCE}
         app: ${APP_NAME}

--- a/openshift/4.0/templates/database/mssql-deploy.yaml
+++ b/openshift/4.0/templates/database/mssql-deploy.yaml
@@ -238,7 +238,11 @@ objects:
         env: ${ENV_NAME}
     spec:
       strategy:
-        type: Rolling
+        type: Recreate
+      recreateParams:
+        pre: {}
+        mid: {}
+        post: {}
       triggers:
         - type: ConfigChange
         - type: ImageChange


### PR DESCRIPTION
Change deployment configuration to use `Recreate` instead of `Rolling` for the database.  This is because the database will fight over the database file when a new pod starts up.