### PR TITLE
PA-2948 Debugging Notifications

### DIFF
--- a/backend/api/Areas/Notification/Controllers/TemplateController.cs
+++ b/backend/api/Areas/Notification/Controllers/TemplateController.cs
@@ -136,6 +136,8 @@ namespace Pims.Api.Areas.Notification.Controllers
         /// </summary>
         /// <param name="templateId"></param>
         /// <param name="to"></param>
+        /// <param name="cc"></param>
+        /// <param name="bcc"></param>
         /// <param name="projectId"></param>
         /// <returns></returns>
         [HttpPost("{templateId}/projects/{projectId}")]
@@ -144,12 +146,12 @@ namespace Pims.Api.Areas.Notification.Controllers
         [ProducesResponseType(typeof(Models.Queue.NotificationQueueModel), 201)]
         [ProducesResponseType(typeof(ErrorResponseModel), 400)]
         [SwaggerOperation(Tags = new[] { "notification" })]
-        public async Task<IActionResult> SendProjectNotificationAsync(int templateId, string to, int projectId)
+        public async Task<IActionResult> SendProjectNotificationAsync(int templateId, string to, string cc, string bcc, int projectId)
         {
             var project = _pimsService.Project.Get(projectId);
             var env = new Entity.Models.EnvironmentModel(_options.Environment.Uri, _options.Environment.Name, _options.Environment.Title);
             var model = new Entity.Models.ProjectNotificationModel(Guid.NewGuid(), env, project, project.Agency);
-            var notification = await _pimsService.NotificationTemplate.SendNotificationAsync(templateId, to, model);
+            var notification = await _pimsService.NotificationTemplate.SendNotificationAsync(templateId, to, cc, bcc, model);
 
             return CreatedAtAction(nameof(QueueController.GetNotificationQueue), new { controller = "queue", id = notification.Id }, _mapper.Map<Models.Queue.NotificationQueueModel>(notification));
         }

--- a/backend/ches/ChesService.cs
+++ b/backend/ches/ChesService.cs
@@ -217,6 +217,10 @@ namespace Pims.Ches
                 email.Cc = new string[0];
                 email.Bcc = new string[0];
             }
+            if (this.Options.AlwaysDelay.HasValue)
+            {
+                email.SendOn = email.SendOn.AddSeconds(this.Options.AlwaysDelay.Value);
+            }
 
             // Make sure there are no blank CC or BCC;
             email.To = email.To.NotNullOrWhiteSpace();
@@ -264,6 +268,11 @@ namespace Pims.Ches
                     c.Cc = new string[0];
                     c.Bcc = new string[0];
                 });
+            }
+            if (this.Options.AlwaysDelay.HasValue)
+            {
+                email.Contexts.ForEach(c =>
+                    c.SendOn = c.SendOn.AddSeconds(this.Options.AlwaysDelay.Value));
             }
 
             // Make sure there are no blank CC or BCC;

--- a/backend/ches/Configuration/ChesOptions.cs
+++ b/backend/ches/Configuration/ChesOptions.cs
@@ -55,6 +55,12 @@ namespace Pims.Ches.Configuration
         /// get/set - Always BCC the specified email address.
         /// </summary>
         public string AlwaysBcc { get; set; }
+
+        /// <summary>
+        /// get/set - Number of seconds to delay sending notifications from their configured 'send on' date and time.
+        /// </summary>
+        /// <value></value>
+        public int? AlwaysDelay { get; set; }
         #endregion
     }
 }

--- a/backend/dal/Services/Concrete/NotificationTemplateService.cs
+++ b/backend/dal/Services/Concrete/NotificationTemplateService.cs
@@ -156,12 +156,25 @@ namespace Pims.Dal.Services
         /// <returns></returns>
         public async Task<NotificationQueue> SendNotificationAsync<T>(int templateId, string to, T model) where T : class // TODO: Allow for a way to pass a model to this function.
         {
+            return await SendNotificationAsync<T>(templateId, to, null, null, model);
+        }
+
+        /// <summary>
+        /// Send an email notification for the specified notification template 'templateId' to the specified list of email addresses in 'to'.
+        /// </summary>
+        /// <param name="templateId"></param>
+        /// <param name="to"></param>
+        /// <param name="cc"></param>
+        /// <param name="bcc"></param>
+        /// <returns></returns>
+        public async Task<NotificationQueue> SendNotificationAsync<T>(int templateId, string to, string cc, string bcc, T model) where T : class // TODO: Allow for a way to pass a model to this function.
+        {
             this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin);
 
             if (String.IsNullOrWhiteSpace(to)) throw new ArgumentException("Argument is required and cannot be null, empty or whitespace.", nameof(to));
 
             var template = this.Context.NotificationTemplates.Find(templateId) ?? throw new KeyNotFoundException();
-            var notification = new NotificationQueue(template, to, template.Subject, template.Body);
+            var notification = new NotificationQueue(template, to, cc, bcc, template.Subject, template.Body);
 
             this.Context.NotificationQueue.Add(notification);
             this.Context.CommitTransaction();

