### PR TITLE
Fix db migration dockerfile

### DIFF
--- a/backend/Dockerfile.migrations
+++ b/backend/Dockerfile.migrations
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 ENV DOTNET_CLI_HOME=/tmp
 ENV PATH="$PATH:/tmp/.dotnet/tools"


### PR DESCRIPTION
The upgrade to .NET5.0 also needs the DB migration Dockerfile to be update appropriately.  This should resolve the devops issue.