### PR TITLE
PIMS 683: Analytics fixes

### DIFF
--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -392,12 +392,6 @@ const PropertyListView: React.FC = () => {
     }
 
     // Send data to SnowPlow.
-    console.log(
-      'Classification:',
-      data.classificationId
-        ? lookupCodes.getClassificationNameById(Number(data.classificationId))
-        : '',
-    );
     window.snowplow('trackSelfDescribingEvent', {
       schema: 'iglu:ca.bc.gov.pims/search/jsonschema/1-0-0',
       data: {

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -392,6 +392,12 @@ const PropertyListView: React.FC = () => {
     }
 
     // Send data to SnowPlow.
+    console.log(
+      'Classification:',
+      data.classificationId
+        ? lookupCodes.getClassificationNameById(Number(data.classificationId))
+        : '',
+    );
     window.snowplow('trackSelfDescribingEvent', {
       schema: 'iglu:ca.bc.gov.pims/search/jsonschema/1-0-0',
       data: {
@@ -401,8 +407,9 @@ const PropertyListView: React.FC = () => {
         address: data.address ?? '',
         pid_pin: data.pid ?? '',
         property_name: data.name ?? '',
-        classification:
-          lookupCodes.getClassificationNameById(Number(filter.classificationId)) ?? '',
+        classification: data.classificationId
+          ? lookupCodes.getClassificationNameById(Number(data.classificationId))
+          : '',
       },
     });
 


### PR DESCRIPTION
![DESCRIPTION]
Filter on property inventory will default to sending Core Operational classification, make it default to empty string.

I have made changes to PropertyListView.tsx file to make sure by default, it will display empty string and if classification field has a value then it will display the string instead of the id. 

<br />

![TICKETS_AND_ISSUES]
<!-- Please list all jira tickets and github issues associated with this pull request. -->

- [PIMS-683: Analytics fixes](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-683)


<br />

![CHECKLIST]

- [x] I have read and agree with the following checklist:

```
- I have performed a self-review of my own code.  
- I have commented my code, particularly in hard-to-understand areas.  
- I have made corresponding changes to the documentation where required.  
- I have tested my changes.  
- My changes generate no new warnings.  
```

<!-- REFERENCES -->
[DESCRIPTION]: https://img.shields.io/badge/description-orange?style=for-the-badge
[TICKETS_AND_ISSUES]: https://img.shields.io/badge/tickets_&_issues-blue?style=for-the-badge
[CHECKLIST]: https://img.shields.io/badge/checklist-gold?style=for-the-badge