### PR TITLE
PIMS-35: Toast adjustment for more clear instructions

### DIFF
--- a/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
@@ -62,7 +62,9 @@ export const saveParcelDataLayerResponse = (
       }),
     );
   } else {
-    toast.warning(`Failed to find parcel layer data. Ensure that the search criteria is valid`);
+    toast.warning(
+      `Failed to find parcel layer data. Ensure that the search criteria is valid, or manually place a marker on the map to continue the process.`,
+    );
   }
 };
 


### PR DESCRIPTION
I was originally working on a modal for this but this is the quickest fix - if we want to use a modal please let me know and I will happily switch it. 

Users were getting confused when entering a valid PIN and no response was returned, in order to further enter information on desired property they would have to manually drop the pin and continue the process. Added some clarification text to the "error" toast that is currently appearing when this scenario happens. 