### PR TITLE
Add environment variables to nginx

### DIFF
--- a/frontend/src/components/maps/hooks/useActiveFeatureLayer.tsx
+++ b/frontend/src/components/maps/hooks/useActiveFeatureLayer.tsx
@@ -3,12 +3,13 @@ import { LayerPopupInformation } from '../leaflet/Map';
 import { geoJSON, Map as LeafletMap, GeoJSON, LatLng } from 'leaflet';
 import { useState } from 'react';
 import { MapProps as LeafletMapProps, Map as ReactLeafletMap } from 'react-leaflet';
-import { useLayerQuery, PARCELS_LAYER_URL, parcelLayerPopupConfig } from '../leaflet/LayerPopup';
+import { useLayerQuery, parcelLayerPopupConfig } from '../leaflet/LayerPopup';
 import useDeepCompareEffect from 'hooks/useDeepCompareEffect';
 import { GeoJsonObject } from 'geojson';
 import { PointFeature } from '../types';
 import { useSelector } from 'react-redux';
 import { RootState } from 'reducers/rootReducer';
+import { useBoundaryLayer } from '../leaflet/LayerPopup/hooks/useBoundaryLayer';
 
 interface IUseActiveParcelMapLayer {
   /** the current leaflet map reference. This hook will add layers to this map reference. */
@@ -35,7 +36,8 @@ const useActiveFeatureLayer = ({
   parcelLayerFeature,
 }: IUseActiveParcelMapLayer) => {
   const [activeFeatureLayer, setActiveFeatureLayer] = useState<GeoJSON>();
-  const parcelsService = useLayerQuery(PARCELS_LAYER_URL);
+  const layerUrl = useBoundaryLayer();
+  const parcelsService = useLayerQuery(layerUrl);
   const draftProperties: PointFeature[] = useSelector<RootState, PointFeature[]>(
     state => state.parcel.draftParcels,
   );

--- a/frontend/src/components/maps/leaflet/LayerPopup/constants/index.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/constants/index.tsx
@@ -1,20 +1,7 @@
 import * as React from 'react';
 
-var environment;
-if (process.env.NODE_ENV === 'production') {
-  environment = '';
-} else if (process.env.NODE_ENV === 'test') {
-  environment = 'test.';
-} else if (process.env.NODE_ENV === 'development') {
-  environment = 'delivery.';
-}
-
 export const MUNICIPALITY_LAYER_URL =
   'https://openmaps.gov.bc.ca/geo/pub/WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_MUNICIPALITIES_SP/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_MUNICIPALITIES_SP';
-export const PARCELS_LAYER_URL =
-  'https://' +
-  environment +
-  'apps.gov.bc.ca/ext/sgw/geo.allgov?service=WFS&version=2.0&request=GetFeature&typeName=geo.allgov:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_FA_SVW&outputFormat=application/json';
 export const PARCELS_LAYER_URL_PUBLIC =
   'https://openmaps.gov.bc.ca/geo/pub/WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW/wfs?service=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW';
 

--- a/frontend/src/components/maps/leaflet/LayerPopup/hooks/useBoundaryLayer.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/hooks/useBoundaryLayer.tsx
@@ -1,0 +1,17 @@
+import { useEnvironment } from 'hooks/useEnvironment';
+
+export const useBoundaryLayer = () => {
+  const env = useEnvironment();
+
+  let domain = '';
+  switch (env.env) {
+    case 'test':
+      domain = `${env.env}.`;
+      break;
+    case 'development':
+      domain = 'delivery.';
+      break;
+  }
+
+  return `https://${domain}apps.gov.bc.ca/ext/sgw/geo.allgov?service=WFS&version=2.0&request=GetFeature&typeName=geo.allgov:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_FA_SVW&outputFormat=application/json`;
+};

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -24,7 +24,6 @@ import {
   municipalityLayerPopupConfig,
   MUNICIPALITY_LAYER_URL,
   parcelLayerPopupConfig,
-  PARCELS_LAYER_URL,
 } from './LayerPopup/constants';
 import { isEmpty, isEqual, isEqualWith } from 'lodash';
 import {
@@ -50,6 +49,7 @@ import { Claims } from '../../../constants';
 import InfoSlideOut from './InfoSlideOut/InfoSlideOut';
 import { PropertyPopUpContextProvider } from '../providers/PropertyPopUpProvider';
 import FilterBackdrop from './FilterBackdrop';
+import { useBoundaryLayer } from './LayerPopup/hooks/useBoundaryLayer';
 
 export type MapViewportChangeEvent = {
   bounds: LatLngBounds | null;
@@ -185,7 +185,8 @@ const Map: React.FC<MapProps> = ({
   const smallScreen = useMediaQuery({ maxWidth: 1800 });
   const [mapWidth, setMapWidth] = useState(0);
   const municipalitiesService = useLayerQuery(MUNICIPALITY_LAYER_URL);
-  const parcelsService = useLayerQuery(PARCELS_LAYER_URL);
+  const layerUrl = useBoundaryLayer();
+  const parcelsService = useLayerQuery(layerUrl);
   const [bounds, setBounds] = useState<LatLngBounds>(defaultBounds);
   const { setChanged } = useFilterContext();
   const [layerPopup, setLayerPopup] = useState<LayerPopupInformation>();

--- a/frontend/src/features/mapSideBar/containers/MapSideBarContainer.tsx
+++ b/frontend/src/features/mapSideBar/containers/MapSideBarContainer.tsx
@@ -12,11 +12,7 @@ import { FormikValues, setIn, getIn } from 'formik';
 import { useState } from 'react';
 import useGeocoder from 'features/properties/hooks/useGeocoder';
 import { isMouseEventRecent } from 'utils';
-import {
-  handleParcelDataLayerResponse,
-  PARCELS_LAYER_URL,
-  useLayerQuery,
-} from 'components/maps/leaflet/LayerPopup';
+import { handleParcelDataLayerResponse, useLayerQuery } from 'components/maps/leaflet/LayerPopup';
 import { LeafletMouseEvent, LatLng } from 'leaflet';
 import AssociatedLandForm from '../SidebarContents/AssociatedLandForm';
 import { toast } from 'react-toastify';
@@ -40,6 +36,7 @@ import { withNameSpace } from 'utils/formUtils';
 import { PropertyTypes, Claims, EvaluationKeys, FiscalKeys } from 'constants/index';
 import { useBuildingApi } from '../hooks/useBuildingApi';
 import { fireMapRefreshEvent } from 'components/maps/hooks/useMapRefreshEvent';
+import { useBoundaryLayer } from 'components/maps/leaflet/LayerPopup/hooks/useBoundaryLayer';
 
 interface IMapSideBarContainerProps {
   refreshParcels: Function;
@@ -140,7 +137,8 @@ const MapSideBarContainer: React.FunctionComponent<IMapSideBarContainerProps> = 
   const [showDelete, setShowDelete] = useState(false);
   const { createBuilding, updateBuilding } = useBuildingApi();
 
-  const parcelLayerService = useLayerQuery(PARCELS_LAYER_URL);
+  const layerUrl = useBoundaryLayer();
+  const parcelLayerService = useLayerQuery(layerUrl);
 
   /**
    * Populate the formik form using the passed parcel.

--- a/frontend/src/features/properties/hooks/useGeocoder.tsx
+++ b/frontend/src/features/properties/hooks/useGeocoder.tsx
@@ -5,12 +5,12 @@ import { useState } from 'react';
 import useCodeLookups from 'hooks/useLookupCodes';
 import {
   useLayerQuery,
-  PARCELS_LAYER_URL,
   handleParcelDataLayerResponse,
   saveParcelDataLayerResponse,
 } from 'components/maps/leaflet/LayerPopup';
 import { LatLng } from 'leaflet';
 import { useDispatch } from 'react-redux';
+import { useBoundaryLayer } from 'components/maps/leaflet/LayerPopup/hooks/useBoundaryLayer';
 
 interface IUseGeocoderProps {
   formikRef: React.MutableRefObject<FormikValues | undefined>;
@@ -42,7 +42,8 @@ export interface IPidSelection {
  */
 const useGeocoder = ({ formikRef, fetchPimsOrLayerParcel }: IUseGeocoderProps) => {
   const { lookupCodes } = useCodeLookups();
-  const parcelsService = useLayerQuery(PARCELS_LAYER_URL);
+  const layerUrl = useBoundaryLayer();
+  const parcelsService = useLayerQuery(layerUrl);
   const [pidSelection, setPidSelection] = useState<IPidSelection>({ showPopup: false, geoPID: '' });
   const api = useApi();
   const dispatch = useDispatch();

--- a/frontend/src/hooks/useEnvironment.ts
+++ b/frontend/src/hooks/useEnvironment.ts
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export interface IEnvironment {
+  env: string;
+}
+
+/**
+ * Fetch the config map environment.json file.
+ *
+ * @returns Environment variables.
+ */
+export const useEnvironment = () => {
+  const [env, setEnv] = React.useState({ env: 'production' });
+
+  React.useEffect(() => {
+    const call = async () => {
+      var response = await fetch('/environment.json');
+      var data = await response.json();
+      return data;
+    };
+
+    call()
+      .then(data => {
+        // Update state with the file data.
+        setEnv(data);
+      })
+      .catch(error => {
+        // File doesn't exist, assume development.
+        setEnv({ env: 'development' });
+      });
+  }, [setEnv]);
+
+  return env;
+};

--- a/openshift/4.0/templates/app/deploy.yaml
+++ b/openshift/4.0/templates/app/deploy.yaml
@@ -59,21 +59,26 @@ parameters:
     description: "Keycloak SSO realm, used by the frontend login."
     required: true
     value: xz0xtue5
-  - name: KEYCLOAK_CONFIG_FILE_NAME
-    displayName: "keycloak.json Config File Name"
-    description: "The name of the configuration file to be used for keycloak.json."
-    required: true
-    value: "keycloak.json"
-  - name: KEYCLOAK_CONFIG_MOUNT_PATH
-    displayName: "keycloak.json Mount Path"
-    description: "The path to use to mount the config file."
-    required: true
-    value: "/tmp/app/dist/"
   - name: KEYCLOAK_AUTHORITY_URL
     displayName: "Keycloak Authority URL"
     description: "The Keycloak authority URL."
     required: true
     value: "https://dev.oidc.gov.bc.ca/auth"
+
+  - name: FILE_CONFIG_MOUNT_PATH
+    displayName: "keycloak.json Mount Path"
+    description: "The path to use to mount the config file."
+    required: true
+    value: "/tmp/app/dist/"
+  - name: KEYCLOAK_CONFIG_FILE_NAME
+    displayName: "keycloak.json Config File Name"
+    description: "The name of the configuration file to be used for keycloak.json."
+    required: true
+    value: "keycloak.json"
+  - name: NODE_ENV
+    displayName: "Node Environment"
+    description: "A way to identify within the app which environment the app is in"
+    value: "production"
 
   - name: REAL_IP_FROM
     description:
@@ -194,6 +199,25 @@ objects:
         "confidential-port": 0
         }'
 
+  # Environment Variable configuration settings.
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: ${APP_NAME}-${ROLE_NAME}-env${INSTANCE}
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      annotations:
+        description: Environment variable configuration
+      labels:
+        name: ${APP_NAME}-${ROLE_NAME}-env${INSTANCE}
+        app: ${APP_NAME}
+        role: ${ROLE_NAME}
+        env: ${ENV_NAME}
+    type: Opaque
+    data:
+      environment.json: '{
+        "env": "${NODE_ENV}"
+        }'
+
   # How the app will be deployed to the pod.
   - kind: DeploymentConfig
     apiVersion: v1
@@ -238,6 +262,12 @@ objects:
                 items:
                   - key: "${KEYCLOAK_CONFIG_FILE_NAME}"
                     path: "${KEYCLOAK_CONFIG_FILE_NAME}"
+            - name: "${APP_NAME}-${ROLE_NAME}-env${INSTANCE}"
+              configMap:
+                name: ${APP_NAME}-${ROLE_NAME}-env${INSTANCE}
+                items:
+                  - key: "environent.json"
+                    path: "environent.json"
           containers:
             - name: ${APP_NAME}-${ROLE_NAME}${INSTANCE}
               image: ""
@@ -263,8 +293,11 @@ objects:
                   memory: ${MEMORY_LIMIT}
               volumeMounts:
                 - name: "${APP_NAME}-${ROLE_NAME}-keycloak${INSTANCE}"
-                  mountPath: "${KEYCLOAK_CONFIG_MOUNT_PATH}${KEYCLOAK_CONFIG_FILE_NAME}"
+                  mountPath: "${FILE_CONFIG_MOUNT_PATH}${KEYCLOAK_CONFIG_FILE_NAME}"
                   subPath: "${KEYCLOAK_CONFIG_FILE_NAME}"
+                - name: "${APP_NAME}-${ROLE_NAME}-env${INSTANCE}"
+                  mountPath: "${FILE_CONFIG_MOUNT_PATH}environment.json"
+                  subPath: "environment.json"
               livenessProbe:
                 httpGet:
                   path: "/nginx_status"


### PR DESCRIPTION
Nginx doesn't natively provide a way to include environment variables in our React application.  This PR provides a way that will look for a `environment.json` file and make it accessible through a useEnvironment() hook.

Openshift deployment configuration has been updated to include a ConfigMap that generates this `environment.json` file for each environment.