### PR TITLE
PA-2875 Updated Not in SPL to Dispose

### DIFF
--- a/frontend/src/features/projects/erp/forms/EnhancedReferralCompleteForm.tsx
+++ b/frontend/src/features/projects/erp/forms/EnhancedReferralCompleteForm.tsx
@@ -213,7 +213,6 @@ const EnhancedReferralCompleteForm = ({
                   Date of Accepted Offer
                 </Form.Label>
                 <FastDatePicker
-                  required
                   outerClassName="col-md-2"
                   formikProps={formikProps}
                   disabled={isReadOnly}
@@ -225,7 +224,6 @@ const EnhancedReferralCompleteForm = ({
                   Purchaser
                 </Form.Label>
                 <FastInput
-                  required
                   field="purchaser"
                   outerClassName="col-md-2"
                   disabled={isReadOnly}
@@ -237,7 +235,6 @@ const EnhancedReferralCompleteForm = ({
                   Offer Amount
                 </Form.Label>
                 <FastCurrencyInput
-                  required
                   field="offerAmount"
                   outerClassName="col-md-2"
                   disabled={isReadOnly}
@@ -250,6 +247,7 @@ const EnhancedReferralCompleteForm = ({
                   Disposal Date
                 </Form.Label>
                 <FastDatePicker
+                  required
                   outerClassName="col-md-2"
                   formikProps={formikProps}
                   disabled={isReadOnly}

--- a/frontend/src/features/projects/erp/forms/ExemptionEnhancedReferralCompleteForm.tsx
+++ b/frontend/src/features/projects/erp/forms/ExemptionEnhancedReferralCompleteForm.tsx
@@ -151,7 +151,6 @@ const ExemptionEnhancedReferralCompleteForm = ({
               Date of Accepted Offer
             </Form.Label>
             <FastDatePicker
-              required
               outerClassName="col-md-2"
               formikProps={formikProps}
               disabled={isReadOnly}
@@ -163,7 +162,6 @@ const ExemptionEnhancedReferralCompleteForm = ({
               Purchaser
             </Form.Label>
             <FastInput
-              required
               field="purchaser"
               outerClassName="col-md-2"
               disabled={isReadOnly}
@@ -175,7 +173,6 @@ const ExemptionEnhancedReferralCompleteForm = ({
               Offer Amount
             </Form.Label>
             <FastCurrencyInput
-              required
               field="offerAmount"
               outerClassName="col-md-2"
               disabled={isReadOnly}
@@ -188,6 +185,7 @@ const ExemptionEnhancedReferralCompleteForm = ({
               Disposal Date
             </Form.Label>
             <FastDatePicker
+              required
               outerClassName="col-md-2"
               formikProps={formikProps}
               disabled={isReadOnly}


### PR DESCRIPTION
Removed some of the required attributes on inputs to allow **Not in SPL** to go to **Disposed**.

![image](https://user-images.githubusercontent.com/3180256/110150211-d6a90e00-7d93-11eb-90b3-167f81387467.png)
