### PR TITLE
Update Notification Audience

### DIFF
--- a/backend/dal/Migrations/v01.11.00/Up/PostUp/01-NotificationTemplates.sql
+++ b/backend/dal/Migrations/v01.11.00/Up/PostUp/01-NotificationTemplates.sql
@@ -2,7 +2,7 @@ PRINT N'Update [NotificationTemplates]'
 
 UPDATE dbo.[NotificationTemplates]
 SET [Audience] = N'ProjectOwner'
-WHERE [Id] IN (2, 3, 4)
+WHERE [Id] IN (2, 3, 4, 16)
 
 UPDATE dbo.[NotificationTemplates]
 SET [Body] = N'


### PR DESCRIPTION
Updating the notification that is currently sent to the owning agency when the shared note is changed to send to the user who created the project instead.

To apply this change to DEV I will need to rollback the migration and then reapply.