### PR TITLE
DevOps always build

### DIFF
--- a/openshift/4.0/pipelines/Jenkinsfile.cicd
+++ b/openshift/4.0/pipelines/Jenkinsfile.cicd
@@ -156,9 +156,6 @@ pipeline {
     }
 
     stage('Build') {
-      when {
-        expression { new Boolean(env.SKIP_BUILD) == false }
-      }
       options { timeout(time: 30, unit: 'MINUTES') }
       failFast true
       parallel {
@@ -196,9 +193,6 @@ pipeline {
     }
 
     stage('Deploy') {
-      when {
-        expression { new Boolean(env.SKIP_BUILD) == false }
-      }
       options { timeout(time: 20, unit: 'MINUTES') }
       steps {
         script {
@@ -225,9 +219,7 @@ pipeline {
   post {
     success {
       script {
-        if (new Boolean(env.SKIP_BUILD) == false) {
-          notify.success(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
-        }
+        notify.success(APP_NAME.toUpperCase(), RELEASE_VERSION, DESTINATION.toUpperCase(), ROCKET_DEPLOY_WEBHOOK)
       }
     }
     failure {


### PR DESCRIPTION
Presently it's impossible to force a build if files don't change, which results in never deploying.

This change will always build and always deploy when running the pipeline.