### PR TITLE
PIMS-80 - fixing lot size issue

### DIFF
--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -184,7 +184,7 @@ export const flattenBuilding = (apiProperty: IBuilding): IProperty => {
     marketFiscalYear: market?.fiscalYear as number,
     marketRowVersion: market?.rowVersion,
     rowVersion: apiProperty.rowVersion,
-    landArea: apiProperty.totalArea,
+    totalArea: apiProperty.totalArea,
   };
   return property;
 };


### PR DESCRIPTION
The lot size was getting displayed to 0 after saving a building in the property list view.
Changed landArea to totalArea in the PropertyListView.tsx file.

I might have found another bug which occurs after you save a record, then you click "cancel" which displays the edited and saved record:
![image](https://user-images.githubusercontent.com/68400651/153083034-205a2ca4-3ba6-4253-b3cc-c4a34f789538.png)


 but if you go back to edit again then the previous values get displayed again for some reason (possibly due to a state?).
![image](https://user-images.githubusercontent.com/68400651/153083190-0084585e-53cb-467f-8fac-b25ee2b07c4c.png)


If you click cancel again, the saved values reappear:
![image](https://user-images.githubusercontent.com/68400651/153083335-642b3c45-4ffe-45c4-96f2-b66b9ea9afde.png)
