### PR TITLE
SPP Number on Inventory Export

### DIFF
--- a/backend/api/Areas/Reports/Mapping/Property/PropertyMap.cs
+++ b/backend/api/Areas/Reports/Mapping/Property/PropertyMap.cs
@@ -1,5 +1,7 @@
 using Mapster;
 using Entity = Pims.Dal.Entities;
+using System.Text.Json;
+using System.Collections.Generic;
 using Model = Pims.Api.Areas.Reports.Models.Property;
 
 namespace Pims.Api.Areas.Reports.Mapping.Property
@@ -39,7 +41,8 @@ namespace Pims.Api.Areas.Reports.Mapping.Property
                 .Map(dest => dest.RentableArea, src => src.RentableArea)
                 .Map(dest => dest.OccupantName, src => src.OccupantName)
                 .Map(dest => dest.LeaseExpiry, src => src.LeaseExpiry)
-                .Map(dest => dest.TransferLeaseOnSale, src => src.TransferLeaseOnSale);
+                .Map(dest => dest.TransferLeaseOnSale, src => src.TransferLeaseOnSale)
+                .Map(dest => dest.ProjectNumbers, src => src.ProjectNumbers);
 
         }
     }

--- a/backend/api/Areas/Reports/Models/Property/PropertyModel.cs
+++ b/backend/api/Areas/Reports/Models/Property/PropertyModel.cs
@@ -185,6 +185,14 @@ namespace Pims.Api.Areas.Reports.Models.Property
         [DisplayName("Transfer Lease on Sale")]
         [CsvHelper.Configuration.Attributes.Name("Transfer Lease on Sale")]
         public bool TransferLeaseOnSale { get; set; }
+        
+        /// <summary>
+        /// get/set - The project number
+        /// </summary>
+        [DisplayName("Project Number")]
+        [CsvHelper.Configuration.Attributes.Name("Project Number")]
+        public string ProjectNumbers { get; set; }
+
         #endregion
         #endregion
     }


### PR DESCRIPTION
There might be a better way to get the project number into the report without the brackets, as it's currently an array.
[pims-inventory (11).xlsx](https://github.com/bcgov/PIMS/files/6718314/pims-inventory.11.xlsx)
