### PR TITLE
PA-2634, PA-2886: Filter bug fixes

### DIFF
--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -180,6 +180,7 @@ const Map: React.FC<MapProps> = ({
     includeAllProperties: keycloak.hasClaim(Claims.ADMIN_PROPERTIES),
   } as any);
   const [baseLayers, setBaseLayers] = useState<BaseLayer[]>([]);
+  const [triggerFilterChanged, setTriggerFilterChanged] = useState(true);
   const [activeBasemap, setActiveBasemap] = useState<BaseLayer | null>(null);
   const smallScreen = useMediaQuery({ maxWidth: 1800 });
   const [mapWidth, setMapWidth] = useState(0);
@@ -219,7 +220,6 @@ const Map: React.FC<MapProps> = ({
   }, [mapRef, mapWidth]);
 
   // TODO: refactor various zoom settings
-
   useEffect(() => {
     if (!interactive) {
       const map = mapRef.current?.leafletElement;
@@ -243,10 +243,12 @@ const Map: React.FC<MapProps> = ({
         return (isEqual(objValue[key], othValue[key]) || (!objValue[key] && !othValue[key])) && acc;
       }, true);
     };
-    if (!isEqualWith(geoFilter, filter, compareValues)) {
+    // Search button will always trigger filter changed (triggerFilterChanged is set to true when search button is clicked)
+    if (!isEqualWith(geoFilter, filter, compareValues) || triggerFilterChanged) {
       dispatch(storeParcelDetail(null));
       setGeoFilter(getQueryParams(filter));
       setChanged(true);
+      setTriggerFilterChanged(false);
     }
   };
 
@@ -344,6 +346,7 @@ const Map: React.FC<MapProps> = ({
                     agencyLookupCodes={agencies}
                     adminAreaLookupCodes={administrativeAreas}
                     onChange={handleMapFilterChange}
+                    setTriggerFilterChanged={setTriggerFilterChanged}
                     showAllAgencySelect={true}
                   />
                 </Container>

--- a/frontend/src/components/maps/leaflet/MapProperties.test.tsx
+++ b/frontend/src/components/maps/leaflet/MapProperties.test.tsx
@@ -219,7 +219,7 @@ describe('MapProperties View', () => {
     expect((loadProperties as jest.Mock).mock.calls[9][0].name).toBe('testname');
   });
 
-  it('makes no additional calls if the filter button is clicked and the filter has not changed.', async () => {
+  it('filter will fire everytime the search button is clicked', async () => {
     const mapRef = createRef<ReactLeafletMap<LeafletMapProps, LeafletMap>>();
 
     const { container } = render(getMap(mapRef, noParcels, emptyDetails));
@@ -227,7 +227,7 @@ describe('MapProperties View', () => {
     fireEvent.click(searchButton!);
 
     const { loadProperties } = useApi();
-    await wait(() => expect(loadProperties).toHaveBeenCalledTimes(9), { timeout: 500 });
+    await wait(() => expect(loadProperties).toHaveBeenCalledTimes(18), { timeout: 500 });
   });
 
   it('makes the correct calls to load the map data when the reset filter is clicked', async () => {

--- a/frontend/src/features/properties/filter/PropertyFilter.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilter.tsx
@@ -45,6 +45,8 @@ export interface IPropertyFilterProps {
   onSorting?: (sort: TableSort<any>) => void;
   /** Show select with my agencies/All Government dropdown */
   showAllAgencySelect?: boolean;
+  /** Override to trigger filterchanged in the parent */
+  setTriggerFilterChanged?: (used: boolean) => void;
 }
 
 const AgencyCol = styled(Col)`
@@ -74,6 +76,7 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
   sort,
   onSorting,
   showAllAgencySelect,
+  setTriggerFilterChanged,
 }) => {
   const [propertyFilter, setPropertyFilter] = React.useState<IPropertyFilter>(defaultFilter);
   const dispatch = useDispatch();
@@ -231,7 +234,10 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
               />
             </Col>
             <Col className="bar-item flex-grow-0">
-              <SearchButton disabled={isSubmitting || findMoreOpen} />
+              <SearchButton
+                disabled={isSubmitting || findMoreOpen}
+                onClick={() => setTriggerFilterChanged && setTriggerFilterChanged(true)}
+              />
             </Col>
             <Col className="bar-item flex-grow-0">
               <ResetButton disabled={isSubmitting || findMoreOpen} onClick={resetFilter} />

--- a/frontend/src/features/properties/filter/__snapshots__/PropertyFilter.test.tsx.snap
+++ b/frontend/src/features/properties/filter/__snapshots__/PropertyFilter.test.tsx.snap
@@ -300,11 +300,6 @@ exports[`MapFilterBar renders correctly 1`] = `
       <button
         class="Button Button--icon-only bg-warning btn btn-primary"
         id="search-button"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseOut={[Function]}
-        onMouseOver={[Function]}
         type="submit"
       >
         <div

--- a/frontend/src/features/properties/filter/__snapshots__/PropertyFilter.test.tsx.snap
+++ b/frontend/src/features/properties/filter/__snapshots__/PropertyFilter.test.tsx.snap
@@ -300,6 +300,11 @@ exports[`MapFilterBar renders correctly 1`] = `
       <button
         class="Button Button--icon-only bg-warning btn btn-primary"
         id="search-button"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         type="submit"
       >
         <div

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -246,6 +246,8 @@ const PropertyListView: React.FC = () => {
   const { updateBuilding, updateParcel } = useApi();
   const [editable, setEditable] = useState(false);
   const tableFormRef = useRef<FormikProps<{ properties: IProperty[] }> | undefined>();
+  /** maintains state of table's propertyType when user switches via tabs  */
+  const [propertyType, setPropertyType] = useState<PropertyTypeNames>(PropertyTypeNames.Land);
   const [dirtyRows, setDirtyRows] = useState<IChangedRow[]>([]);
   const keycloak = useKeycloakWrapper();
   const municipalities = useMemo(
@@ -347,11 +349,11 @@ const PropertyListView: React.FC = () => {
   // Update internal state whenever the filter bar state changes
   const handleFilterChange = useCallback(
     async (value: IPropertyFilter) => {
-      setFilter({ ...value });
-      updateSearch({ ...value });
+      setFilter({ ...value, propertyType: propertyType });
+      updateSearch({ ...value, propertyType: propertyType });
       setPageIndex(0); // Go to first page of results when filter changes
     },
-    [setFilter, setPageIndex, updateSearch],
+    [setFilter, setPageIndex, updateSearch, propertyType],
   );
   // This will get called when the table needs new data
   const handleRequestData = useCallback(
@@ -449,6 +451,7 @@ const PropertyListView: React.FC = () => {
   };
 
   const changePropertyType = (type: PropertyTypeNames) => {
+    setPropertyType(type);
     setPageIndex(0);
     setFilter(state => {
       return {


### PR DESCRIPTION
Search button will now always fire filter changed event, and inventory list view will now correctly stay on the appropriate `propertyType` tab after applying a filter