### PR TITLE
Updated dest email for pims support (PA-14).

### DIFF
--- a/frontend/src/features/help/constants/HelpText.tsx
+++ b/frontend/src/features/help/constants/HelpText.tsx
@@ -106,5 +106,6 @@ export const getTopics = (currentPage: IHelpPage | undefined) => {
 
 /**
  * This is the email that all support tickets should be directed to when using the issue reporting system.
+ * Updated as requested from rpdimithelp@gov.bc.ca to citz_rpd_imit_help@gov.bc.ca
  */
-export const pimsSupportEmail = 'rpdimithelp@gov.bc.ca';
+export const pimsSupportEmail = 'citz_rpd_imit_help@gov.bc.ca';


### PR DESCRIPTION
The email address is incorrect on the PIMS Ask For Help feature.  The email address should be:

citz_rpd_imit_help@gov.bc.ca