### PR TITLE
PIMS-612 - Fixing issue with dev pipeline

### DIFF
--- a/backend/api/appsettings.Development.json
+++ b/backend/api/appsettings.Development.json
@@ -12,7 +12,7 @@
     }
   },
   "ConnectionStrings": {
-    "PIMS": "Server=database,1433;User ID=admin;Database=pims;Encrypt=False"
+    "PIMS": "Server=database,1433;User ID=admin;Database=pims;Encrypt=False;TrustServerCertificate=True;MultiSubnetFailover=True"
   },
   "Pims": {
     "Environment": {

--- a/backend/api/appsettings.Local.json
+++ b/backend/api/appsettings.Local.json
@@ -12,7 +12,7 @@
     }
   },
   "ConnectionStrings": {
-    "PIMS": "Server=database,1433;User ID=admin;Database=pims;Encrypt=False"
+    "PIMS": "Server=database,1433;User ID=admin;Database=pims;TrustServerCertificate=True;MultiSubnetFailover=True"
   },
   "Pims": {
     "Environment": {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes. -->
The dev pipeline is currently giving this error during the run-db-migration step in Openshift:
`Microsoft.Data.SqlClient.SqlException (0x80131904): A connection was successfully established with the server, but then an error occurred during the pre-login handshake. (provider: TCP Provider, error: 35 - An internal exception was caught)
---> System.Security.Authentication.AuthenticationException: The remote certificate was rejected by the provided RemoteCertificateValidationCallback.`

Trying to see if adding these new parameters to the connection string resolves the issue, based on this similar situation: https://github.com/dotnet/SqlClient/issues/1479
`TrustServerCertificate=True;MultiSubnetFailover=True`

<!-- JIRA TICKETS -->
[![](https://img.shields.io/badge/tickets_and_issues_this_solves-blue?style=for-the-badge)](https://hamzamohdzubair.github.io/redant/)
<!-- Please include a list of Jira tickets and or Issues this PR resolves. -->

- [PIMS-612](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-612)

<!-- KNOWN ISSUES -->
[![](https://img.shields.io/badge/known_issues-blueviolet?style=for-the-badge)](https://hamzamohdzubair.github.io/redant/)
<!-- Please include a list of known issues if there are any. -->

- None listed.

## Type(s) of Change

- [x] Bug fix
- [ ] Dependency updates, additions, or removal
- [ ] New feature
- [ ] Refactoring code or cleanup
- [ ] Documentation changes or additions
- [ ] Testing changes or additions
- [ ] Design and user experience
- [ ] Optimizations or security

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
Tested locally with no issues connecting to the database.


## Checklist:

- I have performed a self-review of my own code.
- I have commented my code, particularly in hard-to-understand areas.
- I have made corresponding changes to the documentation where required.
- My changes generate no new warnings.

- [x] I have read the checklist.
