### PR TITLE
To fix the Pipeline issue

### DIFF
--- a/backend/Dockerfile.migrations
+++ b/backend/Dockerfile.migrations
@@ -6,7 +6,7 @@ ENV PATH="$PATH:/tmp/.dotnet/tools"
 
 # Switch to root for package installs
 USER 0
-RUN dotnet tool install --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 5.0.17
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
After discussing with Jeremy, it looks like the Dockerfile.migrations folder in the backend is installing the latest version of dotnet-ef during our integration pipeline:

`RUN dotnet tool install --global dotnet-ef`

which causes it to fail since it is not compatible with our v5, so we need to specify dotnet-ef version to install. Most likely this is the issue, will need to run the pipeline after this gets merged.