### PR TITLE
PIMS-46 Use KeycloakUserId

### DIFF
--- a/backend/api/Controllers/AuthController.cs
+++ b/backend/api/Controllers/AuthController.cs
@@ -53,8 +53,8 @@ namespace Pims.Api.Controllers
         [SwaggerOperation(Tags = new[] { "auth" })]
         public IActionResult Activate()
         {
-            var userId = this.User.GetUserId();
-            var exists = _pimsService.User.UserExists(userId);
+            var keycloakUserId = this.User.GetKeycloakUserId();
+            var exists = _pimsService.User.UserExists(keycloakUserId);
 
             var user = _pimsService.User.Activate();
             if (!exists)
@@ -62,7 +62,7 @@ namespace Pims.Api.Controllers
                 return new CreatedResult($"{user.Id}", new Model.UserModel(user));
             }
 
-            return new JsonResult(new Model.UserModel(userId));
+            return new JsonResult(new Model.UserModel(user.Id, user.KeycloakUserId));
         }
 
         /// <summary>

--- a/backend/api/Helpers/Authorization/RealmAccessRoleRequirement.cs
+++ b/backend/api/Helpers/Authorization/RealmAccessRoleRequirement.cs
@@ -17,7 +17,7 @@ namespace Pims.Api.Helpers.Authorization
 
         #region Constructors
         /// <summary>
-        /// Creates a new instance of a RealmAccessRoleRequirment class.
+        /// Creates a new instance of a RealmAccessRoleRequirement class.
         /// </summary>
         /// <param name="role"></param>
         public RealmAccessRoleRequirement(string role)

--- a/backend/api/Models/Auth/UserModel.cs
+++ b/backend/api/Models/Auth/UserModel.cs
@@ -14,6 +14,11 @@ namespace Pims.Api.Models.Auth
         /// </summary>
         /// <value></value>
         public Guid Id { get; set; }
+
+        /// <summary>
+        /// get/set - The user's keycloak id.
+        /// </summary>
+        public Guid? KeycloakUserId { get; set; }
         #endregion
 
         #region Constructors
@@ -26,9 +31,11 @@ namespace Pims.Api.Models.Auth
         /// Creates a new instance of a UserModel object, initializes it with specified arguments.
         /// </summary>
         /// <param name="id"></param>
-        public UserModel(Guid id)
+        /// <param name="keycloakUserId"></param>
+        public UserModel(Guid id, Guid? keycloakUserId)
         {
             this.Id = id;
+            this.KeycloakUserId = keycloakUserId;
         }
 
         /// <summary>
@@ -38,6 +45,7 @@ namespace Pims.Api.Models.Auth
         public UserModel(Entity.User user)
         {
             this.Id = user.Id;
+            this.KeycloakUserId = user.KeycloakUserId;
         }
         #endregion
     }

