### PR TITLE
PIMS-307 Fix geocoder administrative area

### DIFF
--- a/frontend/src/features/properties/components/GeocoderAutoComplete.tsx
+++ b/frontend/src/features/properties/components/GeocoderAutoComplete.tsx
@@ -71,6 +71,7 @@ export const GeocoderAutoComplete: React.FC<IGeocoderAutoCompleteProps> = ({
       setOptions([]);
     }
   };
+
   React.useEffect(() => {
     return () => {
       search('', true);

--- a/frontend/src/features/properties/filter/PropertyFilter.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilter.tsx
@@ -244,7 +244,15 @@ export const PropertyFilter: React.FC<IPropertyFilterProps> = ({
             <Col className="bar-item flex-grow-0">
               <SearchButton
                 disabled={isSubmitting || findMoreOpen}
-                onClick={() => setTriggerFilterChanged && setTriggerFilterChanged(true)}
+                onClick={() => {
+                  const add = (values.address ?? '').split(',');
+                  if (add.length > 1) {
+                    // Extract the administrative area if it was provided.
+                    setFieldValue('address', add[0]);
+                    setFieldValue('administrativeArea', add[1]);
+                  }
+                  setTriggerFilterChanged && setTriggerFilterChanged(true);
+                }}
               />
             </Col>
             <Col className="bar-item flex-grow-0">

--- a/frontend/src/features/properties/filter/PropertyFilterOptions.tsx
+++ b/frontend/src/features/properties/filter/PropertyFilterOptions.tsx
@@ -45,6 +45,7 @@ export const PropertyFilterOptions: React.FC<IPropertyFilterOptions> = ({ disabl
             displayErrorTooltips
             onSelectionChanged={selection => {
               setFieldValue('address', selection.fullAddress);
+              setFieldValue('administrativeArea', selection.administrativeArea);
             }}
             onTextChange={value => {
               setFieldValue('address', value);


### PR DESCRIPTION
# Description

Adding Geocoder search to the property filter bar.  When typing an address it needs to extract the administrative area if provided, and it also needs to apply the administrative area if selected from the dropdown.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local testing and ran unit-tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
