### PR TITLE
PIMS-24 - Adding error handling in layer query

### DIFF
--- a/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.test.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.test.tsx
@@ -49,7 +49,7 @@ describe('useLayerQuery hook tests', () => {
         await findOneWhereContains({ lat: 1, lng: 1 } as any);
       } catch (err) {}
 
-      expect(toastErrorSpy).toHaveBeenCalledTimes(1);
+      expect(toastErrorSpy).toHaveBeenCalledTimes(2);
     });
     it('retries failed wfs requests', async () => {
       const { findOneWhereContains } = getRenderedHook();
@@ -83,7 +83,7 @@ describe('useLayerQuery hook tests', () => {
         await findByAdministrative('city');
       } catch (err) {}
 
-      expect(toastErrorSpy).toHaveBeenCalledTimes(1);
+      expect(toastErrorSpy).toHaveBeenCalledTimes(2);
     });
     it('retries failed wfs requests', async () => {
       const { findByAdministrative } = getRenderedHook();
@@ -117,7 +117,7 @@ describe('useLayerQuery hook tests', () => {
         await findByPid('pid');
       } catch (err) {}
 
-      expect(toastErrorSpy).toHaveBeenCalledTimes(1);
+      expect(toastErrorSpy).toHaveBeenCalledTimes(2);
     });
     it('retries failed wfs requests', async () => {
       const { findByPid } = getRenderedHook();
@@ -151,7 +151,7 @@ describe('useLayerQuery hook tests', () => {
         await findByPin('pin');
       } catch (err) {}
 
-      expect(toastErrorSpy).toHaveBeenCalledTimes(1);
+      expect(toastErrorSpy).toHaveBeenCalledTimes(2);
     });
     it('retries failed wfs requests', async () => {
       const { findByPin } = getRenderedHook();

--- a/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
@@ -37,13 +37,9 @@ const wfsAxios = () => {
 
   instance.interceptors.response.use(
     response => {
-      toast.dismiss(layerData.LAYER_DATA_LOADING_ID);
-      layerData.LAYER_DATA_ERROR();
-      console.log(response);
       return response;
     },
     error => {
-      console.log(error);
       if (axios.isCancel(error)) {
         return Promise.resolve(error.message);
       }

--- a/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
@@ -107,6 +107,20 @@ const wfsAxios = () => {
     layerData.LAYER_DATA_LOADING();
     return config;
   });
+
+  instance.interceptors.response.use(
+    response => {
+      return response;
+    },
+    error => {
+      if (axios.isCancel(error)) {
+        return Promise.resolve(error.message);
+      }
+      toast.dismiss(layerData.LAYER_DATA_LOADING_ID);
+      layerData.LAYER_DATA_ERROR();
+      return Promise.reject(error);
+    },
+  );
   return instance;
 };
 

--- a/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
@@ -47,7 +47,9 @@ const wfsAxios = () => {
       layerData.LAYER_DATA_ERROR();
 
       // Error is handled and returning empty object.
-      return Promise.resolve({});
+      return Promise.resolve({
+        features: [],
+      });
     },
   );
   return instance;
@@ -144,7 +146,7 @@ export const useLayerQuery = (url: string, geometryName: string = 'SHAPE'): IUse
         await wfsAxios().get(
           `${baseUrl}&cql_filter=CONTAINS(${geometryName},SRID=4326;POINT ( ${latlng.lng} ${latlng.lat}))`,
         )
-      )?.data;
+      )?.data ?? { features: [] };
       return data;
     },
     [baseUrl, geometryName],
@@ -157,7 +159,7 @@ export const useLayerQuery = (url: string, geometryName: string = 'SHAPE'): IUse
           await wfsAxios().get(
             `${baseUrl}&cql_filter=ADMIN_AREA_NAME='${city}' OR ADMIN_AREA_ABBREVIATION='${city}'&outputformat=json`,
           )
-        )?.data;
+        )?.data ?? { features: [] };
 
         if (data.totalFeatures === 0) {
           return null;

--- a/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
@@ -39,9 +39,11 @@ const wfsAxios = () => {
     response => {
       toast.dismiss(layerData.LAYER_DATA_LOADING_ID);
       layerData.LAYER_DATA_ERROR();
+      console.log(response);
       return response;
     },
     error => {
+      console.log(error);
       if (axios.isCancel(error)) {
         return Promise.resolve(error.message);
       }

--- a/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/hooks/useLayerQuery.tsx
@@ -13,6 +13,48 @@ import { toast } from 'react-toastify';
 import { layerData } from 'constants/toasts';
 import * as rax from 'retry-axios';
 
+const MAX_RETRIES = 2;
+const wfsAxios = () => {
+  const instance = axios.create({ timeout: 5000, withCredentials: true });
+  instance.defaults.raxConfig = {
+    retry: MAX_RETRIES,
+    instance: instance,
+    shouldRetry: (error: AxiosError) => {
+      const cfg = rax.getConfig(error);
+      if (cfg?.currentRetryAttempt === MAX_RETRIES) {
+        toast.dismiss(layerData.LAYER_DATA_LOADING_ID);
+        layerData.LAYER_DATA_ERROR();
+      }
+      return rax.shouldRetryRequest(error);
+    },
+  };
+  rax.attach(instance);
+
+  instance.interceptors.request.use(config => {
+    layerData.LAYER_DATA_LOADING();
+    return config;
+  });
+
+  instance.interceptors.response.use(
+    response => {
+      toast.dismiss(layerData.LAYER_DATA_LOADING_ID);
+      layerData.LAYER_DATA_ERROR();
+      return response;
+    },
+    error => {
+      if (axios.isCancel(error)) {
+        return Promise.resolve(error.message);
+      }
+      toast.dismiss(layerData.LAYER_DATA_LOADING_ID);
+      layerData.LAYER_DATA_ERROR();
+
+      // Error is handled and returning empty object.
+      return Promise.resolve({});
+    },
+  );
+  return instance;
+};
+
 export interface IUserLayerQuery {
   /**
    * function to find GeoJSON shape containing a point (x, y)
@@ -85,43 +127,6 @@ export const handleParcelDataLayerResponse = (
     .catch((axiosError: AxiosError) => {
       dispatch(error(parcelLayerDataSlice.reducer.name, axiosError?.response?.status, axiosError));
     });
-};
-const MAX_RETRIES = 2;
-const wfsAxios = () => {
-  const instance = axios.create({ timeout: 5000, withCredentials: true });
-  instance.defaults.raxConfig = {
-    retry: MAX_RETRIES,
-    instance: instance,
-    shouldRetry: (error: AxiosError) => {
-      const cfg = rax.getConfig(error);
-      if (cfg?.currentRetryAttempt === MAX_RETRIES) {
-        toast.dismiss(layerData.LAYER_DATA_LOADING_ID);
-        layerData.LAYER_DATA_ERROR();
-      }
-      return rax.shouldRetryRequest(error);
-    },
-  };
-  rax.attach(instance);
-
-  instance.interceptors.request.use(config => {
-    layerData.LAYER_DATA_LOADING();
-    return config;
-  });
-
-  instance.interceptors.response.use(
-    response => {
-      return response;
-    },
-    error => {
-      if (axios.isCancel(error)) {
-        return Promise.resolve(error.message);
-      }
-      toast.dismiss(layerData.LAYER_DATA_LOADING_ID);
-      layerData.LAYER_DATA_ERROR();
-      return Promise.reject(error);
-    },
-  );
-  return instance;
 };
 
 /**


### PR DESCRIPTION
moving the axios component as a "global" object in the userLayerQuery.tsx, adding error handling within this component for situations where there maybe 403 response codes from a map layer request.