### PR TITLE
PIMS-26 - Edit before project approval

### DIFF
--- a/frontend/src/features/projects/assess/forms/ReviewApproveForm.tsx
+++ b/frontend/src/features/projects/assess/forms/ReviewApproveForm.tsx
@@ -36,7 +36,7 @@ const ReviewApproveForm = ({
   const { project } = useProject();
   const formikProps = useFormikContext<IProject>();
   const { errors } = useFormikContext<IProject>();
-  const [isReadOnly, setIsReadOnly] = useState(true);
+  const [isReadOnly, setIsReadOnly] = useState(!canEdit);
   /** Enter edit mode if allowed and there are errors to display */
   useEffect(() => {
     if (Object.keys(errors).length > 0) {
@@ -58,7 +58,6 @@ const ReviewApproveForm = ({
   const exemptionInfoReviewTasks = _.filter(project.tasks, {
     statusCode: ReviewWorkflowStatus.ExemptionReview,
   });
-
   return (
     <Fragment>
       <ProjectDraftForm


### PR DESCRIPTION
Prior to this change `isReadOnly` would always be set to true from this state unless an error occurred and it would then check the value of `canEdit`. It now defaults `isReadOnly` to the inverse of `canEdit`.

As `isReadOnly` was always true the expression for whether the child components were disabled was `isReadOnly || !canEdit` which was previously always evaluating to true.