### PR TITLE
Land only filter fix

### DIFF
--- a/backend/dal/Helpers/Extensions/PropertyExtensions.cs
+++ b/backend/dal/Helpers/Extensions/PropertyExtensions.cs
@@ -56,12 +56,13 @@ namespace Pims.Dal.Helpers.Extensions
                 query = query.Where(p => p.RentableArea <= filter.RentableArea);
 
             if (filter.BareLandOnly == true)
-                query = (from p in query
-                         join pb in context.ParcelBuildings
-                            on p.Id equals pb.ParcelId into ppbGroup
-                         from pb in ppbGroup.DefaultIfEmpty()
-                         where pb == null && p.PropertyTypeId == Entity.PropertyTypes.Land
-                         select p);
+            {
+                query = from p in query
+                        join pa in context.Parcels on new { p.Id, PropertyTypeId = (int)p.PropertyTypeId } equals new { pa.Id, PropertyTypeId = (int)pa.PropertyTypeId }
+                        where p.PropertyTypeId == Entity.PropertyTypes.Land
+                            && pa.Buildings.Count() == 0
+                        select p;
+            }
 
             if (filter.NELatitude.HasValue && filter.NELongitude.HasValue && filter.SWLatitude.HasValue && filter.SWLongitude.HasValue)
             {


### PR DESCRIPTION
This filter was working on its own (ie. without SPL/ERP filter applied); however, started failing when the two were used together.

I spent a couple of hours trying to get the join to work but it seems as if it was failing due to the attempt to join an in-memory collection with EF. 

This was the only working solution that I could find, let me know if it is efficient enough. 