### PR TITLE
edit-button-hotfix

### DIFF
--- a/frontend/src/features/properties/list/PropertyListView.test.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.test.tsx
@@ -133,7 +133,7 @@ describe('Property list view', () => {
     expect(container.querySelector('span[class="spinner-border"]')).not.toBeInTheDocument();
   });
 
-  it('Displays edit button', async () => {
+  xit('Displays edit button', async () => {
     setupTests();
 
     const { getByTestId } = render(
@@ -147,7 +147,7 @@ describe('Property list view', () => {
     expect(getByTestId('edit-icon')).toBeInTheDocument();
   });
 
-  it('Displays save edit button, when edit is enabled', async () => {
+  xit('Displays save edit button, when edit is enabled', async () => {
     setupTests();
 
     const { getByTestId } = render(
@@ -168,7 +168,7 @@ describe('Property list view', () => {
     });
   });
 
-  it('Displays save edit button, when edit is enabled', async () => {
+  xit('Displays save edit button, when edit is enabled', async () => {
     setupTests();
     const { getByTestId } = render(
       <Provider store={store}>
@@ -188,7 +188,7 @@ describe('Property list view', () => {
     });
   });
 
-  it('Enables edit on property rows that the user has the same agency as the property', async () => {
+  xit('Enables edit on property rows that the user has the same agency as the property', async () => {
     setupTests([{ ...mockFlatProperty }]);
     const { getByTestId, container } = render(
       <Provider store={store}>
@@ -213,7 +213,7 @@ describe('Property list view', () => {
     );
   });
 
-  it('Disables property rows that the user does not have edit permissions for', async () => {
+  xit('Disables property rows that the user does not have edit permissions for', async () => {
     setupTests([{ ...mockFlatProperty, agencyId: 2 }]);
     const { getByTestId, container } = render(
       <Provider store={store}>
@@ -237,7 +237,7 @@ describe('Property list view', () => {
     );
   });
 
-  it('Disables property rows that are in an active project', async () => {
+  xit('Disables property rows that are in an active project', async () => {
     setupTests([{ ...mockFlatProperty, projectNumbers: ['SPP-10000'] }]);
     const { container, getByTestId } = render(
       <Provider store={store}>

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -11,7 +11,8 @@ import * as API from 'constants/API';
 import { ENVIRONMENT } from 'constants/environment';
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { FiscalKeys } from 'constants/fiscalKeys';
-import { Claims, PropertyTypes } from 'constants/index';
+import { PropertyTypes } from 'constants/index';
+// import { Claims, PropertyTypes } from 'constants/index';
 import { Roles } from 'constants/roles';
 import {
   getCurrentFiscal,
@@ -26,7 +27,8 @@ import { useRouterFilter } from 'hooks/useRouterFilter';
 import { fill, intersection, isEmpty, keys, noop, pick, range } from 'lodash';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Button, Container } from 'react-bootstrap';
-import { FaEdit, FaFileExport, FaFolder, FaFolderOpen } from 'react-icons/fa';
+import { FaFileExport, FaFolder, FaFolderOpen } from 'react-icons/fa';
+// import { FaEdit, FaFileExport, FaFolder, FaFolderOpen } from 'react-icons/fa';
 import { FaFileAlt, FaFileExcel } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
@@ -67,17 +69,17 @@ const FileIcon = styled(Button)`
   padding: 6px 5px;
 `;
 
-const EditIconButton = styled(FileIcon)`
-  margin-right: 12px;
-`;
+// const EditIconButton = styled(FileIcon)`
+//   margin-right: 12px;
+// `;
 
-const VerticalDivider = styled.div`
-  border-left: 6px solid rgba(96, 96, 96, 0.2);
-  height: 40px;
-  margin-left: 1%;
-  margin-right: 1%;
-  border-width: 2px;
-`;
+// const VerticalDivider = styled.div`
+//   border-left: 6px solid rgba(96, 96, 96, 0.2);
+//   height: 40px;
+//   margin-left: 1%;
+//   margin-right: 1%;
+//   border-width: 2px;
+// `;
 
 const initialQuery: IPropertyQueryParams = {
   page: 1,
@@ -732,15 +734,16 @@ const PropertyListView: React.FC = () => {
               </FileIcon>
             </TooltipWrapper>
           )}
+          {/*
           <VerticalDivider />
 
-          {!editable && !keycloak.hasClaim(Claims.VIEW_ONLY_PROPERTIES) && (
+           {!editable && !keycloak.hasClaim(Claims.VIEW_ONLY_PROPERTIES) && (
             <TooltipWrapper toolTipId="edit-values" toolTip={'Edit values'}>
               <EditIconButton>
                 <FaEdit data-testid="edit-icon" size={36} onClick={() => setEditable(!editable)} />
               </EditIconButton>
             </TooltipWrapper>
-          )}
+          )} */}
           {editable && (
             <>
               <TooltipWrapper toolTipId="cancel-edited-values" toolTip={'Cancel unsaved edits'}>


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
<!-- PROVIDE BELOW an explanation of your changes -->
As mentioned in Teams chat:

> If you edit a list of buildings from the View Inventory page, any entries that are updated will disassociate their connected land/buildings. 
> 
> I'm going to put in a PR for a temporary fix to hide the edit button on that page, so prod doesn't end up with a bunch of disassociated entries. It doesn't seem to be an issue when editing an individual entry from the sidebar, so users can still use that.
> 
> We can try to diagnose this later, but at first glance it doesn't look straightforward.

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
