### PR TITLE
Fix TRAN agencies

### DIFF
--- a/backend/dal/Migrations/v01.10.04/Up/PostUp/01-Agencies.sql
+++ b/backend/dal/Migrations/v01.10.04/Up/PostUp/01-Agencies.sql
@@ -1,5 +1,16 @@
 PRINT 'Updating TRAN Agencies'
 
+----------------------------------------------------------------
+-- Summary
+-- 1) Change ownership of properties from "TRAN", "PLMB", "TIC" to "BCTFA"
+-- 2) Change ownership of projects from "TRAN", "PLMB", "TIC" to "BCTFA"
+-- 3) Move all TRAN users to the "TRAN" ministry instead of sub-agency
+-- 4) Delete sub-agencies "PLMB" and "TIC"
+--
+-- Note that users will need to be updated manually after this
+-- migration so that they reference the correct agencies (see below).
+----------------------------------------------------------------
+
 -- These are the ministry and agencies from Ministry of Transportation & Infrastructure
 DECLARE @TRAN INT = (SELECT TOP 1 [Id] FROM dbo.[Agencies] WHERE [Code] = 'TRAN')
 DECLARE @BCTFA INT = (SELECT TOP 1 [Id] FROM dbo.[Agencies] WHERE [Code] = 'BCTFA')
@@ -44,23 +55,23 @@ DROP TABLE #TRANUsers
 -- Move properties to BCTFA
 UPDATE dbo.[Parcels]
 SET [AgencyId] = @BCTFA
-WHERE [AgencyId] IN (@TRAN, @PLMB, @TIC, @BCT)
+WHERE [AgencyId] IN (@TRAN, @PLMB, @TIC)
 
 -- Move properties to BCTFA
 UPDATE dbo.[Buildings]
 SET [AgencyId] = @BCTFA
-WHERE [AgencyId] IN (@TRAN, @PLMB, @TIC, @BCT)
+WHERE [AgencyId] IN (@TRAN, @PLMB, @TIC)
 
 -- Move projects to BCTFA
 UPDATE dbo.[Projects]
 SET [AgencyId] = @BCTFA
-WHERE [AgencyId] IN (@TRAN, @PLMB, @TIC, @BCT)
+WHERE [AgencyId] IN (@TRAN, @PLMB, @TIC)
 
 -- Update any access request to use the ministry instead of the agency
 -- Since PIMS currently only supports a single agency to be selected when submitting access requests, this should be fine.
 UPDATE dbo.[AccessRequestAgencies]
 SET [AgencyId] = @TRAN
-WHERE [AgencyId] IN  (@BCTFA, @PLMB, @TIC, @BCT)
+WHERE [AgencyId] IN  (@BCTFA, @PLMB, @TIC)
 
 -- There are no relevant agency responses in production, but in any of the test dbs they need to be cleared
 DELETE FROM dbo.[ProjectAgencyResponses]
@@ -70,7 +81,7 @@ WHERE [AgencyId] IN (@PLMB, @TIC)
 -- There are no relevant notifications in the queue in production, but in any of the test dbs they need to be cleared
 UPDATE dbo.[NotificationQueue]
 SET [ToAgencyId] = @TRAN
-WHERE [ToAgencyId] IN (@BCTFA, @PLMB, @TIC, @BCT)
+WHERE [ToAgencyId] IN (@BCTFA, @PLMB, @TIC)
 
 -- Delete the invalid agencies
 DELETE FROM dbo.[Agencies]


### PR DESCRIPTION
## Summary

I have rolled back DB migration `v01.10.04` in **DEV** and **TEST**.   This PR updates this DB migration so that when it is applied again it will do the following;

1) Change ownership of properties from "TRAN", "PLMB", "TIC" to "BCTFA"
2) Change ownership of projects from "TRAN", "PLMB", "TIC" to "BCTFA"
3) Move all TRAN users to the "TRAN" ministry instead of sub-agency
4) Delete sub-agencies "PLMB" and "TIC"

> Note that users will need to be updated manually after this migration so that they reference the correct agencies (see below).

## Note

The only issue in the prior bug fix was that it was also moving properties from "BC Transit" to "BC Transportation Financing Authority".  I have removed that part of the migration.