### PR TITLE
PIMS-20: Exclude T-GRE from SPL Reports

### DIFF
--- a/backend/dal/Helpers/Extensions/ProjectExtensions.cs
+++ b/backend/dal/Helpers/Extensions/ProjectExtensions.cs
@@ -50,7 +50,7 @@ namespace Pims.Dal.Helpers.Extensions
 
             if (filter.SPLWorkflow == true)
             {
-                query = query.Where(p => p.Workflow.Code == "SPL" && p.Status.Code != "CA");
+                query = query.Where(p => p.Workflow.Code == "SPL" && p.Status.Code != "CA" && p.Status.Code != "T-GRE");
             }
 
             if (!String.IsNullOrWhiteSpace(filter.ProjectNumber))


### PR DESCRIPTION
Downloading the report as an excel file sets the `filter.SPLWorkflow` to true, this was previously only ensuring cancelled SPL projects were not included but it now checks for `Transferred within the GRE` as well. This was already working on the graphical interface, just needed an update to the excel reporting.