### PR TITLE
PIMS-35/36 Fix Jest Test Warnings

### DIFF
--- a/frontend/src/components/Table/ColumnFilter.test.tsx
+++ b/frontend/src/components/Table/ColumnFilter.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ColumnFilter from 'components/Table/ColumnFilter';
 import { ColumnInstanceWithProps } from 'components/Table/types';
@@ -9,7 +9,7 @@ describe('Testing ColumnFilter.tsx', () => {
   const useFormikContextMock = jest.spyOn(Formik, 'useFormikContext');
   const reactMock = jest.spyOn(React, 'useState');
   const setState = jest.fn();
-  screen.debug(undefined, Infinity);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   beforeEach(() => {
     useFormikContextMock.mockReturnValue({
       values: {

--- a/frontend/src/components/common/form/FastDatePicker.test.tsx
+++ b/frontend/src/components/common/form/FastDatePicker.test.tsx
@@ -27,6 +27,7 @@ const testRender = (props?: any, formikProps?: any) =>
   );
 
 describe('fast date picker old date functionality', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   beforeAll(() => {
     (global as any).IS_REACT_ACT_ENVIRONMENT = false;
   });

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -35,9 +35,6 @@ const Header = () => {
 
   const [errors, setErrors] = React.useState<IGenericNetworkAction[]>([]);
 
-  if (location.pathname === '/') {
-    navigate('/mapview', { replace: true });
-  }
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
@@ -48,6 +45,12 @@ const Header = () => {
 
   const isNetworkError = (x: any): x is IGenericNetworkAction =>
     (x as IGenericNetworkAction).type === 'ERROR';
+
+  React.useEffect(() => {
+    if (location.pathname === '/') {
+      navigate('/mapview', { replace: true });
+    }
+  }, []);
 
   React.useEffect(() => {
     const errors: IGenericNetworkAction[] = Object.values(requests)

--- a/frontend/src/features/admin/access/ManageAccessRequests.test.tsx
+++ b/frontend/src/features/admin/access/ManageAccessRequests.test.tsx
@@ -54,7 +54,7 @@ const accessRequests = {
 Enzyme.configure({ adapter: new Adapter() });
 
 const history = createMemoryHistory();
-history.push('admin');
+history.push('/admin');
 const mockStore = configureMockStore([thunk]);
 
 const lCodes = {

--- a/frontend/src/features/admin/agencies/ManageAgencies.test.tsx
+++ b/frontend/src/features/admin/agencies/ManageAgencies.test.tsx
@@ -27,7 +27,7 @@ jest.mock('hooks/useKeycloakWrapper');
 );
 
 const history = createMemoryHistory();
-history.push('admin/agencies');
+history.push('/admin/agencies');
 const mockStore = configureMockStore([thunk]);
 
 const lCodes = {
@@ -70,6 +70,7 @@ const getStore = () =>
           },
         ],
       },
+      rowsPerPage: 10,
     },
     [reducerTypes.LOOKUP_CODE]: lCodes,
     [reducerTypes.NETWORK]: {

--- a/frontend/src/features/admin/users/ManageUsers.test.tsx
+++ b/frontend/src/features/admin/users/ManageUsers.test.tsx
@@ -32,7 +32,7 @@ jest.mock('hooks/useKeycloakWrapper');
 );
 
 const history = createMemoryHistory();
-history.push('admin');
+history.push('/admin');
 const mockStore = configureMockStore([thunk]);
 
 const lCodes = {

--- a/frontend/src/features/help/forms/BugForm.test.tsx
+++ b/frontend/src/features/help/forms/BugForm.test.tsx
@@ -3,6 +3,7 @@ import BugForm from 'features/help/forms/BugForm';
 import React from 'react';
 
 describe('Testing BugForm.tsx', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   it('Form renders with all expected text', () => {
     const { getByText } = render(
       <BugForm

--- a/frontend/src/features/help/forms/FeatureRequestForm.test.tsx
+++ b/frontend/src/features/help/forms/FeatureRequestForm.test.tsx
@@ -3,6 +3,7 @@ import FeatureRequestForm from 'features/help/forms/FeatureRequestForm';
 import React from 'react';
 
 describe('Testing FeatureRequestForm.tsx', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   it('Form renders with all expected text', () => {
     const { getByText } = render(
       <FeatureRequestForm

--- a/frontend/src/features/help/forms/QuestionForm.test.tsx
+++ b/frontend/src/features/help/forms/QuestionForm.test.tsx
@@ -3,6 +3,7 @@ import QuestionForm from 'features/help/forms/QuestionForm';
 import React from 'react';
 
 describe('Testing BugForm.tsx', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   it('Form renders with all expected text', () => {
     const { getByText } = render(
       <QuestionForm

--- a/frontend/src/features/mapSideBar/SidebarContents/BuildingForm.test.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/BuildingForm.test.tsx
@@ -74,6 +74,9 @@ const buildingForm = (
 );
 
 describe('Building Form', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+
   it('component renders correctly', () => {
     const { container } = render(buildingForm);
     expect(container.firstChild).toMatchSnapshot();

--- a/frontend/src/features/mapSideBar/SidebarContents/LandForm.test.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/LandForm.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ILookupCode } from 'actions/ILookupCode';
 import { IParcel } from 'actions/parcelsActions';
+import { ISteppedFormValues } from 'components/common/form/StepForm';
 import * as API from 'constants/API';
 import Claims from 'constants/claims';
 import { Classifications } from 'constants/classifications';
+import { valuesToApiFormat } from 'features/mapSideBar/SidebarContents/LandForm';
 import { createMemoryHistory } from 'history';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import noop from 'lodash/noop';
@@ -16,8 +18,6 @@ import useKeycloakMock from 'useKeycloakWrapperMock';
 import { fillInput } from 'utils/testUtils';
 
 import { LandForm } from '.';
-import { valuesToApiFormat } from 'features/mapSideBar/SidebarContents/LandForm';
-import { ISteppedFormValues } from 'components/common/form/StepForm';
 
 const mockStore = configureMockStore([thunk]);
 const history = createMemoryHistory();
@@ -131,6 +131,9 @@ const getLandForm = (disabled?: boolean, initialValues?: IParcel) => (
 );
 
 describe('Land Form', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+
   it('component renders correctly', () => {
     const { container } = render(getLandForm());
     expect(container.firstChild).toMatchSnapshot();

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/AssociatedLandReviewPage.test.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/AssociatedLandReviewPage.test.tsx
@@ -30,6 +30,7 @@ const getElement = (disabled: boolean) => {
 };
 
 describe('AssociatedLandReviewPage', () => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
   const { container, getByText } = render(getElement(false));
   it('renders correctly', () => {
     expect(container.firstChild).toMatchSnapshot();

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/LandSearchForm.test.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/LandSearchForm.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { ILookupCode } from 'actions/ILookupCode';
+import { IParcel } from 'actions/parcelsActions';
 import * as API from 'constants/API';
 import Claims from 'constants/claims';
+import LandForm from 'features/mapSideBar/SidebarContents/LandForm';
 import { createMemoryHistory } from 'history';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import noop from 'lodash/noop';
@@ -11,10 +14,6 @@ import { MemoryRouter } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import useKeycloakMock from 'useKeycloakWrapperMock';
-
-import LandForm from 'features/mapSideBar/SidebarContents/LandForm';
-import { IParcel } from 'actions/parcelsActions';
-import { userEvent } from '@testing-library/user-event';
 
 const mockStore = configureMockStore([thunk]);
 const history = createMemoryHistory();
@@ -103,6 +102,9 @@ const getLandForm = (disabled?: boolean, initialValues?: IParcel) => (
 );
 
 describe('Land Form', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+
   it('component renders correctly', () => {
     const { container } = render(getLandForm());
     expect(container.firstChild).toMatchSnapshot();

--- a/frontend/src/features/mapSideBar/components/tabs/BuildingDetails.tsx
+++ b/frontend/src/features/mapSideBar/components/tabs/BuildingDetails.tsx
@@ -36,6 +36,11 @@ interface IBuildingDetailsProps {
   setEditInfo: Dispatch<SetStateAction<object>>;
 }
 
+const StyledProjectNumbers = styled.div`
+  flex-direction: column;
+  display: flex;
+`;
+
 /**
  * @description For buildings, displays building details
  * @param {IBuildingDetailsProps} props
@@ -72,10 +77,6 @@ export const BuildingDetails: React.FC<any> = (props: IBuildingDetailsProps) => 
   const rightColumnStyle: CSSProperties = { display: 'flex', justifyContent: 'left' };
   const fieldFontWeight = 600;
   const fieldFontSize = 'small';
-  const StyledProjectNumbers = styled.div`
-    flex-direction: column;
-    display: flex;
-  `;
 
   return (
     <div className="identification">

--- a/frontend/src/features/mapSideBar/components/tabs/ParcelDetails.tsx
+++ b/frontend/src/features/mapSideBar/components/tabs/ParcelDetails.tsx
@@ -32,6 +32,11 @@ interface IParcelDetailsProps {
   index?: number;
 }
 
+const StyledProjectNumbers = styled.div`
+  flex-direction: column;
+  display: flex;
+`;
+
 /**
  * @description For parcels, shows details with parcel information.
  * @param {IParcelDetailsProps} props
@@ -48,10 +53,6 @@ export const ParcelDetails: React.FC<any> = (props: IParcelDetailsProps) => {
   // Style Constants
   const { leftColumnWidth, rightColumnWidth, boldFontWeight, fontSize, headerColour } = tabStyles;
   const rightColumnStyle: CSSProperties = { display: 'flex', justifyContent: 'left' };
-  const StyledProjectNumbers = styled.div`
-    flex-direction: column;
-    display: flex;
-  `;
 
   // Address form:
   const lookupCodes = useAppSelector((store) => store.lookupCode.lookupCodes);

--- a/frontend/src/features/projects/assess/steps/ReviewApproveStep.test.tsx
+++ b/frontend/src/features/projects/assess/steps/ReviewApproveStep.test.tsx
@@ -204,6 +204,8 @@ const getReviewApproveStep = (storeOverride?: any) => (
 );
 
 describe('Review Approve Step', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/frontend/src/features/projects/common/forms/UpdateInfoForm.test.tsx
+++ b/frontend/src/features/projects/common/forms/UpdateInfoForm.test.tsx
@@ -23,6 +23,7 @@ const userRoles: string[] | Claims[] = [];
 const userAgencies: number[] = [1];
 const userAgency: number = 1;
 
+jest.spyOn(console, 'error').mockImplementation(() => {});
 jest.mock('hooks/useKeycloakWrapper');
 (useKeycloakWrapper as jest.Mock).mockReturnValue(
   new (useKeycloakMock as any)(userRoles, userAgencies, userAgency),

--- a/frontend/src/features/projects/dispose/ProjectDisposeView.test.tsx
+++ b/frontend/src/features/projects/dispose/ProjectDisposeView.test.tsx
@@ -84,6 +84,7 @@ const renderElement = (store: any) => (
 );
 
 describe('Project Dispose View', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   afterEach(() => {
     cleanup();
     jest.clearAllMocks();

--- a/frontend/src/features/projects/dispose/hooks/useStepper.test.tsx
+++ b/frontend/src/features/projects/dispose/hooks/useStepper.test.tsx
@@ -34,6 +34,7 @@ const store = mockStore({
 });
 
 describe('useStepper hook functionality', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   beforeAll(() => {
     renderHook(() => useStepper(), {
       wrapper: ({ children }: { children: any }) => (

--- a/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.test.tsx
+++ b/frontend/src/features/projects/dispose/steps/SelectProjectPropertiesStep.test.tsx
@@ -41,6 +41,8 @@ const store = mockStore({
   },
 });
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 const uiElement = (
   <Provider store={store}>
     <MemoryRouter initialEntries={[history.location]}>

--- a/frontend/src/features/routes/LayoutWrapper.test.tsx
+++ b/frontend/src/features/routes/LayoutWrapper.test.tsx
@@ -4,7 +4,6 @@ import { LayoutWrapper } from 'features/routes';
 import { createMemoryHistory } from 'history';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import useKeycloakMock from 'useKeycloakWrapperMock';
@@ -31,11 +30,10 @@ describe('Layout Wrapper', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     act(() => {
-      ReactDOM.render(
+      render(
         <MemoryRouter initialEntries={[history.location]}>
           <LayoutWrapper component={() => <p>Title Test Page</p>} title={title} />
         </MemoryRouter>,
-        container,
       );
     });
 

--- a/frontend/src/utils/KeycloakEventHandler.test.ts
+++ b/frontend/src/utils/KeycloakEventHandler.test.ts
@@ -18,6 +18,10 @@ const dispatchSpy = jest.spyOn(store, 'dispatch');
 const saveJwtSpy = jest.spyOn(jwtSlice, 'saveJwt');
 const clearJwtSpy = jest.spyOn(jwtSlice, 'clearJwt');
 const setKeycloakReadySpy = jest.spyOn(keycloakReadySlice, 'setKeycloakReady');
+// Mock console functions to avoid large amounts of printouts in tests
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'debug').mockImplementation(() => {});
+jest.spyOn(console, 'group').mockImplementation(() => {});
 
 const keycloak = {
   subject: 'test',


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-35: ](https://citz-imb.atlassian.net/browse/PIMS-35?atlOrigin=eyJpIjoiYWVkYTZiNDFjNjFmNDRhYjkyOTVjMWI5NmUyZWMxNGUiLCJwIjoiaiJ9)Resolve react-paginate warnings in jest tests
[PIMS-36: ](https://citz-imb.atlassian.net/browse/PIMS-36?atlOrigin=eyJpIjoiMDM2YzU1NWIxZWRiNGNhY2I2YjRlMWNhZmMwYzkwOTUiLCJwIjoiaiJ9)Resolve "relative pathnames are not supported in memory history" in jest tests

<!-- PROVIDE BELOW an explanation of your changes -->
Started with fixing the issues mentioned in the above tickets:

- Paginate warnings were caused by react-paginate not liking when -1 is used as the starting page, but that's what the table pagination does. 
- Relative pathnames just needed a `/` before paths to make them correct. 

Added fixes:
- Updated a ReactDOM.render to a render from the testing-library
- Move a navigate to within a useEffect hook
- Move two styled components outside of components

There were a lot of errors that were more like complaints from libraries we are using, but they are specific to the tests and how they lack some overarching structures like Formik. 
If these issues didn't need to be fixed or if I couldn't fix them but they didn't affect tests, I mocked the console reporting to suppress all the warn and error outputs. This shouldn't be used to hide legitimate errors, but I think in this testing environment it's an acceptable compromise.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
