### PR TITLE
[PIMS-227] Fix: Buildings disassociating from land

### DIFF
--- a/backend/api/Areas/Property/Controllers/BuildingController.cs
+++ b/backend/api/Areas/Property/Controllers/BuildingController.cs
@@ -123,7 +123,7 @@ namespace Pims.Api.Areas.Property.Controllers
         {
             var entity = _mapper.Map<Entity.Building>(model);
 
-            var updatedEntity = _pimsService.Building.Update(entity);
+            var updatedEntity = _pimsService.Building.UpdateFinancials(entity);
             var building = _mapper.Map<Model.BuildingModel>(updatedEntity);
 
             return new JsonResult(building);

--- a/backend/dal/Services/Concrete/BuildingService.cs
+++ b/backend/dal/Services/Concrete/BuildingService.cs
@@ -381,7 +381,7 @@ namespace Pims.Dal.Services
                 .Include(b => b.Fiscals)
                 .FirstOrDefault(b => b.Id == building.Id) ?? throw new KeyNotFoundException();
             this.ThrowIfNotAllowedToUpdate(existingBuilding, _options.Project);
-            existingBuilding.Classification = building.Classification;
+
             var user = this.Context.Users
                .Include(u => u.Agencies)
                .ThenInclude(a => a.Agency)
@@ -399,6 +399,7 @@ namespace Pims.Dal.Services
             {
                 this.Context.SetOriginalRowVersion(existingBuilding);
                 this.Context.UpdateBuildingFinancials(existingBuilding, building.Evaluations, building.Fiscals);
+                existingBuilding.ClassificationId = building.ClassificationId;
             }
 
             this.Context.SaveChanges();

--- a/backend/tests/unit/api/Controllers/BuildingControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/BuildingControllerTest.cs
@@ -5,6 +5,7 @@ using Pims.Api.Areas.Property.Controllers;
 using Pims.Core.Comparers;
 using Pims.Core.Test;
 using Pims.Dal;
+using Pims.Dal.Entities;
 using Pims.Dal.Entities.Models;
 using Pims.Dal.Security;
 using System;
@@ -76,6 +77,144 @@ namespace Pims.Api.Test.Controllers
             var actualResult = Assert.IsType<Model.BuildingModel>(actionResult.Value);
             Assert.Equal(mapper.Map<Model.BuildingModel>(expectedTestBuilding), actualResult, new DeepPropertyCompare());
             service.Verify(m => m.Building.Get(expectedBuildingId), Times.Once());
+        }
+        #endregion
+
+        #region AddBuilding
+        [Fact]
+        public void AddBuilding_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<BuildingController>(Permissions.PropertyAdd);
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var expectedTestBuilding = EntityHelper.CreateBuilding(parcel, 1, "1234", "name", 50, 50);
+            var user = EntityHelper.CreateUser("Tester");
+            expectedTestBuilding.UpdatedBy = user;
+            expectedTestBuilding.CreatedBy = user;
+
+            // Mocking the .Add method. If passed any type of Building, returns that building.
+            service.Setup(m => m.Building.Add(It.IsAny<Building>())).Returns((Building building) => building);
+
+
+            // Act
+            var building = mapper.Map<Model.BuildingModel>(expectedTestBuilding);
+            var result = controller.AddBuilding(building);
+
+            // Assert
+            var actionResult = Assert.IsType<CreatedAtActionResult>(result);
+            var actualResult = Assert.IsType<Model.BuildingModel>(actionResult.Value);
+            Assert.Equal(building.Name, actualResult.Name);
+            Assert.Equal(building.Id, actualResult.Id);
+            Assert.Equal(building.ProjectNumbers, actualResult.ProjectNumbers, new DeepPropertyCompare());
+            Assert.Equal(building.Latitude, actualResult.Latitude);
+            Assert.Equal(building.Longitude, actualResult.Longitude);
+            Assert.Null(actualResult.Agency);
+        }
+        #endregion
+
+        #region UpdateBuilding
+        [Fact]
+        public void UpdateBuilding_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<BuildingController>(Permissions.PropertyEdit);
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var expectedTestBuilding = EntityHelper.CreateBuilding(parcel, 1, "1", "name", 50, 50);
+
+            // Mocking the .Update method. If passed any type of Building, returns that building.
+            service.Setup(m => m.Building.Update(It.IsAny<Building>())).Returns((Building building) => building);
+
+            // Act
+            var building = mapper.Map<Model.BuildingModel>(expectedTestBuilding);
+
+            var result = controller.UpdateBuilding(1, building);
+
+            // Assert
+            var actionResult = Assert.IsType<JsonResult>(result);
+            var actualResult = Assert.IsType<Model.BuildingModel>(actionResult.Value);
+            Assert.Equal(building.Name, actualResult.Name);
+            Assert.Equal(building.Id, actualResult.Id);
+            Assert.Equal(building.ProjectNumbers, actualResult.ProjectNumbers, new DeepPropertyCompare());
+            Assert.Equal(building.Latitude, actualResult.Latitude);
+            Assert.Equal(building.Longitude, actualResult.Longitude);
+        }
+        #endregion
+
+        #region UpdateBuildingFinancials
+        [Fact]
+        public void UpdateBuildingFinancials_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<BuildingController>(Permissions.PropertyEdit);
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var expectedTestBuilding = EntityHelper.CreateBuilding(parcel, 1, "1", "name", 50, 50);
+            expectedTestBuilding.ClassificationId = 1;
+
+            // Mocking the .UpdateFinancials method. If passed any type of Building, returns that building.
+            service.Setup(m => m.Building.UpdateFinancials(It.IsAny<Building>())).Returns((Building building) => building);
+
+            // Act
+            var building = mapper.Map<Model.BuildingModel>(expectedTestBuilding);
+
+            var result = controller.UpdateBuildingFinancials(1, building);
+
+            // Assert
+            var actionResult = Assert.IsType<JsonResult>(result);
+            var actualResult = Assert.IsType<Model.BuildingModel>(actionResult.Value);
+            Assert.Equal(building.Name, actualResult.Name);
+            Assert.Equal(building.Id, actualResult.Id);
+            Assert.Equal(building.ProjectNumbers, actualResult.ProjectNumbers, new DeepPropertyCompare());
+            Assert.Equal(building.Latitude, actualResult.Latitude);
+            Assert.Equal(building.Longitude, actualResult.Longitude);
+            Assert.Equal(building.ClassificationId, actualResult.ClassificationId);
+        }
+        #endregion
+
+        #region DeleteBuilding
+        [Fact]
+        public void DeleteBuilding_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var controller = helper.CreateController<BuildingController>(Permissions.ProjectDelete);
+
+            var service = helper.GetService<Mock<IPimsService>>();
+            var mapper = helper.GetService<IMapper>();
+
+            var parcel = EntityHelper.CreateParcel(1, 1, 1, 1);
+            var expectedTestBuilding = EntityHelper.CreateBuilding(parcel, 1, "1", "name", 50, 50);
+
+            // Mocking the .Remove method. If passed any type of Building, returns that building.
+            service.Setup(m => m.Building.Remove(It.IsAny<Building>()));
+
+            // Act
+            var building = mapper.Map<Model.BuildingModel>(expectedTestBuilding);
+
+            var result = controller.DeleteBuilding(1, building);
+
+            // Assert
+            // Deletion just returns the original model.
+            var actionResult = Assert.IsType<JsonResult>(result);
+            var actualResult = Assert.IsType<Model.BuildingModel>(actionResult.Value);
+            Assert.Equal(building.Name, actualResult.Name);
+            Assert.Equal(building.Id, actualResult.Id);
+            Assert.Equal(building.ProjectNumbers, actualResult.ProjectNumbers, new DeepPropertyCompare());
+            Assert.Equal(building.Latitude, actualResult.Latitude);
+            Assert.Equal(building.Longitude, actualResult.Longitude);
         }
         #endregion
         #endregion

