### PR TITLE
PIMS-6 Fix Cancel Notifications

### DIFF
--- a/backend/ches/ChesService.cs
+++ b/backend/ches/ChesService.cs
@@ -103,7 +103,7 @@ namespace Pims.Ches
             }
             catch (HttpClientRequestException ex)
             {
-                _logger.LogError(ex, $"Failed to send/receive request: ${url}");
+                _logger.LogError(ex, $"Failed to send/receive request: {ex.StatusCode} {url}");
                 var response = await this.Client?.DeserializeAsync<Ches.Models.ErrorResponseModel>(ex.Response);
                 throw new ChesException(ex, this.Client, response);
             }
@@ -131,7 +131,7 @@ namespace Pims.Ches
             }
             catch (HttpClientRequestException ex)
             {
-                _logger.LogError(ex, $"Failed to send/receive request: ${url}");
+                _logger.LogError(ex, $"Failed to send/receive request: {ex.StatusCode} {url}");
                 var response = await this.Client?.DeserializeAsync<Ches.Models.ErrorResponseModel>(ex.Response);
                 throw new ChesException(ex, this.Client, response);
             }
@@ -163,7 +163,7 @@ namespace Pims.Ches
             }
             catch (HttpClientRequestException ex)
             {
-                _logger.LogError(ex, $"Failed to send/receive request: ${url}");
+                _logger.LogError(ex, $"Failed to send/receive request: {ex.StatusCode} {url}");
                 var response = await this.Client?.DeserializeAsync<Ches.Models.ErrorResponseModel>(ex.Response);
                 throw new ChesException(ex, this.Client, response);
             }
@@ -194,7 +194,7 @@ namespace Pims.Ches
             }
             catch (HttpClientRequestException ex)
             {
-                _logger.LogError(ex, $"Failed to send/receive request: ${this.Options.AuthUrl}");
+                _logger.LogError(ex, $"Failed to send/receive request: {ex.StatusCode} {this.Options.AuthUrl}");
                 var response = await this.Client?.DeserializeAsync<Ches.Models.ErrorResponseModel>(ex.Response);
                 throw new ChesException(ex, this.Client, response);
             }


### PR DESCRIPTION
When notification cancellations fail, so does cancelling a project.  Currently the main issue for this is because there are projects that created notifications in the prior version of CHES, which do not exist in the current version.

This fix will ignore the specific error response from CHES for missing notifications (404).  This isn't an ideal solution, but one that will resolve current issues.

I have notified the Common Services team of their design implementation issue regarding returning a 404 for a valid endpoint and a missing message.  They should be returning a 204, or a 200 with an empty array like they do for other endpoints.