### PR TITLE
PIMS-80: Property list building view financials not saving

### DIFF
--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -751,10 +751,6 @@ const PropertyListView: React.FC = () => {
               validationSchema={Yup.object().shape({
                 properties: Yup.array().of(
                   Yup.object().shape({
-                    assessedLand: Yup.number()
-                      .min(0, 'Minimum value is $0')
-                      .max(1000000000, 'Maximum value is $1,000,000,000')
-                      .required('Required'),
                     market: Yup.number()
                       .min(0, 'Minimum value is $0')
                       .max(1000000000, 'Maximum value is $1,000,000,000')


### PR DESCRIPTION
I've disabled validation on the assessed land field now which allows the editing and saving of financial values in the building view mode.
I noticed that there are a couple other minor bugs which can be addressed at a later date, one is that after saving a financial value, the lot size value switches to display "NaN". 
![image](https://user-images.githubusercontent.com/68400651/152389225-5da092d9-2679-482a-a683-0da27d3dbbe7.png)
The value is still there, as we can switch to the parcels view and then back and the value is there, it's just not getting displayed when you click save for some reason. Maybe something to do with the state?

The other issue is that after saving your edits, if you click the cancel button to get out of "edit" mode, the assessed building value for the record/s that was changed goes to 0:
![image](https://user-images.githubusercontent.com/68400651/152389733-6108b638-3d49-4448-8cd0-fbc8366049ba.png)

Just click the parcels view and then come back to the buildings view and the values will reappear:
![image](https://user-images.githubusercontent.com/68400651/152389943-f287f8b1-239f-47b8-b203-2367bdeb8bed.png)
