### PR TITLE
PIMS-61: Clean up Layers

### DIFF
--- a/frontend/src/components/maps/leaflet/LayersControl/LayersTree.tsx
+++ b/frontend/src/components/maps/leaflet/LayersControl/LayersTree.tsx
@@ -32,7 +32,7 @@ const ParentNode = styled(ListGroup.Item)`
 
 const LayerNode = styled(ListGroup.Item)`
   display: flex;
-  padding-left: 25px;
+  padding-left: 40px !important;
   border: none;
   padding-top: 5px;
   padding-bottom: 5px;
@@ -240,7 +240,7 @@ const layers = layersTree.map((parent, parentIndex) => {
     nodes: parent.nodes?.map((node: any, index) => ({
       ...node,
       zIndex: (parentIndex + 1) * index,
-      opacity: 0.3,
+      opacity: 99.9,
     })),
   };
 });


### PR DESCRIPTION
Indenting children layers in layer map legend and increasing opacity of map layers.

![image](https://user-images.githubusercontent.com/68400651/156818797-d11c5df8-7c0d-47eb-92cb-864d8639ba36.png)
