### PR TITLE
Bug fixes for submitting on behalf on child agency

### DIFF
--- a/backend/dal/Services/Concrete/BuildingService.cs
+++ b/backend/dal/Services/Concrete/BuildingService.cs
@@ -147,7 +147,7 @@ namespace Pims.Dal.Services
                     && (isAdmin
                         || b.IsVisibleToOtherAgencies
                         || ((!b.IsSensitive || viewSensitive)
-                            && (userAgencies.Contains(b.AgencyId) || userAgencies.Contains(b.Agency.ParentId))))) ?? throw new KeyNotFoundException();
+                            && userAgencies.Contains(b.AgencyId)))) ?? throw new KeyNotFoundException();
 
             return building;
         }
@@ -167,7 +167,7 @@ namespace Pims.Dal.Services
 
             // A building should have a unique name within the parcel it is located on.
             building.Parcels.ForEach(pb => this.Context.ThrowIfNotUnique(pb.Parcel, building));
-            // SRES users allowed to overwrite, or if user belongs to parent ministry
+            // If the user is not an admin, and their agency is not a parent override to their user agency
             if (!this.User.HasPermission(Permissions.AdminProperties) && agency.ParentId != null)
             {
                 building.AgencyId = agency.Id;

--- a/backend/dal/Services/Concrete/BuildingService.cs
+++ b/backend/dal/Services/Concrete/BuildingService.cs
@@ -147,7 +147,7 @@ namespace Pims.Dal.Services
                     && (isAdmin
                         || b.IsVisibleToOtherAgencies
                         || ((!b.IsSensitive || viewSensitive)
-                            && userAgencies.Contains(b.AgencyId)))) ?? throw new KeyNotFoundException();
+                            && (userAgencies.Contains(b.AgencyId) || userAgencies.Contains(b.Agency.ParentId))))) ?? throw new KeyNotFoundException();
 
             return building;
         }
@@ -167,8 +167,8 @@ namespace Pims.Dal.Services
 
             // A building should have a unique name within the parcel it is located on.
             building.Parcels.ForEach(pb => this.Context.ThrowIfNotUnique(pb.Parcel, building));
-            // SRES users allowed to overwrite
-            if (!this.User.HasPermission(Permissions.AdminProperties))
+            // SRES users allowed to overwrite, or if user belongs to parent ministry
+            if (!this.User.HasPermission(Permissions.AdminProperties) && agency.ParentId != null)
             {
                 building.AgencyId = agency.Id;
                 building.Agency = agency;

--- a/backend/dal/Services/Concrete/ParcelService.cs
+++ b/backend/dal/Services/Concrete/ParcelService.cs
@@ -196,8 +196,8 @@ namespace Pims.Dal.Services
             if (parcel.Parcels.Count() > 0 && parcel.Subdivisions.Count() > 0) throw new InvalidOperationException("Parcel may only have associated parcels or subdivisions, not both.");
 
             this.Context.Parcels.ThrowIfNotUnique(parcel);
-            // SRES users allowed to overwrite
-            if (!this.User.HasPermission(Permissions.AdminProperties))
+            // If the user is not an admin, and their agency is not a parent override to their user agency
+            if (!this.User.HasPermission(Permissions.AdminProperties) && agency.ParentId != null)
             {
                 parcel.AgencyId = agency.Id;
                 parcel.Agency = agency;

--- a/backend/tests/unit/dal/Services/ParcelServiceTest.cs
+++ b/backend/tests/unit/dal/Services/ParcelServiceTest.cs
@@ -693,7 +693,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             init.SaveChanges();
             var parcel = EntityHelper.CreateParcel(1);
@@ -716,7 +716,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             init.SaveChanges();
             var parcel = EntityHelper.CreateParcel(1);
@@ -765,7 +765,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             var project = init.CreateProject(1);
             project.ReportedFiscalYear = 2020;
@@ -807,7 +807,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             var originalParcel = init.CreateParcel(1);
             init.SaveChanges();
@@ -832,7 +832,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             init.CreateParcel(1);
             init.SaveChanges();
@@ -857,7 +857,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             var originalParcel = init.CreateParcel(1);
             init.SaveChanges();
@@ -882,7 +882,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             var originalParcel = init.CreateParcel(1);
             originalParcel.PIN = 1;
@@ -908,7 +908,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             var originalParcel = init.CreateParcel(1);
             originalParcel.PIN = 1;
@@ -1177,7 +1177,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd, Permissions.PropertyEdit).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd, Permissions.PropertyEdit).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             var parcel = EntityHelper.CreateParcel(1);
 
@@ -1207,7 +1207,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd, Permissions.PropertyEdit).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyAdd, Permissions.PropertyEdit).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             var parcel = EntityHelper.CreateParcel(1);
 
@@ -1237,7 +1237,7 @@ namespace Pims.Dal.Test.Services
         {
             // Arrange
             var helper = new TestHelper();
-            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyEdit, Permissions.PropertyAdd).AddAgency(1);
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView, Permissions.PropertyEdit, Permissions.PropertyAdd).AddAgency(10);
             var init = helper.InitializeDatabase(user);
             var originalParcel = init.CreateParcel(1);
             var updatedParcel = init.CreateParcel(3);

--- a/frontend/src/components/Table/ColumnFilter.tsx
+++ b/frontend/src/components/Table/ColumnFilter.tsx
@@ -21,7 +21,6 @@ const Wrapper = styled('div')`
   align-items: center;
   justify-items: center;
   position: relative;
-  font-size: 12px;
   padding: 0 5px;
 `;
 

--- a/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
+++ b/frontend/src/features/properties/list/__snapshots__/PropertyListView.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`Property list view Matches snapshot 1`] = `
   align-items: center;
   justify-items: center;
   position: relative;
-  font-size: 12px;
   padding: 0 5px;
 }
 

--- a/frontend/src/utils/YupSchema.ts
+++ b/frontend/src/utils/YupSchema.ts
@@ -157,7 +157,8 @@ export const BuildingInformationSchema = Yup.object().shape({
   address: Address.required(),
   agencyId: Yup.number()
     .transform(emptyStringToNull)
-    .required('Required'),
+    .required('Required')
+    .typeError('Selection from list required.'),
   isSensitive: Yup.boolean()
     .nullable()
     .transform(emptyStringToNull)
@@ -248,6 +249,7 @@ export const ParcelSchema = Yup.object()
         .of(FinancialYear),
       agencyId: Yup.number()
         .transform(emptyStringToNull)
+        .typeError('Selection from list required.')
         .required('Required'),
     },
     [['pin', 'pid']],
@@ -365,6 +367,7 @@ export const LandIdentificationSchema = Yup.object().shape(
       .test('is-valid', 'Please enter a valid number', val => Number(val) < 200000),
     agencyId: Yup.number()
       .transform(emptyStringToNull)
+      .typeError('Selection from list required.')
       .required('Required'),
     lotSize: Yup.number(),
     isSensitive: Yup.boolean()


### PR DESCRIPTION
Validation now more detailed for type error if it occurs, and allow REM's to submit on behalf of a child agency if they are a part of a parent agency. 