### PR TITLE
disable clustering until after zoom is done

### DIFF
--- a/frontend/src/components/maps/hooks/useSupercluster.test.tsx
+++ b/frontend/src/components/maps/hooks/useSupercluster.test.tsx
@@ -57,7 +57,7 @@ describe('useSupercluster hook', () => {
     ];
 
     const zoom = 10;
-    const options = { radius: 75, maxZoom: 20 };
+    const options = { radius: 75, maxZoom: 20, enableClustering: true };
 
     // Act
     const App = () => {

--- a/frontend/src/components/maps/hooks/useSupercluster.ts
+++ b/frontend/src/components/maps/hooks/useSupercluster.ts
@@ -5,11 +5,15 @@ import deepEqual from 'dequal';
 import Supercluster from 'supercluster';
 import { ICluster } from '../types';
 
+interface SuperclusterOptions<P, C> extends Supercluster.Options<P, C> {
+  /** Optionally enable clusters recalculation */
+  enableClustering?: boolean;
+}
 export interface UseSuperclusterProps<P, C> {
   points: Array<Supercluster.PointFeature<P>>;
   bounds?: BBox;
   zoom: number;
-  options?: Supercluster.Options<P, C>;
+  options?: SuperclusterOptions<P, C>;
 }
 
 const useSupercluster = <
@@ -33,8 +37,14 @@ const useSupercluster = <
       superclusterRef.current.load(points);
     }
 
-    if (bounds) {
+    /**
+     * Only create clusters when zooming to results is done OR number of points is
+     * greater than 100 (avoid perfomrance issues when rendering all points)
+     */
+    if (bounds && (options?.enableClustering || points.length > 100)) {
       setClusters(superclusterRef.current.getClusters(bounds, zoomInt));
+    } else {
+      setClusters(points);
     }
 
     pointsRef.current = points;

--- a/frontend/src/components/maps/leaflet/PointClusterer.tsx
+++ b/frontend/src/components/maps/leaflet/PointClusterer.tsx
@@ -133,7 +133,7 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
     points,
     bounds,
     zoom,
-    options: { radius: 60, extent: 256, minZoom, maxZoom },
+    options: { radius: 60, extent: 256, minZoom, maxZoom, enableClustering: !filterState.changed },
   });
   const currentClusterIds = useMemo(() => {
     if (!currentCluster?.properties?.cluster_id) {
@@ -242,16 +242,11 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
       const group: LeafletFeatureGroup = featureGroupRef.current.leafletElement;
       const groupBounds = group.getBounds();
 
-      if (
-        groupBounds.isValid() &&
-        group.getBounds().isValid() &&
-        filterState.changed &&
-        !selected?.parcelDetail &&
-        tilesLoaded
-      ) {
+      if (groupBounds.isValid() && filterState.changed && !selected?.parcelDetail && tilesLoaded) {
         filterState.setChanged(false);
         map.fitBounds(group.getBounds(), { maxZoom: zoom > MAX_ZOOM ? zoom : MAX_ZOOM });
       }
+
       setSpider({});
       spiderfierRef.current?.unspiderfy();
       setCurrentCluster(undefined);


### PR DESCRIPTION
Allow zoom to the map results after search and avoid cluster splitting before zoom is done.