### PR TITLE
Add tabs to cancelled projects, and shared notes back to project information 

### DIFF
--- a/frontend/src/features/projects/common/ProjectSummaryView.tsx
+++ b/frontend/src/features/projects/common/ProjectSummaryView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Container, Form } from 'react-bootstrap';
 import { ReviewProjectForm } from '../dispose';
 import { useStepForm, StepStatusIcon, ProjectNotes, useProject } from '.';
@@ -7,8 +7,11 @@ import './ProjectSummaryView.scss';
 import { StepActions } from '../dispose/components/StepActions';
 import { noop } from 'lodash';
 import StepErrorSummary from './components/StepErrorSummary';
-import { IStepProps } from './interfaces';
+import { IStepProps, ReviewWorkflowStatus, SPPApprovalTabs } from './interfaces';
 import { PublicNotes } from './components/ProjectNotes';
+import { ErpTabs, saveErpTab } from '../erp';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'reducers/rootReducer';
 
 /**
  * Read only version of all step components. Allows notes field to be edited
@@ -17,6 +20,14 @@ const ProjectSummaryView = ({ formikRef }: IStepProps) => {
   const { project } = useProject();
   const { onSubmitReview, noFetchingProjectRequests } = useStepForm();
   const initialValues = { ...project, confirmation: true };
+  const [submitStatusCode, setSubmitStatusCode] = useState(undefined);
+  const dispatch = useDispatch();
+  const setCurrentTab = (tabName: string) => {
+    dispatch(saveErpTab(tabName));
+  };
+  const currentTab =
+    useSelector<RootState, string | null>(state => state.erpTab) ??
+    SPPApprovalTabs.projectInformation;
   return (
     <Container fluid className="ProjectSummaryView">
       <StepStatusIcon approvedOn={project.approvedOn} status={project.status} />
@@ -28,6 +39,13 @@ const ProjectSummaryView = ({ formikRef }: IStepProps) => {
       >
         {formikProps => (
           <Form>
+            {project.status?.code === ReviewWorkflowStatus.Cancelled && (
+              <ErpTabs
+                isReadOnly
+                goToGreTransferred={noop}
+                {...{ currentTab, setCurrentTab, setSubmitStatusCode, submitStatusCode }}
+              />
+            )}
             <ReviewProjectForm canEdit={false} />
             <ProjectNotes disabled={!project.status?.isActive} />
             <PublicNotes disabled={!project.status?.isActive} />

--- a/frontend/src/features/projects/common/tabs/ProjectInformationTab.tsx
+++ b/frontend/src/features/projects/common/tabs/ProjectInformationTab.tsx
@@ -7,6 +7,7 @@ import {
   UpdateInfoForm,
   useProject,
 } from '../../common';
+import { PublicNotes } from '../components/ProjectNotes';
 import AdditionalPropertyInformationForm from '../forms/AdditionalPropertyInformationForm';
 
 interface IProjectInformationTabProps {
@@ -30,8 +31,9 @@ const ProjectInformationTab: React.FunctionComponent<IProjectInformationTabProps
       />
 
       <h3>Notes</h3>
-      <ProjectNotes className="col-md-auto" disabled={true} label="Agency Notes" />
+      <ProjectNotes className="col-md-auto" disabled={true} label="Notes" />
       <PrivateNotes className="col-md-auto" disabled={isReadOnly} />
+      <PublicNotes />
       <ProjectNotes
         label="Reporting"
         tooltip="Notes for Reporting"

--- a/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
+++ b/frontend/src/features/projects/erp/steps/__snapshots__/GreTransferStep.test.tsx.snap
@@ -12,6 +12,12 @@ exports[`GRE Transfer Step renders correctly 1`] = `
   font-family: 'BCSans',Fallback,sans-serif;
 }
 
+.c2 {
+  text-align: center;
+  font-family: 'BCSans-Bold';
+  margin-bottom: 1.5rem;
+}
+
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -20,12 +26,6 @@ exports[`GRE Transfer Step renders correctly 1`] = `
   -webkit-flex-flow: column;
   -ms-flex-flow: column;
   flex-flow: column;
-}
-
-.c2 {
-  text-align: center;
-  font-family: 'BCSans-Bold';
-  margin-bottom: 1.5rem;
 }
 
 <div

--- a/frontend/src/features/projects/spl/tabs/SurplusPropertyInformationTab.tsx
+++ b/frontend/src/features/projects/spl/tabs/SurplusPropertyInformationTab.tsx
@@ -6,6 +6,7 @@ import {
   ProjectDraftForm,
   UpdateInfoForm,
   useProject,
+  PublicNotes,
 } from '../../common';
 import AdditionalPropertyInformationForm from '../../common/forms/AdditionalPropertyInformationForm';
 
@@ -30,8 +31,9 @@ const SurplusPropertyInformationTab: React.FunctionComponent<ISurplusPropertyInf
       />
 
       <h3>Notes</h3>
-      <ProjectNotes className="col-md-auto" disabled={true} label="Agency Notes" />
+      <ProjectNotes className="col-md-auto" disabled={true} label="Notes" />
       <PrivateNotes className="col-md-auto" disabled={isReadOnly} />
+      <PublicNotes />
       <ProjectNotes
         label="Reporting"
         field="reportingNote"


### PR DESCRIPTION
2 little tweaks in this PR

**1.** Add tabs to cancelled projects so user's can browse previous information regarding the project
![image](https://user-images.githubusercontent.com/15724124/123676529-ea6ff880-d7f8-11eb-8ce7-238f11806dfe.png)
**2.** Add shared notes back to project information, and rename Agency Notes -> Notes to avoid confusion 
![image](https://user-images.githubusercontent.com/15724124/123676679-1d19f100-d7f9-11eb-95ed-74a35639572e.png)
