### PR TITLE
PIMS-100: Property Inventory Management System  Building slide out on the map issue on buildings with more than one evaluation.

### DIFF
--- a/frontend/src/components/maps/leaflet/InfoSlideOut/BuildingAttributes.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/BuildingAttributes.tsx
@@ -28,7 +28,10 @@ export const BuildingAttributes: React.FC<IBuildingAttributes> = ({
     formatAssessed = formatMoney(buildingInfo?.assessedBuilding);
   } else if (buildingInfo?.evaluations?.length >= 1) {
     formatAssessed = formatMoney(
-      buildingInfo?.evaluations.sort((a, b) => compareDate(a.date, b.date)).reverse()[0].value,
+      buildingInfo?.evaluations
+        .slice()
+        .sort((a, b) => compareDate(a.date, b.date))
+        .reverse()[0].value,
     );
   } else {
     formatAssessed = '';


### PR DESCRIPTION
When a building contains more than one evaluation/assessment value, it seems that the existing code for sorting the values was "mutating" the array which caused the Cannot assign to read only property '0' of object '[object Array]' error.

Adding slice() method before the sort method which creates a copy of array seems to fix the issue, tested creating multiple assessments on buildings locally and it seems to work. 