--- a/backend/tests/unit/api/Routes/Property/BuildingControllerTest.cs
+++ b/backend/tests/unit/api/Routes/Property/BuildingControllerTest.cs
@@ -4,6 +4,8 @@ using Pims.Core.Test;
 using Pims.Dal.Security;
 using System.Diagnostics.CodeAnalysis;
 using Xunit;
+using Model = Pims.Api.Areas.Property.Models.Building;
+
 
 namespace Pims.Api.Test.Routes
 {
@@ -53,6 +55,58 @@ namespace Pims.Api.Test.Routes
             Assert.NotNull(endpoint);
             endpoint.HasGet("{id}");
             endpoint.HasPermissions(Permissions.PropertyView);
+        }
+
+        [Fact]
+        public void AddBuilding_Route()
+        {
+            // Arrange
+            var endpoint = typeof(BuildingController).FindMethod(nameof(BuildingController.AddBuilding), typeof(Model.BuildingModel));
+
+            // Act
+            // Assert
+            Assert.NotNull(endpoint);
+            endpoint.HasPost();
+            endpoint.HasPermissions(Permissions.PropertyAdd);
+        }
+
+        [Fact]
+        public void UpdateBuilding_Route()
+        {
+            // Arrange
+            var endpoint = typeof(BuildingController).FindMethod(nameof(BuildingController.UpdateBuilding), typeof(int), typeof(Model.BuildingModel));
+
+            // Act
+            // Assert
+            Assert.NotNull(endpoint);
+            endpoint.HasPut("{id}");
+            endpoint.HasPermissions(Permissions.PropertyEdit);
+        }
+
+        [Fact]
+        public void UpdateBuildingFinancials_Route()
+        {
+            // Arrange
+            var endpoint = typeof(BuildingController).FindMethod(nameof(BuildingController.UpdateBuildingFinancials), typeof(int), typeof(Model.BuildingModel));
+
+            // Act
+            // Assert
+            Assert.NotNull(endpoint);
+            endpoint.HasPut("{id}/financials");
+            endpoint.HasPermissions(Permissions.PropertyEdit);
+        }
+
+        [Fact]
+        public void DeleteBuilding_Route()
+        {
+            // Arrange
+            var endpoint = typeof(BuildingController).FindMethod(nameof(BuildingController.DeleteBuilding), typeof(int), typeof(Model.BuildingModel));
+
+            // Act
+            // Assert
+            Assert.NotNull(endpoint);
+            endpoint.HasDelete("{id}");
+            endpoint.HasPermissions(Permissions.PropertyDelete);
         }
         #endregion
     }

