### PR TITLE
PIMS-110 Return all property names

### DIFF
--- a/frontend/src/store/slices/hooks/propertyActionCreator.ts
+++ b/frontend/src/store/slices/hooks/propertyActionCreator.ts
@@ -12,7 +12,7 @@ const getPropertyNames = (filter: IGeoSearchParams) =>
 
 export const fetchPropertyNames = (agencyId: number) => async (dispatch: Dispatch<AnyAction>) => {
   const axiosResponse = CustomAxios()
-    .get(ENVIRONMENT.apiUrl + getPropertyNames({ agencies: agencyId?.toString() }))
+    .get(ENVIRONMENT.apiUrl + getPropertyNames({}))
     .then(response => dispatch(savePropertyNames(response.data)));
   return await handleAxiosResponse(STORE_PROPERTY_NAMES, axiosResponse)(dispatch);
 };


### PR DESCRIPTION
The property name filter was only showing properties for the user's agency.  I have removed this condition.

![image](https://user-images.githubusercontent.com/3180256/164533906-0b905283-e608-404e-86c1-9e69533fa912.png)
