### PR TITLE
PIMS-351: Update @babel/traverse sub-dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,7 +154,8 @@
     "fork-ts-checker-webpack-plugin@<6.5.3": "6.5.3",
     "nth-check@<2.0.1": "2.0.1",
     "css-whatt@<5.0.1": "5.0.1",
-    "semver": "7.5.2"
+    "semver": "7.5.2",
+    "@babel/traverse@<7.23.2": "7.23.2"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-351: ](https://citz-imb.atlassian.net/browse/PIMS-351?atlOrigin=eyJpIjoiOGFjNGJhZDhiOTU2NGY1OGE1OTMyOGIwNTA4ZThiZTciLCJwIjoiaiJ9)

<!-- PROVIDE BELOW an explanation of your changes -->
Update @babel/traverse sub-dependency. This is mostly by `babel`, but also by `react-scripts` and `jest` somewhat. 
Any dependency trying to use a version less than 7.23.2 will now use 7.23.2 instead.

Tests appear to run fine. Builds with no errors. Navigated the site and didn't notice anything unusual.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