--- a/frontend/src/features/properties/list/PropertyListView.tsx
+++ b/frontend/src/features/properties/list/PropertyListView.tsx
@@ -11,8 +11,7 @@ import * as API from 'constants/API';
 import { ENVIRONMENT } from 'constants/environment';
 import { EvaluationKeys } from 'constants/evaluationKeys';
 import { FiscalKeys } from 'constants/fiscalKeys';
-import { PropertyTypes } from 'constants/index';
-// import { Claims, PropertyTypes } from 'constants/index';
+import { Claims, PropertyTypes } from 'constants/index';
 import { Roles } from 'constants/roles';
 import {
   getCurrentFiscal,
@@ -27,8 +26,7 @@ import { useRouterFilter } from 'hooks/useRouterFilter';
 import { fill, intersection, isEmpty, keys, noop, pick, range } from 'lodash';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Button, Container } from 'react-bootstrap';
-import { FaFileExport, FaFolder, FaFolderOpen } from 'react-icons/fa';
-// import { FaEdit, FaFileExport, FaFolder, FaFolderOpen } from 'react-icons/fa';
+import { FaEdit, FaFileExport, FaFolder, FaFolderOpen } from 'react-icons/fa';
 import { FaFileAlt, FaFileExcel } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
@@ -69,17 +67,17 @@ const FileIcon = styled(Button)`
   padding: 6px 5px;
 `;
 
-// const EditIconButton = styled(FileIcon)`
-//   margin-right: 12px;
-// `;
+const EditIconButton = styled(FileIcon)`
+  margin-right: 12px;
+`;
 
-// const VerticalDivider = styled.div`
-//   border-left: 6px solid rgba(96, 96, 96, 0.2);
-//   height: 40px;
-//   margin-left: 1%;
-//   margin-right: 1%;
-//   border-width: 2px;
-// `;
+const VerticalDivider = styled.div`
+  border-left: 6px solid rgba(96, 96, 96, 0.2);
+  height: 40px;
+  margin-left: 1%;
+  margin-right: 1%;
+  border-width: 2px;
+`;
 
 const initialQuery: IPropertyQueryParams = {
   page: 1,
@@ -325,6 +323,7 @@ const PropertyListView: React.FC = () => {
 
   // We'll start our table without any data
   const [data, setData] = useState<IProperty[] | undefined>();
+
   // For getting the buildings on parcel folder click
   const [expandData, setExpandData] = useState<any>({});
 
@@ -734,16 +733,16 @@ const PropertyListView: React.FC = () => {
               </FileIcon>
             </TooltipWrapper>
           )}
-          {/*
+
           <VerticalDivider />
 
-           {!editable && !keycloak.hasClaim(Claims.VIEW_ONLY_PROPERTIES) && (
+          {!editable && !keycloak.hasClaim(Claims.VIEW_ONLY_PROPERTIES) && (
             <TooltipWrapper toolTipId="edit-values" toolTip={'Edit values'}>
               <EditIconButton>
                 <FaEdit data-testid="edit-icon" size={36} onClick={() => setEditable(!editable)} />
               </EditIconButton>
             </TooltipWrapper>
-          )} */}
+          )}
           {editable && (
             <>
               <TooltipWrapper toolTipId="cancel-edited-values" toolTip={'Cancel unsaved edits'}>

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -198,7 +198,6 @@ export const useApi = (props?: IApiProps): PimsAPI => {
       `${ENVIRONMENT.apiUrl}/properties/buildings/${id}/financials`,
       { ...building, totalArea: building.landArea, buildingTenancy: building.buildingTenancy },
     );
-    console.log('Tenancy:' + building.buildingTenancy);
     return data;
   }, []);
 


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-227: ](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-227)

<!-- PROVIDE BELOW an explanation of your changes -->
Issue:
When updating buildings from the View Inventory page, it was causing some fields, including associated land parcels, to be cleared or reset to default values. 
This was because that information is never loaded on the page and was therefore sent back to the API without it, which interpreted it as intentionally removed.

Changes:
- The route for updating financials was restored to only update the financials.
- Added an assignment to update the `ClassificationId` and removed the attempted update to `Classification`. `ClassificationId` is the foreign key and should be updated instead.
- Restored the edit button.

Testing instructions:
1. Identify a building with associated land. 
2. Go to the View Inventory page and edit that building, then save your edits.
3. Ensure the building still has associated land and has saved the new classification.

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
