### PR TITLE
[PIMS-158] Axios request failed error

### DIFF
--- a/frontend/src/features/projects/common/hooks/useStepForm.test.tsx
+++ b/frontend/src/features/projects/common/hooks/useStepForm.test.tsx
@@ -1,0 +1,94 @@
+import useStepForm from 'features/projects/common/hooks/useStepForm';
+import { IProject } from 'features/projects/interfaces';
+import { FormikValues } from 'formik';
+import React from 'react';
+
+// Setup Mocks
+jest.mock('store', () => ({
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn().mockReturnValue(undefined),
+}));
+
+jest.mock('store/slices/hooks', () => ({
+  useNetworkStore: () => ({
+    clearRequest: jest.fn(),
+  }),
+}));
+
+jest.mock('hooks/useKeycloakWrapper', () =>
+  jest.fn().mockReturnValue(() => ({
+    hasRole: jest.fn().mockReturnValue(true),
+    hasAgency: jest.fn().mockReturnValue(true),
+    hasClaim: jest.fn().mockReturnValue(true),
+  })),
+);
+
+// Need these to fail for now. Re-mock if you need resolved promises
+jest.mock('..', () => ({
+  // createProject is a function that returns another function that returns a promise
+  createProject: jest.fn().mockReturnValue(
+    () =>
+      new Promise((resolve, reject) => {
+        reject({
+          response: {
+            data: {
+              error: 'Test error',
+            },
+          },
+        });
+      }),
+  ),
+  updateProject: jest.fn().mockReturnValue(
+    () =>
+      new Promise((resolve, reject) => {
+        reject({
+          response: {
+            data: {
+              error: 'Test error',
+            },
+          },
+        });
+      }),
+  ),
+}));
+
+const formikRef: React.MutableRefObject<FormikValues | undefined> = {
+  current: {
+    setStatus: jest.fn(),
+  },
+};
+
+const project: IProject = {
+  projectNumber: '',
+  name: '',
+  description: '',
+  fiscalYear: 2023,
+  properties: [],
+  projectAgencyResponses: [],
+  note: '',
+  notes: [],
+  publicNote: '',
+  privateNote: '',
+  agencyId: 1,
+  statusId: 0,
+  tierLevelId: 0,
+  tasks: [],
+  statusHistory: [],
+};
+
+describe('Testing useStepForm Functions', () => {
+  it('addOrUpdateProject throws axios error when axios fails', async () => {
+    const { addOrUpdateProject } = useStepForm();
+    try {
+      await addOrUpdateProject(project, formikRef);
+      expect(false).toBeTruthy(); // Fail if the above doesn't throw
+    } catch (e: unknown) {
+      expect((e as { message: string }).message).toBe('Axios request failed: Test error');
+    }
+
+    // Not sure why this doesn't work for this test. Above isn't optimal, but still tests Error.
+    // expect(async () => {
+    //   await addOrUpdateProject(project, formikRef);
+    // }).toThrowError();
+  });
+});

--- a/frontend/src/features/projects/common/hooks/useStepForm.tsx
+++ b/frontend/src/features/projects/common/hooks/useStepForm.tsx
@@ -107,7 +107,7 @@ const useStepForm = () => {
       .catch((error: AxiosError<any>) => {
         const msg: string = error?.response?.data?.error ?? error.toString();
         formikRef?.current?.setStatus({ msg });
-        throw Error('axios request failed');
+        throw Error(`Axios request failed: ${msg}`);
       })
       .finally(() => {
         network.clearRequest(ProjectActions.UPDATE_PROJECT);


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-158: ](https://citz-imb.atlassian.net/browse/PIMS-158?atlOrigin=eyJpIjoiZDdhOWRmNGY1ZTg2NGFiZjg5YmViYzk3N2JlNGVjOTMiLCJwIjoiaiJ9)

<!-- PROVIDE BELOW an explanation of your changes -->
I believe the original issue was caused by lack of permissions (local keycloak roles). Not an issue with the proper roles assigned. This is only an issue that will appear in local.

Decided to add additional feedback to the error message though.
Can test this by removing your Keycloak role (keep a minimal one) and trying to navigate through a step form, like Disposals. 

Original error:
![image](https://github.com/bcgov/PIMS/assets/37922247/403b72cb-4879-4fc8-a639-50d7e06fc3e8)


Example of updated error:
![image](https://github.com/bcgov/PIMS/assets/37922247/90c83828-7ace-412c-ad0a-cdd5aa82eb9c)

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
