### PR TITLE
Pims-351 header styling tweaks

### DIFF
--- a/frontend/src/components/layout/AppNavBar/AppNavBar.scss
+++ b/frontend/src/components/layout/AppNavBar/AppNavBar.scss
@@ -5,7 +5,7 @@ nav.map-nav {
   font-family: 'BCSans', Fallback, sans-serif;
   white-space: nowrap;
   padding: 0;
-  margin: 0 -1.5rem;
+  margin: 0 4rem;
   .navbar-toggler {
     font-size: 0.8rem;
     border-color: #ddd;

--- a/frontend/src/components/layout/Header/Header.scss
+++ b/frontend/src/components/layout/Header/Header.scss
@@ -1,9 +1,12 @@
 @import '../../../fonts.scss';
 
 .App-header.navbar {
-  padding: 0 10px;
+  margin-left: 5rem;
   min-height: 70px;
   color: #ffffff;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0;
 
   .longAppName {
     display: none;
@@ -13,16 +16,21 @@
   }
 
   .brand-box {
-    padding: 10px 0;
+    padding-right: 0;
 
     .pims-logo {
       margin: 0 10px;
     }
   }
 
+  .bc-gov-icon {
+    padding-left: 15px;
+  }
+
   .title h1 {
     margin-top: 10px;
-    padding-left: 0px;
+    margin-right: 15.5rem;
+    padding-left: 0;
     text-align: center;
     font-size: 24px;
     text-decoration: none solid rgb(255, 255, 255);

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -17,7 +17,7 @@ import { UserProfile } from './UserProfile';
 
 const VerticalBar = styled.span`
   border-left: 2px solid white;
-  font-size: 34px;
+  font-size: 30px;
   margin: 0 15px 0 25px;
   vertical-align: top;
 `;
@@ -102,15 +102,15 @@ const Header = () => {
           <img
             className="bc-gov-icon"
             src={BClogoUrl}
-            width="156"
-            height="43"
+            width="164"
+            height="45"
             alt="Government of BC logo"
           />
         </a>
         <VerticalBar />
         <img className="pims-logo" src={PIMSlogo} height="50" alt="PIMS logo" />
       </Navbar.Brand>
-      <Nav className="title mr-auto">
+      <Nav className="title">
         <Nav.Item>
           <h1 className="longAppName">Property Inventory Management System</h1>
           <h1 className="shortAppName">PIMS</h1>
@@ -119,7 +119,7 @@ const Header = () => {
       {keycloak.obj.authenticated && <UserProfile />}
       <Nav className="other">
         {errors && errors.length ? (
-          <FaBomb size={30} className="errors" onClick={handleShow} />
+          <FaBomb size={24} className="errors" onClick={handleShow} />
         ) : null}
       </Nav>
       {errorModal(errors)}

--- a/frontend/src/features/admin/agencies/ManageAgencies.scss
+++ b/frontend/src/features/admin/agencies/ManageAgencies.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   padding: 0;
+  
   .agency-toolbar {
     justify-content: center;
     padding: 0px;
@@ -24,10 +25,10 @@
   .table-section {
     margin-left: 15%;
     margin-right: 15%;
-    padding: 1rem 2rem;
+    padding: 2.5rem 2rem;
     max-height: calc(
       100vh - #{$header-height} - #{$navbar-height} - #{$mapfilter-height} - #{$footer-height}
-    );
+    ) + 5;
     table {
       background-color: white;
     }

--- a/frontend/src/features/help/components/HelpModal.tsx
+++ b/frontend/src/features/help/components/HelpModal.tsx
@@ -71,7 +71,7 @@ const HelpModal: FunctionComponent<ModalProps> = ({ handleCancel, handleSubmit, 
         onHide={handleCancel}
         dialogClassName="help-modal"
       >
-        <ModalHeader closeButton>
+        <ModalHeader closeButton closeVariant="white">
           <DraggableTitle>
             Help Desk&nbsp;
             <StyledTooltip toolTipId="help-toolTip" toolTip="Click and drag to move this popup" />

--- a/frontend/src/features/help/containers/HelpContainer.tsx
+++ b/frontend/src/features/help/containers/HelpContainer.tsx
@@ -20,12 +20,17 @@ export function HelpContainer() {
   return keycloak.obj.authenticated ? (
     <Nav.Item>
       <TooltipWrapper toolTipId="help-tooltip" toolTip="Ask for Help">
-        <a>
+        <div
+          style={{
+            width: 25,
+            marginRight: 260,
+          }}
+        >
           <FaQuestionCircle
-            style={{ cursor: 'pointer', color: '#fff', marginLeft: -145 }}
+            style={{ cursor: 'pointer', color: '#fff', marginRight: 50 }}
             onClick={() => setShowHelp(true)}
           />
-        </a>
+        </div>
       </TooltipWrapper>
       <HelpModal
         show={showHelp}


### PR DESCRIPTION
# Description

**Styling fixes** for **pims-63** branch since moving from **react-bootstrap 4 to 5** broke some components.

Fixes styling of **Header** bar and **AppNavBar**. 
Fixes **close button** in **HelpModal** so it's white again.  
Adds padding to the bottom of the Administration > **Agencies page** so the page navigation is visible in 100% browser zoom (This was also an issue in dev, not just pims-63).

**Known Issue:** The Help Modal button's tooltip is a bit off center and the arrow from the tooltip isn't the right color. If you know how to fix this please let me know.

![help](https://user-images.githubusercontent.com/16313579/195205486-bc1c065d-bb6c-4112-839a-93b88d845d8f.PNG)

Fixes [PIMS-351](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-351)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
