### PR TITLE
PIMS-42: The project initiator doesn't seem to be getting the "Project Owner" notifications

### DIFF
--- a/backend/dal/Helpers/Extensions/ProjectExtensions.cs
+++ b/backend/dal/Helpers/Extensions/ProjectExtensions.cs
@@ -400,7 +400,7 @@ namespace Pims.Dal.Helpers.Extensions
             var updatedById = originalProject.UpdatedById;
             context.Entry(originalProject).CurrentValues.SetValues(updatedProject);
             originalProject.Agency = agency; // Don't want to allow agency to change through this method.
-            originalProject.CreatedById = updatedById; // Don't want these updated externally.
+            originalProject.CreatedById = createdById; // Don't want these updated externally.
             originalProject.UpdatedById = updatedById; // Don't want these updated externally.
             context.SetOriginalRowVersion(originalProject);
 


### PR DESCRIPTION
It looks like there's a bug which occurs if someone who is not the "initiator" or creator of the project approves the project, the CreatedById gets overwritten by the updater of the project.

I think there was a copy and paste error in the code...