### PR TITLE
adding the lookupcodes hook to the propertylistview page

### DIFF
--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -25,12 +25,13 @@ import useCodeLookups from 'hooks/useLookupCodes';
 import { useRouterFilter } from 'hooks/useRouterFilter';
 import { fill, intersection, isEmpty, keys, noop, pick, range } from 'lodash';
 import queryString from 'query-string';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Container } from 'react-bootstrap';
 import { FaEdit, FaFileExport, FaFolder, FaFolderOpen } from 'react-icons/fa';
 import { FaFileAlt, FaFileExcel } from 'react-icons/fa';
 import { toast } from 'react-toastify';
 import { useAppDispatch } from 'store';
+import { getFetchLookupCodeAction } from 'store/slices/hooks/lookupCodeActionCreator';
 import styled from 'styled-components';
 import { decimalOrUndefined, mapLookupCode } from 'utils';
 import download from 'utils/download';
@@ -439,6 +440,11 @@ const PropertyListView = () => {
   }, [fetchData, pageIndex, pageSize, filter, agencyIds, sorting]);
 
   const dispatch = useAppDispatch();
+
+  /** make sure lookup codes are updated on page load */
+  useEffect(() => {
+    getFetchLookupCodeAction()(dispatch);
+  }, [dispatch]);
 
   /**
    * @param {'csv' | 'excel'} accept Whether the fetch is for type of CSV or EXCEL

--- a/frontend/src/hooks/useLookupCodes.tsx
+++ b/frontend/src/hooks/useLookupCodes.tsx
@@ -16,7 +16,6 @@ import { useKeycloakWrapper } from './useKeycloakWrapper';
 export function useCodeLookups() {
   const keycloak = useKeycloakWrapper();
   const lookupCodes = useAppSelector<ILookupCode[]>((store) => store.lookupCode.lookupCodes);
-  console.log('agenci code lookups: ' + lookupCodes.length);
   const getCodeById = (type: string, id: string): string | undefined => {
     return lookupCodes.filter((code) => code.type === type && code.id === id)?.find((x) => x)?.code;
   };


### PR DESCRIPTION
# Description

Included the code which calls the lookupcodes that populates the drop downs for the filter bar at the top of the page.
Removed a couple more debug lines.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Am able to see the drop down lists for Agencies, locations, and classifications now from the View Property Inventory page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
