### PR TITLE
Fix CHES cancel response

### DIFF
--- a/backend/core/Http/HttpRequestClient.cs
+++ b/backend/core/Http/HttpRequestClient.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Pims.Core.Exceptions;
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -65,10 +66,11 @@ namespace Pims.Core.Http
         public async Task<TModel> DeserializeAsync<TModel>(HttpResponseMessage response)
         {
             var data = await response.Content.ReadAsByteArrayAsync();
-
+            var contentType = response.Content.Headers.ContentType;
             try
             {
-                return JsonSerializer.Deserialize<TModel>(data, _serializeOptions);
+                if (contentType.MediaType.Contains("json", StringComparison.InvariantCultureIgnoreCase))
+                    return JsonSerializer.Deserialize<TModel>(data, _serializeOptions);
             }
             catch (Exception ex)
             {
@@ -76,6 +78,8 @@ namespace Pims.Core.Http
                 _logger.LogError(ex, $"Failed to deserialize response: {body}");
                 throw ex;
             }
+
+            throw new HttpClientRequestException(response, $"Response must contain JSON but was '{contentType.MediaType}'.");
         }
 
         #region HttpResponseMessage Methods
@@ -152,6 +156,7 @@ namespace Pims.Core.Http
                 }
             }
 
+            _logger.LogInformation($"HTTP request made '{message.RequestUri}'");
             return await this.Client.SendAsync(message);
         }
 

--- a/backend/tests/unit/dal/Libraries/Ches/ChesServiceTest.cs
+++ b/backend/tests/unit/dal/Libraries/Ches/ChesServiceTest.cs
@@ -1019,7 +1019,10 @@ namespace Pims.Dal.Test.Libraries.Ches
             {
                 Content = new StringContent("{}", Encoding.UTF8, "application/json")
             };
-            var status = new StatusResponseModel();
+            var status = new StatusResponseModel()
+            {
+                Status = "pending"
+            };
 
             var client = helper.GetService<Mock<IHttpRequestClient>>();
             client.Setup(m => m.SendAsync<TokenModel>(It.IsAny<string>(), It.IsAny<HttpMethod>(), It.IsAny<HttpRequestHeaders>(), It.IsAny<HttpContent>(), It.IsAny<Func<HttpResponseMessage, bool>>())).ReturnsAsync(token);


### PR DESCRIPTION
## Description

CHES has a few issues/behaviours that have been discovered.

- Attempting to cancel a message that can't be cancelled throws an error 409.
- Attempting to request the status of a message after cancelling it times-out with a 504.

## Solution

- HTTP Request and CHES library have been updated to only deserialize JSON data.
- A request for the status of the message will be sent to determine if it can be cancelled, instead of just sending a cancel message and then asking for the status.