### PR TITLE
Remove 'Populate property details' hyperlink

### DIFF
--- a/frontend/src/components/maps/leaflet/LayerPopup/LayerPopUpContent.test.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/LayerPopUpContent.test.tsx
@@ -1,5 +1,4 @@
-import { cleanup, render } from '@testing-library/react';
-import { SidebarContextType } from 'features/mapSideBar/hooks/useQueryParamSideBar';
+import { cleanup } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { LatLng, LatLngBounds } from 'leaflet';
 import React from 'react';
@@ -60,65 +59,5 @@ describe('Layer Popup Content', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-  });
-
-  it('Populate details link does not appear on default', () => {
-    const { queryByText } = render(
-      <MemoryRouter initialEntries={[history.location]}>
-        <MapContainer>
-          <LayerPopupContent
-            data={mockLayer.data}
-            config={mockLayer.config}
-            onAddToParcel={mockLayer.onAddToParcel}
-            bounds={bounds}
-          />
-        </MapContainer>
-      </MemoryRouter>,
-    );
-    const link = queryByText(/Populate property details/i);
-    expect(link).toBeNull();
-  });
-
-  it('Populate details link appears when sideBar open', () => {
-    const queryParams = new URLSearchParams();
-    queryParams.set('disabled', 'false');
-    queryParams.set('loadDraft', 'false');
-    queryParams.set('sidebar', 'true');
-    queryParams.set('sidebarContext', SidebarContextType.ADD_BUILDING);
-
-    history.push({
-      pathname: '/mapview',
-      search: queryParams.toString(),
-    });
-    const { getByText } = render(
-      <MemoryRouter initialEntries={[history.location]}>
-        <MapContainer>
-          <LayerPopupContent
-            data={mockLayer.data}
-            config={mockLayer.config}
-            onAddToParcel={mockLayer.onAddToParcel}
-            bounds={bounds}
-          />
-        </MapContainer>
-      </MemoryRouter>,
-    );
-    const link = getByText(/Populate property details/i);
-    expect(link).toBeInTheDocument();
-  });
-
-  xit('Zoom link does not appear without bounds', () => {
-    const { queryByText } = render(
-      <MemoryRouter initialEntries={[history.location]}>
-        <MapContainer>
-          <LayerPopupContent
-            data={mockLayer.data}
-            config={mockLayer.config}
-            onAddToParcel={mockLayer.onAddToParcel}
-          />
-        </MapContainer>
-      </MemoryRouter>,
-    );
-    const link = queryByText(/Zoom/i);
-    expect(link).toBeNull();
   });
 });

--- a/frontend/src/components/maps/leaflet/LayerPopup/LayerPopupContent.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/LayerPopupContent.tsx
@@ -1,4 +1,3 @@
-import { SidebarContextType } from 'features/mapSideBar/hooks/useQueryParamSideBar';
 import { LatLng, LatLngBounds } from 'leaflet';
 import { keys } from 'lodash';
 import * as React from 'react';
@@ -66,26 +65,10 @@ export const LayerPopupContent: React.FC<IPopupContentProps> = ({
 }) => {
   const rows = React.useMemo(() => keys(config), [config]);
   const location = useLocation();
-  const queryParams = new URLSearchParams(location.search);
-  const isEditing = [
-    SidebarContextType.ADD_BUILDING,
-    SidebarContextType.UPDATE_BUILDING,
-    SidebarContextType.ADD_ASSOCIATED_LAND,
-    SidebarContextType.ADD_BARE_LAND,
-    SidebarContextType.UPDATE_BARE_LAND,
-    SidebarContextType.UPDATE_DEVELOPED_LAND,
-  ].includes(queryParams.get('sidebarContext') as any);
-  const populateDetails = queryParams.get('sidebar') === 'true' && isEditing ? true : false;
 
   const leaflet = useMap();
   const curZoom = leaflet.getZoom();
   const boundZoom = leaflet.getBoundsZoom(bounds!);
-
-  // Populate Property Details link query params
-  const propertyDetailsQueryParams = new URLSearchParams(location.search);
-  propertyDetailsQueryParams.set('sidebar', 'true');
-  propertyDetailsQueryParams.set('disabled', 'false');
-  propertyDetailsQueryParams.set('loadDraft', 'false');
 
   return (
     <>
@@ -98,16 +81,6 @@ export const LayerPopupContent: React.FC<IPopupContentProps> = ({
       </ListGroup>
       <MenuRow>
         <Col>
-          {populateDetails && (data.PID !== undefined || data.PIN !== undefined) ? (
-            <StyledLink
-              onClick={(e: any) => onAddToParcel(e, { ...data, CENTER: center })}
-              to={{
-                search: propertyDetailsQueryParams.toString(),
-              }}
-            >
-              Populate property details
-            </StyledLink>
-          ) : null}
           {bounds && curZoom! !== boundZoom ? (
             <StyledLink
               to={{ ...location }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes. -->

Removed populate property details hyperlink button.

<!-- JIRA TICKETS -->
[![](https://img.shields.io/badge/tickets_and_issues_this_solves-blue?style=for-the-badge)](https://hamzamohdzubair.github.io/redant/)
<!-- Please include a list of Jira tickets and or Issues this PR resolves. -->

- [PIMS-610](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-610)

<!-- KNOWN ISSUES -->
[![](https://img.shields.io/badge/known_issues-blueviolet?style=for-the-badge)](https://hamzamohdzubair.github.io/redant/)
<!-- Please include a list of known issues if there are any. -->

- None listed.

## Type(s) of Change

- [ ] Bug fix
- [ ] Dependency updates, additions, or removal
- [ ] New feature
- [x] Refactoring code or cleanup
- [ ] Documentation changes or additions
- [ ] Testing changes or additions
- [ ] Design and user experience
- [ ] Optimizations or security

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->

Link no longer appears, tests pass.

## Checklist:

- I have performed a self-review of my own code.
- I have commented my code, particularly in hard-to-understand areas.
- I have made corresponding changes to the documentation where required.
- My changes generate no new warnings.

- [x] I have read the checklist.
