### PR TITLE
Pims 81 - Rollback sqM to sqft and update sqft to Sq. M

### DIFF
--- a/backend/dal/Migrations/v01.15.00/Down/PostDown/01-NotificationTemplates.sql
+++ b/backend/dal/Migrations/v01.15.00/Down/PostDown/01-NotificationTemplates.sql
@@ -1,0 +1,6 @@
+PRINT 'Updating NotificationTemplates'
+
+-- Replace the instances thats shows sqM with sqft
+UPDATE [pims].dbo.[NotificationTemplates]
+SET [Body] = REPLACE([Body], 'sqM', 'sqft') 
+WHERE Body LIKE '%sqM%';

--- a/backend/dal/Migrations/v01.15.00/Up/PostUp/01-NotificationTemplates.sql
+++ b/backend/dal/Migrations/v01.15.00/Up/PostUp/01-NotificationTemplates.sql
@@ -5,7 +5,3 @@ UPDATE [pims].dbo.[NotificationTemplates]
 SET [Body] = REPLACE([Body], 'sqft', 'Sq. M') 
 WHERE Body LIKE '%sqft%';
 
--- Replace the instances thats shows sqM with Sq. M
-UPDATE [pims].dbo.[NotificationTemplates]
-SET [Body] = REPLACE([Body], 'sqM', 'Sq. M')  
-WHERE Body LIKE '%sqM%';

--- a/backend/dal/Migrations/v01.15.00/Up/PostUp/01-NotificationTemplates.sql
+++ b/backend/dal/Migrations/v01.15.00/Up/PostUp/01-NotificationTemplates.sql
@@ -1,6 +1,11 @@
 PRINT 'Updating NotificationTemplates'
 
--- Replace the instances thats shows sqft with sqM
+-- Replace the instances thats shows sqft with Sq. M
 UPDATE [pims].dbo.[NotificationTemplates]
-SET [Body] = REPLACE([Body], 'sqft', 'sqM') 
-WHERE Body LIKE '%sqft%'
+SET [Body] = REPLACE([Body], 'sqft', 'Sq. M') 
+WHERE Body LIKE '%sqft%';
+
+-- Replace the instances thats shows sqM with Sq. M
+UPDATE [pims].dbo.[NotificationTemplates]
+SET [Body] = REPLACE([Body], 'sqM', 'Sq. M')  
+WHERE Body LIKE '%sqM%';


### PR DESCRIPTION
Modified the notification templates to update sqft to Sq. M and rollback the previous changes that had sqM.