### PR TITLE
HOTFIX: Ensure map takes full height when sidebar is out

### DIFF
--- a/frontend/src/features/properties/map/MapView.scss
+++ b/frontend/src/features/properties/map/MapView.scss
@@ -51,6 +51,7 @@ $narrowSidebarSize: 700px;
   }
 }
 .side-bar {
+  height: 100%;
   .map-side-drawer {
     margin-left: 0px;
     .scroll {


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  


<!-- PROVIDE BELOW an explanation of your changes -->
The map didn't take up 100% of the height if you navigated there from View Inventory by clicking on a property. 
The .side-bar class didn't have a height property.
Height set to 100%.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
