### PR TITLE
PIMS-356 - Excel export for specific property classifications not working (Disposed, Transferred in GRE etc..)

### DIFF
--- a/frontend/src/features/projects/list/ProjectListView.tsx
+++ b/frontend/src/features/projects/list/ProjectListView.tsx
@@ -130,15 +130,18 @@ export const ProjectListView: React.FC<IProps> = ({
       (value as any).agencies
         ? setFilter({ ...value, agencies: (value as any)?.agencies })
         : setFilter({ ...value });
-      if ((value as any).statusId) {
-        setFilter({ ...value, statusId: (value as any).statusId?.map((x: any) => x) });
-      } else {
+      if ((value as any).statusId.length === 0) {
         setFilter({ ...value });
-        setClearSelected(!clearSelected);
+      } else if ((value as any).statusId) {
+        setFilter({
+          ...value,
+          statusId: (value as any).statusId?.map((x: any) => x),
+          notStatusId: [],
+        });
       }
       setPageIndex(0); // Go to first page of results when filter changes
     },
-    [setFilter, setPageIndex, clearSelected],
+    [setFilter, setPageIndex],
   );
   const onPageSizeChanged = useCallback(size => {
     setPageSize(size);


### PR DESCRIPTION
# Description

By default when viewing the "View Projects" page, the list will initially exclude projects whose statuses are either Denied, Transferred-GRE, Cancelled, or Disposed. The status filter would work when viewing projects on the webpage, but when exporting to excel you would not see these project statuses in the report.

This "initial" filter state in the ProjectListView.tsx component for "notStatusId" were being passed into the filter when exporting to excel in the ProjectExtensions.cs GenerateQuery function on line 91 which would essentially exclude these project statuses.

`if (filter.NotStatusId?.Any() == true)
  {
      query = query.Where(p => !filter.NotStatusId.Contains(p.StatusId));
  }`

The fix was to "reset" the notStatusId in the PropertyListView.tsx, in the frontend, to an empty array when a "new" filter is being applied from the View Projects page which lets these previously excluded projects to be part of the Excel report.

![image](https://user-images.githubusercontent.com/68400651/195953050-c9b9be79-b12f-47ae-b8e6-2c529e95e781.png)



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
