### PR TITLE
PIMS-90: Export list of Users not working 

### DIFF
--- a/backend/dal/Services/Admin/Concrete/UserService.cs
+++ b/backend/dal/Services/Admin/Concrete/UserService.cs
@@ -84,7 +84,6 @@ namespace Pims.Dal.Services.Admin
             {
                 if (filter.Page < 1) filter.Page = 1;
                 if (filter.Quantity < 1) filter.Quantity = 1;
-                if (filter.Quantity > 50) filter.Quantity = 50;
                 if (filter.Sort == null) filter.Sort = new string[] { };
 
                 if (!string.IsNullOrWhiteSpace(filter.Username))
@@ -106,7 +105,7 @@ namespace Pims.Dal.Services.Admin
                         EF.Functions.Like(r.Role.Name, $"%{filter.Role}")));
                 if (!string.IsNullOrWhiteSpace(filter.Agency))
                     query = query.Where(u => u.Agencies.Any(a =>
-                        EF.Functions.Like(a.Agency.Name, $"%{filter.Agency}")));
+                        EF.Functions.Like(a.Agency.Name, $"%{filter.Agency}") || EF.Functions.Like(a.Agency.Parent.Name, $"%{filter.Agency}")));
 
                 if (filter.Sort.Any())
                 {


### PR DESCRIPTION
Right now, there is no easy way to select all subagency users belonging to a parent agency and there is a limit of 50 users when exporting to excel. This PR will change the way the filter works so that if you select a parent agency such as Education, it will return all Education users including all users whose parent agency belong to Education such as all the school district users.