### PR TITLE
Fixing view property inventory page

### DIFF
--- a/frontend/src/components/common/form/StepForm/SteppedForm.tsx
+++ b/frontend/src/components/common/form/StepForm/SteppedForm.tsx
@@ -22,7 +22,7 @@ import { ISteppedFormProps, ISteppedFormValues, IStepperTab } from './types';
 
 const TabbedForm = styled(Form)`
   .hideTabs {
-    a.nav-item {
+    li.nav-item {
       background-color: white;
       display: none;
     }
@@ -230,15 +230,17 @@ const tabTitle = (title: string, index: number, setTabToDeleteId: (index: number
     <>
       <AbbreviatedText text={title} maxLength={20} />
       <TooltipWrapper toolTipId="remove-associated-parcel" toolTip="Remove this associated parcel">
-        <FaWindowClose
-          size={15}
-          data-testid={`delete-parcel-${index + 1}`}
-          onClick={(e: any) => {
-            e.preventDefault();
-            e.stopPropagation();
-            setTabToDeleteId(index);
-          }}
-        ></FaWindowClose>
+        <a>
+          <FaWindowClose
+            size={15}
+            data-testid={`delete-parcel-${index + 1}`}
+            onClick={(e: any) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setTabToDeleteId(index);
+            }}
+          ></FaWindowClose>
+        </a>
       </TooltipWrapper>
     </>
   );

--- a/frontend/src/features/properties/list/PropertyListView.scss
+++ b/frontend/src/features/properties/list/PropertyListView.scss
@@ -15,6 +15,10 @@ $contentheading-height: 60px;
     .map-filter-bar {
       align-items: center;
       padding: 1rem 0;
+      display: flex;
+      flex-wrap: wrap;
+      margin-right: -5px;
+      margin-left: -5px;
       .vl {
         border-left: 6px solid rgba(96, 96, 96, 0.2);
         height: 40px;
@@ -43,6 +47,8 @@ $contentheading-height: 60px;
       .map-filter-typeahead {
         min-width: 200px;
         max-width: 250px;
+        padding-right: 5px;
+        padding-left: 5px;
       }
       .btn-warning {
         color: white;


### PR DESCRIPTION
# Description

Adding 4 styles to the filter bar and fixed forwardref error on SteppedForm.tsx-->FAWindowclose on the View Inventory Property page.
![image](https://user-images.githubusercontent.com/80914899/195179463-d19d53e0-0aea-4550-a61d-e0a77cd59984.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
