### PR TITLE
PIMS-48: SPP-11023 - Transfer within GRE - can no longer see Private Notes

### DIFF
--- a/frontend/src/features/projects/common/ProjectSummaryView.tsx
+++ b/frontend/src/features/projects/common/ProjectSummaryView.tsx
@@ -39,28 +39,30 @@ const ProjectSummaryView = ({ formikRef }: IStepProps) => {
       >
         {formikProps => (
           <Form>
-            {project.status?.code === ReviewWorkflowStatus.Cancelled && (
+            {(project.status?.code === ReviewWorkflowStatus.Cancelled ||
+              project.status?.code === ReviewWorkflowStatus.TransferredGRE) && (
               <ErpTabs
                 isReadOnly
                 goToGreTransferred={noop}
                 {...{ currentTab, setCurrentTab, setSubmitStatusCode, submitStatusCode }}
               />
             )}
-            {project.status?.code !== ReviewWorkflowStatus.Cancelled && (
-              <>
-                <ReviewProjectForm canEdit={false} />
-                <ProjectNotes disabled={!project.status?.isActive} />
-                <PublicNotes disabled={!project.status?.isActive} />
-                <StepErrorSummary />
-                <StepActions
-                  onSave={() => formikProps.submitForm()}
-                  onNext={noop}
-                  nextDisabled={true}
-                  saveDisabled={!project.status?.isActive}
-                  isFetching={!noFetchingProjectRequests}
-                />
-              </>
-            )}
+            {project.status?.code !== ReviewWorkflowStatus.Cancelled &&
+              project.status?.code !== ReviewWorkflowStatus.TransferredGRE && (
+                <>
+                  <ReviewProjectForm canEdit={false} />
+                  <ProjectNotes disabled={!project.status?.isActive} />
+                  <PublicNotes disabled={!project.status?.isActive} />
+                  <StepErrorSummary />
+                  <StepActions
+                    onSave={() => formikProps.submitForm()}
+                    onNext={noop}
+                    nextDisabled={true}
+                    saveDisabled={!project.status?.isActive}
+                    isFetching={!noFetchingProjectRequests}
+                  />
+                </>
+              )}
           </Form>
         )}
       </Formik>


### PR DESCRIPTION
Fixing layout of the Project Summary form to show tabs when viewing a project whose status has changed to Transfer within GRE. This will allow Maggie to see the history of the T-GRE project and other project information and details.