### PR TITLE
PIMS-41: Issue with selecting and dropping the pin to the map

### DIFF
--- a/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/BuildingForm.test.tsx.snap
+++ b/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/BuildingForm.test.tsx.snap
@@ -813,7 +813,7 @@ exports[`Building Form component renders correctly 1`] = `
                             style="display: flex;"
                           >
                             <p>
-                              Drag and drop the pin on the map to mark the location of this building, or if you already have the coordinates, you can enter them manually in the fields below.
+                              Click on the pin, and then click your desired location on the map to mark the of this building, or if you already have the coordinates, you can enter them in the fields below.
                             </p>
                           </div>
                         </div>

--- a/frontend/src/features/properties/components/forms/subforms/LatLongForm.tsx
+++ b/frontend/src/features/properties/components/forms/subforms/LatLongForm.tsx
@@ -47,14 +47,16 @@ const LatLongForm = <T extends any>(props: LatLongFormProps & FormikProps<T>) =>
           <div className="instruction" style={{ display: 'flex' }}>
             {props.building && (
               <p>
-                Drag and drop the pin on the map to mark the location of this building, or if you
-                already have the coordinates, you can enter them manually in the fields below.
+                Click on the pin, and then click your desired location on the map to mark the of
+                this building, or if you already have the coordinates, you can enter them in the
+                fields below.
               </p>
             )}
             {!props.building && (
               <p>
-                Drag and drop the pin on the map to mark the location of this parcel, or if you
-                already have the coordinates, you can enter them manually in the fields below.
+                Click on the pin, and then click your desired location on the map to pull the parcel
+                details. Or if you already have the coordinates, you can enter them manually in the
+                fields below.
               </p>
             )}
           </div>


### PR DESCRIPTION
Changed wording on the LatLongForm to clarify the instructions for using the pin for the building as the parcel form's instructions are correct.