### PR TITLE
Fix for log4j to upgrade Sonarqube

### DIFF
--- a/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
+++ b/frontend/src/features/projects/list/__snapshots__/ProjectListView.test.tsx.snap
@@ -136,6 +136,12 @@ exports[`Project list view tests Matches snapshot 1`] = `
               </option>
               <option
                 class="option"
+                value="2023"
+              >
+                2022 / 2023
+              </option>
+              <option
+                class="option"
                 value="2022"
               >
                 2021 / 2022
@@ -199,12 +205,6 @@ exports[`Project list view tests Matches snapshot 1`] = `
                 value="2012"
               >
                 2011 / 2012
-              </option>
-              <option
-                class="option"
-                value="2011"
-              >
-                2010 / 2011
               </option>
             </select>
           </div>

--- a/openshift/4.0/templates/sonarqube/deploy.yaml
+++ b/openshift/4.0/templates/sonarqube/deploy.yaml
@@ -26,7 +26,7 @@ parameters:
   - displayName: SonarQube version
     name: SONARQUBE_VERSION
     required: true
-    value: "9.2-community"
+    value: "lts-community"
 
 objects:
   - apiVersion: v1

--- a/openshift/4.0/templates/sonarqube/deploy.yaml
+++ b/openshift/4.0/templates/sonarqube/deploy.yaml
@@ -26,7 +26,7 @@ parameters:
   - displayName: SonarQube version
     name: SONARQUBE_VERSION
     required: true
-    value: "lts-enterprise"
+    value: "9.2-community"
 
 objects:
   - apiVersion: v1

--- a/openshift/4.0/templates/sonarqube/deploy.yaml
+++ b/openshift/4.0/templates/sonarqube/deploy.yaml
@@ -26,7 +26,7 @@ parameters:
   - displayName: SonarQube version
     name: SONARQUBE_VERSION
     required: true
-    value: "8.2.2"
+    value: "lts-enterprise"
 
 objects:
   - apiVersion: v1
@@ -42,7 +42,7 @@ objects:
             tags: sonarqube
           from:
             kind: DockerImage
-            name: "bcgovimages/sonarqube:${SONARQUBE_VERSION}"
+            name: "sonarqube:${SONARQUBE_VERSION}"
           importPolicy: {}
           name: "${SONARQUBE_VERSION}"
   - apiVersion: v1
@@ -67,7 +67,9 @@ objects:
           maxUnavailable: 25%
           timeoutSeconds: 600
           updatePeriodSeconds: 1
-        type: Rolling
+        type: Recreate
+        recreateParams:
+          timeoutSeconds: 9600
       template:
         metadata:
           annotations:


### PR DESCRIPTION
using the lts-enterprise image from sonarqube: https://hub.docker.com/_/sonarqube?tab=tags
I believe the version is v8.9.6, and I'm assuming enterprise is the one to use.
Also modified the deployment strategy from rolling to recreate and added a longer timeout:
recreateParams:
          timeoutSeconds: 9600