### PR TITLE
PIMS-297 Add Geocoder search

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -21,5 +21,10 @@
   "jest.autoRun": {
     "onStartup": ["all-tests"]
   },
-  "cSpell.words": ["Formik", "PIMS", "siteminder"]
+  "cSpell.words": [
+    "bbox",
+    "Formik",
+    "PIMS",
+    "siteminder"
+  ]
 }

--- a/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.tsx
+++ b/frontend/src/components/maps/leaflet/InfoSlideOut/InfoSlideOut.tsx
@@ -192,8 +192,12 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
 
   const keycloak = useKeycloakWrapper();
   const dispatch = useAppDispatch();
-  const canViewProperty = keycloak.canUserViewProperty(propertyInfo);
-  const canEditProperty = keycloak.canUserEditProperty(propertyInfo);
+  const canViewProperty =
+    keycloak.canUserViewProperty(propertyInfo) &&
+    popUpContext.propertyTypeID !== PropertyTypes.GEOCODER;
+  const canEditProperty =
+    keycloak.canUserEditProperty(propertyInfo) &&
+    popUpContext.propertyTypeID !== PropertyTypes.GEOCODER;
 
   const renderContent = () => {
     if (popUpContext.propertyInfo) {
@@ -218,6 +222,7 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
           </>
         );
       } else if (canViewProperty) {
+        if (popUpContext.propertyTypeID === PropertyTypes.GEOCODER) return null;
         if (isBuilding) {
           return (
             <AssociatedParcelsList parcels={(popUpContext.propertyInfo as IBuilding).parcels} />
@@ -304,23 +309,26 @@ const InfoControl: React.FC<InfoControlProps> = ({ open, setOpen, onHeaderAction
             <InfoIcon />
           </InfoButton>
         </TooltipWrapper>
-        {open && popUpContext.propertyInfo && canViewProperty && (
-          <TooltipWrapper
-            toolTipId="associated-items-id"
-            toolTip={isBuilding ? 'Associated Land' : 'Associated Buildings'}
-          >
-            <TabButton
-              id="slideOutTab"
-              variant="outline-secondary"
-              className={clsx({ open })}
-              onClick={() => {
-                setGeneralInfoOpen(false);
-              }}
+        {open &&
+          popUpContext.propertyInfo &&
+          canViewProperty &&
+          popUpContext.propertyTypeID !== PropertyTypes.GEOCODER && (
+            <TooltipWrapper
+              toolTipId="associated-items-id"
+              toolTip={isBuilding ? 'Associated Land' : 'Associated Buildings'}
             >
-              {isBuilding ? <LandSvg className="svg" /> : <BuildingSvg className="svg" />}
-            </TabButton>
-          </TooltipWrapper>
-        )}
+              <TabButton
+                id="slideOutTab"
+                variant="outline-secondary"
+                className={clsx({ open })}
+                onClick={() => {
+                  setGeneralInfoOpen(false);
+                }}
+              >
+                {isBuilding ? <LandSvg className="svg" /> : <BuildingSvg className="svg" />}
+              </TabButton>
+            </TooltipWrapper>
+          )}
         {open && <InfoMain className={clsx({ open })}>{renderContent()}</InfoMain>}
       </InfoContainer>
     </Control>

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -157,7 +157,7 @@ const getQueryParams = (filter: IPropertyFilter): IGeoSearchParams => {
 const defaultBounds = new LatLngBounds([60.09114547, -119.49609429], [48.78370426, -139.35937554]);
 
 /**
- * Creates a Leaflet map and by default includes a number of preconfigured layers.
+ * Creates a Leaflet map and by default includes a number of pre-configured layers.
  * @param param0
  */
 const Map: React.FC<MapProps> = ({

--- a/frontend/src/components/maps/leaflet/mapUtils.tsx
+++ b/frontend/src/components/maps/leaflet/mapUtils.tsx
@@ -73,6 +73,16 @@ export const subdivisionIconSelect = L.icon({
   shadowSize: [41, 41],
 });
 
+export const geocoderIcon = L.icon({
+  iconUrl:
+    require('assets/images/pins/marker-green.png').default ?? 'assets/images/pins/marker-green.png',
+  shadowUrl: require('assets/images/pins/marker-shadow.png').default ?? 'marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
 // draft parcel icon (green)
 export const draftParcelIcon = L.icon({
   iconUrl:
@@ -305,6 +315,8 @@ export const getMarkerIcon = (feature: ICluster, selected?: boolean) => {
       return parcelIconSelect;
     } else if (propertyTypeId === PropertyTypes.SUBDIVISION) {
       return subdivisionIconSelect;
+    } else if (propertyTypeId === PropertyTypes.GEOCODER) {
+      return geocoderIcon;
     } else {
       return buildingIconSelect;
     }
@@ -336,6 +348,8 @@ export const getMarkerIcon = (feature: ICluster, selected?: boolean) => {
       return parcelIcon;
     } else if (propertyTypeId === PropertyTypes.SUBDIVISION) {
       return subdivisionIcon;
+    } else if (propertyTypeId === PropertyTypes.GEOCODER) {
+      return geocoderIcon;
     } else {
       return buildingIcon;
     }

--- a/frontend/src/constants/propertyTypes.ts
+++ b/frontend/src/constants/propertyTypes.ts
@@ -4,4 +4,5 @@ export enum PropertyTypes {
   SUBDIVISION = 2,
   DRAFT_PARCEL = 3,
   DRAFT_BUILDING = 4,
+  GEOCODER = 5,
 }

--- a/frontend/src/features/properties/hooks/useGeocoder.tsx
+++ b/frontend/src/features/properties/hooks/useGeocoder.tsx
@@ -116,7 +116,7 @@ const useGeocoder = ({ formikRef, fetchPimsOrLayerParcel }: IUseGeocoderProps) =
             } as LatLng)
             .then(response => {
               const pid = getIn(response, 'features.0.properties.PID');
-              //it is possible the geocoder will fail to get the pid but the parcel layer service request will succeed. In that case, double check that the pid doesn't exist within pims.
+              // it is possible the geocoder will fail to get the pid but the parcel layer service request will succeed. In that case, double check that the pid doesn't exist within pims.
               if (pid) {
                 const parcelLayerSearchCallback = () => {
                   const response = parcelsService.findByPid(pid);

--- a/frontend/src/hooks/api/geocoder/useApiGeocoder.ts
+++ b/frontend/src/hooks/api/geocoder/useApiGeocoder.ts
@@ -1,8 +1,14 @@
+import Axios from 'axios';
+import { FeatureCollection } from 'geojson';
 import { useApi } from 'hooks/api';
 import React from 'react';
 
 import { IGeoAddressModel, ISitePidsModel } from '.';
 
+/**
+ * Provides a simple api to communicate with geocoder endpoints.
+ * @returns API controller with endpoints to Geocoder.
+ */
 export const useApiGeocoder = () => {
   const api = useApi();
 
@@ -13,6 +19,39 @@ export const useApiGeocoder = () => {
       },
       findAddresses: async (address: string) => {
         return api.get<IGeoAddressModel[]>(`/tools/geocoder/addresses?address=${address}`);
+      },
+      addresses: async (address: string, bbox?: string, locality?: string) => {
+        const axios = Axios.create({
+          baseURL: 'https://geocoder.api.gov.bc.ca',
+        });
+        // TODO: Figure out how to only return good results, Geocoder returns a ton of junk.
+        var params: any = {
+          ver: '1.2',
+          addressString: `"${address}"`,
+          outputSRS: 4326,
+          // maxResults: 10,
+          minScore: 60,
+          setBack: 0,
+          echo: true,
+          brief: true,
+          autoComplete: true,
+          locationDescriptor: 'parcelPoint',
+          // interpolation: 'adaptive',
+          // matchPrecision: 'CIVIC_NUMBER,STREET',
+          provinceCode: 'BC',
+        };
+        if (!!locality) params.localities = locality;
+        if (!!bbox) {
+          const values = bbox.split(',');
+          params.bbox = `${values[0]},${values[2]},${values[1]},${values[3]}`;
+        }
+        return axios.get<FeatureCollection>(`/addresses.json`, {
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE,PATCH,OPTIONS',
+          },
+          params,
+        });
       },
     }),
     [api],

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -4,6 +4,7 @@ import { IGeoSearchParams } from 'constants/API';
 import { ENVIRONMENT } from 'constants/environment';
 import CustomAxios, { LifecycleToasts } from 'customAxios';
 import { IApiProperty } from 'features/projects/interfaces';
+import { GeoJsonObject } from 'geojson';
 import * as _ from 'lodash';
 import queryString from 'query-string';
 import { useCallback } from 'react';
@@ -38,7 +39,7 @@ export interface PimsAPI extends AxiosInstance {
   ) => Promise<{ available: boolean }>;
   searchAddress: (text: string) => Promise<IGeocoderResponse[]>;
   getSitePids: (siteId: string) => Promise<IGeocoderPidsResponse>;
-  loadProperties: (params?: IGeoSearchParams) => Promise<any[]>;
+  loadProperties: (params?: IGeoSearchParams) => Promise<GeoJsonObject[]>;
   getBuilding: (id: number) => Promise<IBuilding>;
   getParcel: (id: number) => Promise<IParcel>;
   updateBuilding: (id: number, data: IApiProperty) => Promise<IBuilding>;
@@ -131,9 +132,9 @@ export const useApi = (props?: IApiProps): PimsAPI => {
   );
 
   axios.loadProperties = useCallback(
-    async (params?: IGeoSearchParams): Promise<any[]> => {
+    async (params?: IGeoSearchParams): Promise<GeoJsonObject[]> => {
       try {
-        const { data } = await axios.get<any[]>(
+        const { data } = await axios.get<GeoJsonObject[]>(
           `${ENVIRONMENT.apiUrl}/properties/search/wfs?${
             params ? queryString.stringify(params) : ''
           }`,
@@ -141,7 +142,7 @@ export const useApi = (props?: IApiProps): PimsAPI => {
         return data;
       } catch (error) {
         throw new Error(
-          `${(error as any).message}: An error occured while fetching properties in inventory.`,
+          `${(error as any).message}: An error occurred while fetching properties in inventory.`,
         );
       }
     },

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -224,7 +224,6 @@ export const getYear = (date?: Date | string): number => {
   } else {
     momentDate = moment(date);
   }
-  console.debug(date);
   return momentDate.year();
 };
 


### PR DESCRIPTION
# Description

When searching for properties on the map it will include Geocoder results if an address is provided.  It marks those properties from Geocoder with a empty green icon marker.

The Geocoder results aren't always very great and probably should be filtered better to reduce unrelated properties, but it's not clear what the best way to do this would be.

![image](https://user-images.githubusercontent.com/3180256/184691037-37378c32-d605-420e-8429-bcefddfdf599.png)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
