### PR TITLE
PIMS-18: Allow SPL tab to be accessible by other statuses 

### DIFF
--- a/frontend/src/features/projects/erp/steps/ErpStep.scss
+++ b/frontend/src/features/projects/erp/steps/ErpStep.scss
@@ -1,5 +1,5 @@
 .erpStep {
   .nav-tabs .nav-item.nav-link {
-    width: 25%;
+    width: 20%;
   }
 }

--- a/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/ErpStep.test.tsx.snap
@@ -112,6 +112,18 @@ exports[`ERP Approval Step ERP close out form tab renders correctly 1`] = `
         Enhanced Referral Process
       </a>
       <a
+        aria-controls="approvalTabs-tabpane-surplusPropertyList"
+        aria-selected="false"
+        class="nav-item nav-link"
+        data-rb-event-key="surplusPropertyList"
+        href="#"
+        id="approvalTabs-tab-surplusPropertyList"
+        role="tab"
+        tabindex="-1"
+      >
+        Surplus Properties List
+      </a>
+      <a
         aria-controls="approvalTabs-tabpane-closeOutForm"
         aria-selected="true"
         class="nav-item nav-link active"
@@ -1224,6 +1236,18 @@ exports[`ERP Approval Step renders correctly 1`] = `
         role="tab"
       >
         Enhanced Referral Process
+      </a>
+      <a
+        aria-controls="approvalTabs-tabpane-surplusPropertyList"
+        aria-selected="false"
+        class="nav-item nav-link"
+        data-rb-event-key="surplusPropertyList"
+        href="#"
+        id="approvalTabs-tab-surplusPropertyList"
+        role="tab"
+        tabindex="-1"
+      >
+        Surplus Properties List
       </a>
     </nav>
     <div

--- a/frontend/src/features/projects/erp/tabs/ErpTabs.tsx
+++ b/frontend/src/features/projects/erp/tabs/ErpTabs.tsx
@@ -11,7 +11,7 @@ import { useFormikContext } from 'formik';
 import { EnhancedReferralTab } from '..';
 import { isEqual } from 'lodash';
 import { ProjectInformationTab, DocumentationTab } from '../../common';
-import { CloseOutFormTab } from 'features/projects/spl';
+import { CloseOutFormTab, SplTab } from 'features/projects/spl';
 import { isTabInError } from 'components/common/tabValidation';
 import ErrorTabs from 'components/common/ErrorTabs';
 
@@ -75,6 +75,17 @@ const ErpTabs: React.FunctionComponent<IErpTabsProps> = ({
           }`}
         >
           <EnhancedReferralTab
+            isReadOnly={isReadOnly}
+            setSubmitStatusCode={setSubmitStatusCode}
+            goToGreTransferred={() => submitForm().then(() => goToGreTransferred())}
+          />
+        </Tab>
+        <Tab
+          eventKey={SPPApprovalTabs.spl}
+          title="Surplus Properties List"
+          tabClassName={isTabInError(errors, SPPApprovalTabs.spl)}
+        >
+          <SplTab
             isReadOnly={isReadOnly}
             setSubmitStatusCode={setSubmitStatusCode}
             goToGreTransferred={() => submitForm().then(() => goToGreTransferred())}


### PR DESCRIPTION
Allow the SPL tab to be accessible by other statuses for the case of a project transitioning to another status and needing to view previous data.

- Width was slightly adjusted to accommodate for the extra tab (was previously stacking tabs when closeout form tab was included)

![image](https://user-images.githubusercontent.com/15724124/122837467-fca5e000-d2a8-11eb-94bb-0b4ed4d71103.png)


