### PR TITLE
PIMS-116 Update project filter

### DIFF
--- a/backend/dal/Helpers/Extensions/ProjectExtensions.cs
+++ b/backend/dal/Helpers/Extensions/ProjectExtensions.cs
@@ -81,6 +81,11 @@ namespace Pims.Dal.Helpers.Extensions
                 query = query.Where(p => filter.StatusId.Contains(p.StatusId));
             }
 
+            if (filter.NotStatusId?.Any() == true)
+            {
+                query = query.Where(p => !filter.NotStatusId.Contains(p.StatusId));
+            }
+
             if (filter.Agencies?.Any() == true)
             {
                 // Get list of sub-agencies for any agency selected in the filter.

--- a/backend/entities/Models/ProjectFilter.cs
+++ b/backend/entities/Models/ProjectFilter.cs
@@ -27,6 +27,11 @@ namespace Pims.Dal.Entities.Models
         public int[] StatusId { get; set; }
 
         /// <summary>
+        /// get/set - An array of status Id.
+        /// </summary>
+        public int[] NotStatusId { get; set; }
+
+        /// <summary>
         /// get/set - The project tier level.
         /// </summary>
         /// <value></value>
@@ -91,6 +96,7 @@ namespace Pims.Dal.Entities.Models
             this.Name = filter.GetStringValue(nameof(this.Name));
             this.StatusId = filter.GetIntArrayValue("status");
             this.StatusId = filter.GetIntArrayValue(nameof(this.StatusId));
+            this.NotStatusId = filter.GetIntArrayValue(nameof(this.NotStatusId));
             this.TierLevelId = filter.GetIntNullValue(nameof(this.TierLevelId));
             this.CreatedByMe = filter.GetBoolNullValue(nameof(this.CreatedByMe));
             this.SPLWorkflow = filter.GetBoolNullValue(nameof(this.SPLWorkflow));
@@ -118,6 +124,7 @@ namespace Pims.Dal.Entities.Models
                 || this.CreatedByMe.HasValue
                 || this.FiscalYear.HasValue
                 || (this.StatusId?.Any() ?? false)
+                || (this.NotStatusId?.Any() ?? false)
                 || (this.Agencies?.Any() ?? false)
                 || (this.Workflows?.Any() ?? false);
         }

--- a/frontend/src/features/projects/list/ProjectListView.tsx
+++ b/frontend/src/features/projects/list/ProjectListView.tsx
@@ -41,6 +41,7 @@ import { IStatus } from 'features/projects/interfaces';
 interface IProjectFilterState {
   name?: string;
   statusId?: string[];
+  notStatusId?: string[];
   agencyId?: string;
   agencies?: number[];
   fiscalYear?: number | '';
@@ -56,6 +57,7 @@ interface IProps {
 const initialValues: IProjectFilterState = {
   name: '',
   statusId: [],
+  notStatusId: ['16', '23', '32'], // Denied, Cancelled, Disposed
   agencyId: '',
   agencies: [],
   fiscalYear: '',
@@ -163,6 +165,7 @@ export const ProjectListView: React.FC<IProps> = ({
           pageSize,
           filter: {
             ...filter,
+            notStatusId: filter?.statusId?.length ? [] : filter?.notStatusId,
             statusId: filter?.statusId?.length ? filter.statusId : defaultFilter.statusId,
           },
         });


### PR DESCRIPTION
By default now all project list views exclude Denied, Cancelled, and Disposed projects.  You can manually search for them still.