--- a/backend/core/Extensions/IdentityExtensions.cs
+++ b/backend/core/Extensions/IdentityExtensions.cs
@@ -16,7 +16,7 @@ namespace Pims.Core.Extensions
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        public static Guid GetUserId(this ClaimsPrincipal user)
+        public static Guid GetKeycloakUserId(this ClaimsPrincipal user)
         {
             var value = user?.FindFirstValue(ClaimTypes.NameIdentifier);
             return String.IsNullOrWhiteSpace(value) ? Guid.Empty : new Guid(value);

--- a/backend/dal/Helpers/Extensions/ProjectExtensions.cs
+++ b/backend/dal/Helpers/Extensions/ProjectExtensions.cs
@@ -61,7 +61,9 @@ namespace Pims.Dal.Helpers.Extensions
                 query = query.Where(p => p.TierLevelId == filter.TierLevelId);
             if (filter.CreatedByMe.HasValue && filter.CreatedByMe.Value)
             {
-                query = query.Where(p => p.CreatedById.Equals(user.GetUserId()));
+                var keycloakUserId = user.GetKeycloakUserId();
+                var userId = context.Users.Where(u => u.KeycloakUserId == keycloakUserId).Select(u => u.Id).FirstOrDefault(); // TODO: Add User.Id to claims to speed up query.
+                query = query.Where(p => p.CreatedById.Equals(userId));
             }
 
             if (filter.FiscalYear.HasValue)

--- a/backend/dal/PIMSContext.cs
+++ b/backend/dal/PIMSContext.cs
@@ -162,7 +162,8 @@ namespace Pims.Dal
             var modifiedEntries = ChangeTracker.Entries()
                     .Where(x => (x.State == EntityState.Added || x.State == EntityState.Modified));
 
-            var userId = _httpContextAccessor.HttpContext.User.GetUserId();
+            var keycloakUserId = _httpContextAccessor.HttpContext.User.GetKeycloakUserId();
+            var userId = this.Users.Where(u => u.KeycloakUserId == keycloakUserId).Select(u => u.Id).FirstOrDefault(); // TODO: Should add the User.Id to a claim so that it can be easily returned.
             foreach (var entry in modifiedEntries)
             {
                 if (entry.Entity is BaseEntity entity)

--- a/backend/dal/Services/Admin/Concrete/BuildingService.cs
+++ b/backend/dal/Services/Admin/Concrete/BuildingService.cs
@@ -218,7 +218,8 @@ namespace Pims.Dal.Services.Admin
             this.User.ThrowIfNotAuthorized(Permissions.SystemAdmin, Permissions.AgencyAdmin);
 
             var buildings = entities.Where(e => e != null);
-            var userId = this.User.GetUserId();
+            var keycloakUserId = this.User.GetKeycloakUserId();
+            var userId = this.Context.Users.Where(u => u.KeycloakUserId == keycloakUserId).Select(u => u.Id).FirstOrDefault();
             buildings.ForEach((building) =>
             {
                 building.PropertyTypeId = (int)PropertyTypes.Building;

--- a/backend/dal/Services/Admin/Concrete/UserService.cs
+++ b/backend/dal/Services/Admin/Concrete/UserService.cs
@@ -203,7 +203,8 @@ namespace Pims.Dal.Services.Admin
 
             if (!existingUser.Agencies.Any())
             {
-                user.ApprovedById = this.User.GetUserId();
+                var keycloakUserId = this.User.GetKeycloakUserId();
+                user.ApprovedById = this.Context.Users.Where(u => u.KeycloakUserId == keycloakUserId).Select(u => u.Id).FirstOrDefault();
                 user.ApprovedOn = DateTime.UtcNow;
             }
 
@@ -265,7 +266,8 @@ namespace Pims.Dal.Services.Admin
             if (isApproving)
             {
                 var approvedUser = this.Context.Users.Find(existingAccessRequest.UserId);
-                approvedUser.ApprovedById = this.User.GetUserId();
+                var keycloakUserId = this.User.GetKeycloakUserId();
+                approvedUser.ApprovedById = this.Context.Users.Where(u => u.KeycloakUserId == keycloakUserId).Select(u => u.Id).FirstOrDefault();
                 approvedUser.ApprovedOn = DateTime.UtcNow;
                 this.Context.Users.Update(approvedUser);
             }

--- a/backend/dal/Services/IUserService.cs
+++ b/backend/dal/Services/IUserService.cs
@@ -9,7 +9,7 @@ namespace Pims.Dal.Services
     /// </summary>
     public interface IUserService : IService
     {
-        bool UserExists(Guid id);
+        bool UserExists(Guid KeycloakUserId);
         User Activate();
         IEnumerable<int> GetAgencies(Guid userId);
         AccessRequest GetAccessRequest();

--- a/tools/keycloak/sync/SyncFactory.cs
+++ b/tools/keycloak/sync/SyncFactory.cs
@@ -349,7 +349,8 @@ namespace Pims.Tools.Keycloak.Sync
 
             foreach (var user in users)
             {
-                var kuser = await GetUserAsync(user);
+                var kuser = kusers.FirstOrDefault(u => u.Id == user.KeycloakUserId || u.Username == user.Username);
+                kuser = await GetUserAsync(kuser?.Id ?? user.KeycloakUserId ?? user.Id);
 
                 // Ignore users that only exist in PIMS.
                 if (kuser == null) continue;
@@ -445,14 +446,14 @@ namespace Pims.Tools.Keycloak.Sync
         /// Get the keycloak user that matches the PIMS user.
         /// If it doesn't exist return 'null'.
         /// </summary>
-        /// <param name="user"></param>
+        /// <param name="keycloakUserId"></param>
         /// <returns></returns>
-        private async Task<KModel.UserModel> GetUserAsync(UserModel user)
+        private async Task<KModel.UserModel> GetUserAsync(Guid keycloakUserId)
         {
             try
             {
                 // Make a request to keycloak to find a matching user.
-                return await _client.HandleRequestAsync<KModel.UserModel>(HttpMethod.Get, $"{_options.Auth.Keycloak.Admin.Authority}/users/{user.KeycloakUserId}");
+                return await _client.HandleRequestAsync<KModel.UserModel>(HttpMethod.Get, $"{_options.Auth.Keycloak.Admin.Authority}/users/{keycloakUserId}");
             }
             catch (HttpClientRequestException ex)
             {


### PR DESCRIPTION
With the change to the User entity that now links to Keycloak through a separate property `KeycloakUserId` instead of the `Id`, additional changes needed to be made to support this.

DEV continued to work correctly because the `Id` and `KeycloakUserId` are identical values, however in TEST it will have different values based on what has been imported.

A better solution than the one I implemented would be to add the PIMS `User.Id` to the claims found in Keycloak to reduce the need to make an additional query/connection to the database for the `User.Id`, however this will take more time and requires additional updates to Keycloak.