--- a/backend/dal/Services/INotificationTemplateService.cs
+++ b/backend/dal/Services/INotificationTemplateService.cs
@@ -17,5 +17,6 @@ namespace Pims.Dal.Services
         void Remove(NotificationTemplate template);
         Task<NotificationQueue> SendNotificationAsync(int templateId, string to);
         Task<NotificationQueue> SendNotificationAsync<T>(int templateId, string to, T model) where T : class;
+        Task<NotificationQueue> SendNotificationAsync<T>(int templateId, string to, string cc, string bcc, T model) where T : class;
     }
 }

--- a/backend/entities/NotificationQueue.cs
+++ b/backend/entities/NotificationQueue.cs
@@ -192,7 +192,20 @@ namespace Pims.Dal.Entities
         /// <param name="to"></param>
         /// <param name="subject"></param>
         /// <param name="body"></param>
-        public NotificationQueue(NotificationTemplate template, string to, string subject, string body)
+        public NotificationQueue(NotificationTemplate template, string to, string subject, string body) : this(template, to, null, null, subject, body)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of a NotificationQueue class, initializes with specified parameters.
+        /// </summary>
+        /// <param name="template"></param>
+        /// <param name="to"></param>
+        /// <param name="cc"></param>
+        /// <param name="bcc"></param>
+        /// <param name="subject"></param>
+        /// <param name="body"></param>
+        public NotificationQueue(NotificationTemplate template, string to, string cc, string bcc, string subject, string body)
         {
             if (String.IsNullOrWhiteSpace(to)) throw new ArgumentException("Argument is required and cannot be null, empty or whitespace.", nameof(to));
             if (String.IsNullOrWhiteSpace(subject)) throw new ArgumentException("Argument is required and cannot be null, empty or whitespace.", nameof(subject));
@@ -202,6 +215,8 @@ namespace Pims.Dal.Entities
             this.TemplateId = template?.Id ?? throw new ArgumentNullException(nameof(template));
             this.Template = template;
             this.To = to;
+            this.Cc = cc;
+            this.Bcc = bcc;
             this.Subject = subject;
             this.Body = body;
             this.BodyType = template.BodyType;

--- a/backend/notifications/NotificationService.cs
+++ b/backend/notifications/NotificationService.cs
@@ -64,9 +64,9 @@ namespace Pims.Notifications
                 // Send notifications to CHES.
                 var response = await SendAsync(new Model.Email()
                 {
-                    To = notification.To.Split(";"),
-                    Cc = notification.Cc?.Split(";"),
-                    Bcc = notification.Bcc?.Split(";"),
+                    To = notification.To.Split(";").Select(v => v.Trim()),
+                    Cc = notification.Cc?.Split(";").Select(v => v.Trim()),
+                    Bcc = notification.Bcc?.Split(";").Select(v => v.Trim()),
                     Encoding = (Model.EmailEncodings)Enum.Parse(typeof(Model.EmailEncodings), notification.Encoding.ToString()),
                     BodyType = (Model.EmailBodyTypes)Enum.Parse(typeof(Model.EmailBodyTypes), notification.BodyType.ToString()),
                     Priority = (Model.EmailPriorities)Enum.Parse(typeof(Model.EmailPriorities), notification.Priority.ToString()),

--- a/backend/tests/unit/api/Controllers/Notification/TemplateControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/Notification/TemplateControllerTest.cs
@@ -208,11 +208,11 @@ namespace Pims.Api.Test.Controllers
             var template = EntityHelper.CreateNotificationTemplate(1, "test");
             var notification = EntityHelper.CreateNotificationQueue(1, template);
             var project = EntityHelper.CreateProject(1);
-            service.Setup(m => m.NotificationTemplate.SendNotificationAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<object>())).ReturnsAsync(notification);
+            service.Setup(m => m.NotificationTemplate.SendNotificationAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>())).ReturnsAsync(notification);
             service.Setup(m => m.Project.Get(It.IsAny<int>())).Returns(project);
 
             // Act
-            var result = await controller.SendProjectNotificationAsync(template.Id, "test@test.com", project.Id);
+            var result = await controller.SendProjectNotificationAsync(template.Id, "test@test.com", null, null, project.Id);
 
             // Assert
             var actionResult = Assert.IsType<CreatedAtActionResult>(result);

--- a/backend/tests/unit/api/Routes/Notification/TemplateControllerTest.cs
+++ b/backend/tests/unit/api/Routes/Notification/TemplateControllerTest.cs
@@ -112,7 +112,7 @@ namespace Pims.Api.Test.Routes.Project
         public void SendNotificationAsync_Route()
         {
             // Arrange
-            var endpoint = typeof(TemplateController).FindMethod(nameof(TemplateController.SendProjectNotificationAsync), typeof(int), typeof(string), typeof(int));
+            var endpoint = typeof(TemplateController).FindMethod(nameof(TemplateController.SendProjectNotificationAsync), typeof(int), typeof(string), typeof(string), typeof(string), typeof(int));
 
             // Act
             // Assert


### PR DESCRIPTION
Adding a configurable delay to all notifications.

Providing a way to test `to`, `cc`, and `bcc` notifications.  This may allow us to debug production email issues as we can send emails and place them in a queue for a length of time where support resources can review the test emails.