### PR TITLE
[PIMS-140] Update react-leaflet

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
     "react-draggable": "4.4.5",
     "react-error-boundary": "4.0.10",
     "react-icons": "4.10.1",
-    "react-leaflet": "3.2.5",
+    "react-leaflet": "4.2.1",
     "react-paginate": "8.2.0",
     "react-redux": "8.1.2",
     "react-redux-loading-bar": "5.0.4",

--- a/frontend/src/components/maps/leaflet/LayersControl/LayersControl.test.tsx
+++ b/frontend/src/components/maps/leaflet/LayersControl/LayersControl.test.tsx
@@ -99,7 +99,7 @@ describe('LayersControl View', () => {
     const { ready } = setup(<Template />, setMap);
     await waitFor(() => ready);
     await waitFor(() => expect(mapInstance).toBeDefined());
-    console.log(mapInstance)
+
     expect(isLayerVisible('parcelBoundaries', mapInstance)).toBeDefined();
     expect(isLayerVisible('municipalities', mapInstance)).toBeUndefined();
   });

--- a/frontend/src/components/maps/leaflet/LayersControl/LayersControl.test.tsx
+++ b/frontend/src/components/maps/leaflet/LayersControl/LayersControl.test.tsx
@@ -99,6 +99,7 @@ describe('LayersControl View', () => {
     const { ready } = setup(<Template />, setMap);
     await waitFor(() => ready);
     await waitFor(() => expect(mapInstance).toBeDefined());
+    console.log(mapInstance)
     expect(isLayerVisible('parcelBoundaries', mapInstance)).toBeDefined();
     expect(isLayerVisible('municipalities', mapInstance)).toBeUndefined();
   });

--- a/frontend/src/utils/testUtils.tsx
+++ b/frontend/src/utils/testUtils.tsx
@@ -1,7 +1,6 @@
 import { fireEvent } from '@testing-library/react';
-import { Map as LeafletMap } from 'leaflet';
 import { noop } from 'lodash';
-import React, { Ref } from 'react';
+import React from 'react';
 import { MapContainer, useMap } from 'react-leaflet';
 
 /**

--- a/frontend/src/utils/testUtils.tsx
+++ b/frontend/src/utils/testUtils.tsx
@@ -2,7 +2,7 @@ import { fireEvent } from '@testing-library/react';
 import { Map as LeafletMap } from 'leaflet';
 import { noop } from 'lodash';
 import React, { Ref } from 'react';
-import { MapContainer } from 'react-leaflet';
+import { MapContainer, useMap } from 'react-leaflet';
 
 /**
  * Utility type for generic props of component testing
@@ -27,20 +27,21 @@ export function createMapContainer(
   whenCreated: (map: L.Map | null) => void = noop,
 ) {
   return function Container({ children }: PropsWithChildren) {
-    const mapRef = React.useRef<LeafletMap>(null);
+    const MapController = () => {
+      const map = useMap();
+      React.useEffect(() => {
+        whenCreated(map || null);
+        done();
+      }, []);
 
-    React.useEffect(() => {
-      whenCreated(mapRef.current);
-    }, []);
+      return <></>;
+    };
+
     return (
       <div id="mapid" style={{ width: 500, height: 500 }}>
-        <MapContainer
-          center={[48.43, -123.37]}
-          zoom={14}
-          whenReady={done}
-          ref={mapRef as Ref<LeafletMap>}
-        >
+        <MapContainer center={[48.43, -123.37]} zoom={14}>
           {children}
+          <MapController />
         </MapContainer>
       </div>
     );

--- a/frontend/src/utils/testUtils.tsx
+++ b/frontend/src/utils/testUtils.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from '@testing-library/react';
+import { Map as LeafletMap } from 'leaflet';
 import { noop } from 'lodash';
-import React from 'react';
+import React, { Ref } from 'react';
 import { MapContainer } from 'react-leaflet';
 
 /**
@@ -23,16 +24,21 @@ export interface PropsWithChildren {
  */
 export function createMapContainer(
   done: () => void = noop,
-  whenCreated: (map: L.Map) => void = noop,
+  whenCreated: (map: L.Map | null) => void = noop,
 ) {
   return function Container({ children }: PropsWithChildren) {
+    const mapRef = React.useRef<LeafletMap>(null);
+
+    React.useEffect(() => {
+      whenCreated(mapRef.current);
+    }, []);
     return (
       <div id="mapid" style={{ width: 500, height: 500 }}>
         <MapContainer
           center={[48.43, -123.37]}
           zoom={14}
           whenReady={done}
-          whenCreated={whenCreated}
+          ref={mapRef as Ref<LeafletMap>}
         >
           {children}
         </MapContainer>


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-140: ](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-140)

<!-- PROVIDE BELOW an explanation of your changes -->
Updated react-leaflet to version 4.2.1

The parameter `onClose` for popups were removed. Need to use a ref now to track when it closes.
The `whenCreated` parameter was also removed from the Leaflet map, so it also had to be handled with a ref.

Current status:
~One test failing because only sees `mapInstance` as null.~

Test working now. The way to access the inner map has changed, and there isn't a lot of information out there about how to do this now that `whenCreated` is removed. There is a `useMap()` function that seems to work to get the inner map component of `MapContainer`. 
Finally found this here: https://stackoverflow.com/questions/65394203/leaflet-react-get-map-instance-in-functional-component
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
