### PR TITLE
PIMS-336 Surplus Properties Popup Styling

### DIFF
--- a/frontend/src/components/SearchBar/FindMorePropertiesForm.scss
+++ b/frontend/src/components/SearchBar/FindMorePropertiesForm.scss
@@ -1,0 +1,74 @@
+@import '../../colors.scss';
+
+#find-more-properties {
+  width: 52em;
+  .form-section {
+    margin: 1em 0;
+    padding: 0.5em;
+    background-color: $table-header-color;
+    border-radius: 5px;
+    .form-row,
+    .form-row-centred {
+      display: flex;
+      justify-content: left;
+      align-items: center;
+      padding: 0 5%;
+      .form-label {
+        margin: 0.5em;
+        width: fit-content;
+        text-align: right;
+      }
+      .form-control.number-input {
+        width: 6em;
+      }
+      .form-control.building-select {
+        width: 15em;
+      }
+      .form-control.project-number-input {
+        width: 10em;
+      }
+
+      .location-label-col {
+        width: 5em;
+      }
+      .location-col {
+        width: 17.8em;
+      }
+      .lot-size-col {
+        .form-label {
+          width: 4em;
+          text-align: left;
+        }
+      }
+      .lot-size-max-col {
+        width: 8.8em;
+      }
+    }
+    .form-row-centred {
+      justify-content: center;
+    }
+  }
+
+  .invalid-feedback-container {
+    width: 100%;
+    display: flex;
+    flex-direction: row-reverse;
+    text-align: center;
+    .invalid-feedback {
+      display: block;
+    }
+  }
+  .search-button {
+    width: 100%;
+    margin: 0.5em 0;
+  }
+  .vertical-line {
+    border-left: 10px solid rgba(96, 96, 96, 0.2);
+    height: 1.5rem;
+    border-width: 2px;
+  }
+
+  .no-padding {
+    padding: 0;
+  }
+}

--- a/frontend/src/components/SearchBar/FindMorePropertiesForm.test.tsx
+++ b/frontend/src/components/SearchBar/FindMorePropertiesForm.test.tsx
@@ -1,4 +1,5 @@
 import Adapter from '@cfaester/enzyme-adapter-react-18';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { ILookupCode } from 'actions/ILookupCode';
 import FindMorePropertiesForm from 'components/SearchBar/FindMorePropertiesForm';
 import * as API from 'constants/API';
@@ -27,6 +28,8 @@ jest.mock('hooks/useKeycloakWrapper');
 jest.mock('formik');
 Enzyme.configure({ adapter: new Adapter() });
 
+const handleSubmit = jest.fn();
+
 (useFormikContext as jest.Mock).mockReturnValue({
   values: {
     classificationId: 0,
@@ -34,6 +37,7 @@ Enzyme.configure({ adapter: new Adapter() });
   },
   registerField: jest.fn(),
   unregisterField: jest.fn(),
+  handleSubmit: handleSubmit,
 });
 (getIn as jest.Mock).mockReturnValue(0);
 
@@ -66,16 +70,27 @@ const store = mockStore({
   lookupCode: lCodes,
 });
 
-it('limited fast select renders correctly', () => {
-  // const context = useFormikContext();
-  const tree = renderer
-    .create(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[history.location]}>
-          <FindMorePropertiesForm />
-        </MemoryRouter>
-      </Provider>,
-    )
-    .toJSON();
-  expect(tree).toMatchSnapshot();
+const RenderHelper = () => (
+  <Provider store={store}>
+    <MemoryRouter initialEntries={[history.location]}>
+      <FindMorePropertiesForm />
+    </MemoryRouter>
+  </Provider>
+);
+
+describe('Testing FindMorePropertiesForm', () => {
+  it('Snapshot Test', () => {
+    const tree = renderer.create(<RenderHelper />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('handleSubmit function called', () => {
+    const { container } = render(<RenderHelper />);
+    const searchButton = container.querySelector('.search-button');
+    waitFor(() => {
+      fireEvent.click(searchButton!);
+    });
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/components/SearchBar/FindMorePropertiesForm.test.tsx
+++ b/frontend/src/components/SearchBar/FindMorePropertiesForm.test.tsx
@@ -1,0 +1,81 @@
+import Adapter from '@cfaester/enzyme-adapter-react-18';
+import { ILookupCode } from 'actions/ILookupCode';
+import FindMorePropertiesForm from 'components/SearchBar/FindMorePropertiesForm';
+import * as API from 'constants/API';
+import Claims from 'constants/claims';
+import Enzyme from 'enzyme';
+import { getIn, useFormikContext } from 'formik';
+import { createMemoryHistory } from 'history';
+import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import renderer from 'react-test-renderer';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import useKeycloakMock from 'useKeycloakWrapperMock';
+
+const userRoles: string[] | Claims[] = [];
+const userAgencies: number[] = [1];
+const userAgency: number = 1;
+
+jest.mock('hooks/useKeycloakWrapper');
+(useKeycloakWrapper as jest.Mock).mockReturnValue(
+  new (useKeycloakMock as any)(userRoles, userAgencies, userAgency),
+);
+
+jest.mock('formik');
+Enzyme.configure({ adapter: new Adapter() });
+
+(useFormikContext as jest.Mock).mockReturnValue({
+  values: {
+    classificationId: 0,
+    classification: 'zero',
+  },
+  registerField: jest.fn(),
+  unregisterField: jest.fn(),
+});
+(getIn as jest.Mock).mockReturnValue(0);
+
+const mockStore = configureMockStore([thunk]);
+const history = createMemoryHistory();
+
+const lCodes = {
+  lookupCodes: [
+    { name: 'agencyVal', id: '1', isDisabled: false, type: API.AGENCY_CODE_SET_NAME },
+    { name: 'disabledAgency', id: '2', isDisabled: true, type: API.AGENCY_CODE_SET_NAME },
+  ] as ILookupCode[],
+};
+
+const selectedUser = {
+  username: 'tester',
+  firstName: 'firstName',
+  lastName: 'lastName',
+  email: 'test@test.com',
+  isDisabled: false,
+  emailVerified: false,
+  agencies: [1],
+  roles: [],
+  rowVersion: 'AAAAAAAAB9E=',
+  note: 'test note',
+  lastLogin: '2023-02-28T17:45:39.7381599',
+};
+
+const store = mockStore({
+  users: { user: selectedUser },
+  lookupCode: lCodes,
+});
+
+it('limited fast select renders correctly', () => {
+  // const context = useFormikContext();
+  const tree = renderer
+    .create(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[history.location]}>
+          <FindMorePropertiesForm />
+        </MemoryRouter>
+      </Provider>,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/components/SearchBar/FindMorePropertiesForm.tsx
+++ b/frontend/src/components/SearchBar/FindMorePropertiesForm.tsx
@@ -1,77 +1,24 @@
-import variables from '_variables.module.scss';
+import './FindMorePropertiesForm.scss';
+
 import { Button, Check, DisplayError, Input, Select } from 'components/common/form';
 import { TypeaheadField } from 'components/common/form/Typeahead';
 import * as API from 'constants/API';
 import { getIn, useFormikContext } from 'formik';
 import useCodeLookups from 'hooks/useLookupCodes';
-import React, { useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { Col, Container, Form, Row } from 'react-bootstrap';
-import styled from 'styled-components';
 import { mapLookupCode } from 'utils';
 
-const StyledRow = styled(Row)`
-  .form-group {
-    display: flex;
-    .form-label {
-      margin-top: 0.5rem;
-      margin-right: 10px;
-      width: 150px;
-      text-align: right;
-    }
-  }
-`;
-
-/** input used to display small number values in this form */
-const NumberInput = styled((props: any) => <Input {...props} />)`
-  width: 86px;
-`;
-
-/** controlling the width of the select component used in this form */
-const StyledSelect = styled((props: any) => <Select {...props} />)`
-  width: 250px;
-`;
-
-/** bar seperator for the inputs */
-const VerticalLine = styled.span`
-  border-left: 10px solid rgba(96, 96, 96, 0.2);
-  height: 40px;
-  margin-left: 20px;
-  border-width: 2px;
-`;
-
-/** styled component used for project number */
-const ProjectNumber = styled((props: any) => <Input {...props} />)`
-  width: 129px;
-  margin-right: 10px;
-`;
-
-/** styled container with grey background to contain form contents */
-const FormSection = styled((props: any) => <Container {...props} />)`
-  margin-top: 20px;
-  background-color: ${variables.tableHeaderColor};
-  border-radius: 5px;
-`;
-
-const SearchButton = styled((props: any) => <Button {...props} />)`
-  margin-top: 10px;
-`;
-
-const StyledLocation = styled((props: any) => <TypeaheadField {...props} />)`
-  width: 250px;
-  margin-left: 60px;
-`;
+/** bar separator for the inputs */
+const VerticalLine = () => <span className="vertical-line" />;
 
 /** the area where invalid feedback or ERP/SPL selection will be displayed */
-const InvalidFeedback = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: row-reverse;
-  margin: 0.5rem 0;
-  text-align: center;
-  .invalid-feedback {
-    display: block;
-  }
-`;
+interface IChildProps {
+  children: ReactElement;
+}
+const InvalidFeedback = ({ children }: IChildProps) => (
+  <div className="invalid-feedback-container">{children}</div>
+);
 
 /** This form is triggered by the FindMorePropertiesButton and contains additional filter fields for the PropertiesFilter */
 const FindMorePropertiesForm = () => {
@@ -101,7 +48,7 @@ const FindMorePropertiesForm = () => {
   }, []);
 
   return (
-    <>
+    <div id="find-more-properties">
       <p>
         Search for properties within the Enhanced Referral Process (ERP) or Surplus Property List
         (SPL)
@@ -117,14 +64,14 @@ const FindMorePropertiesForm = () => {
           RealPropertyDivision.Disposals@gov.bc.ca
         </a>
       </p>
-      <FormSection>
+      <Container className="form-section">
         {displayError && (
           <InvalidFeedback>
             <DisplayError errorPrompt field="inSurplusPropertyProgram" />
           </InvalidFeedback>
         )}
 
-        <StyledRow style={{ marginLeft: 160, paddingTop: 20, paddingBottom: '10px' }}>
+        <Row className="form-row form-row-centred">
           <Col md="auto">
             <Check label="ERP Properties" field="inEnhancedReferralProcess" />
           </Col>
@@ -134,18 +81,18 @@ const FindMorePropertiesForm = () => {
           <Col md="auto">
             <Check label="SPL Properties" field="inSurplusPropertyProgram" />
           </Col>
-        </StyledRow>
-      </FormSection>
-      <FormSection>
-        <Row style={{ marginLeft: 5, paddingTop: 10 }}>
-          <h6>Search by</h6>
         </Row>
-        <StyledRow style={{ marginLeft: 20, paddingBottom: '20px', alignItems: 'center' }}>
-          <Col md={1} style={{ marginRight: '-25px' }}>
-            <Form.Label style={{ marginTop: '.5rem' }}>Location</Form.Label>
+      </Container>
+      <Container className="form-section">
+        <Row>
+          <h6>Search By</h6>
+        </Row>
+        <Row className="form-row">
+          <Col md="auto" className="location-label-col">
+            <Form.Label>Location</Form.Label>
           </Col>
-          <Col md="auto" style={{ marginRight: '-25px' }}>
-            <StyledLocation
+          <Col md="auto" className="location-col">
+            <TypeaheadField
               name="administrativeArea"
               placeholder="Enter a location"
               paginate={false}
@@ -162,63 +109,72 @@ const FindMorePropertiesForm = () => {
             <VerticalLine />
           </Col>
           <Col md="auto">
-            <ProjectNumber field="projectNumber" label="Project number" placeholder="SPP #" />
+            <Input
+              field="projectNumber"
+              label="Project Number"
+              placeholder="SPP #"
+              className="project-number-input"
+            />
           </Col>
-        </StyledRow>
-      </FormSection>
-      <FormSection>
-        <Row style={{ marginLeft: 5, paddingTop: 10 }}>
-          <h6>Land search criteria</h6>
         </Row>
-        <StyledRow style={{ marginLeft: 20, paddingBottom: '20px', alignItems: 'center' }}>
-          <Col md="auto">
-            <NumberInput label="Lot size" field="minLotSize" placeholder="min" />
+      </Container>
+      <Container className="form-section">
+        <Row>
+          <h6>Land Search Criteria</h6>
+        </Row>
+        <Row className="form-row">
+          <Col md="auto" className="lot-size-col">
+            <Input label="Lot Size" field="minLotSize" placeholder="min" className="number-input" />
           </Col>
-          <Col md="auto">
-            <span style={{ marginTop: 5, marginLeft: 5, marginRight: 5 }}>-</span>
+          <Col md="auto" className="no-padding">
+            <span>-</span>
           </Col>
-          <Col md="auto">
-            <NumberInput field="maxLotSize" placeholder="max" />
+          <Col md="auto" className="lot-size-max-col">
+            <Input field="maxLotSize" placeholder="max" className="number-input" />
           </Col>
           <Col md="auto">
             <VerticalLine />
           </Col>
           <Col md="auto">
-            <Check label="Land only" field="bareLandOnly" />
+            <Check label="Land Only" field="bareLandOnly" />
           </Col>
-        </StyledRow>
-      </FormSection>
-      <FormSection>
-        <Row style={{ marginLeft: 5, paddingTop: 10 }}>
-          <h6>Building search criteria</h6>
         </Row>
-        <StyledRow style={{ marginLeft: 20, paddingBottom: '20px', alignItems: 'center' }}>
-          <Col md={7} style={{ marginRight: '-35px' }}>
-            <StyledSelect
+      </Container>
+      <Container className="form-section">
+        <Row>
+          <h6>Building Search Criteria</h6>
+        </Row>
+        <Row className="form-row">
+          <Col md="auto">
+            <Select
+              className="building-select"
               field="predominateUseId"
               placeholder="Any"
               options={predominateUses}
-              label="Predominate use"
+              label="Predominate Use"
             />
           </Col>
           <Col md="auto">
             <VerticalLine />
           </Col>
           <Col md="auto">
-            <NumberInput label="Net usable area" field="rentableArea" />
+            <Input label="Net Usable Area" field="rentableArea" className="number-input" />
           </Col>
-        </StyledRow>
-      </FormSection>
+        </Row>
+      </Container>
       <Row>
-        <SearchButton
-          onClick={() => {
-            handleSearch();
-          }}
-        >
-          Search
-        </SearchButton>
+        <Col xs={12}>
+          <Button
+            className="search-button"
+            onClick={() => {
+              handleSearch();
+            }}
+          >
+            Search
+          </Button>
+        </Col>
       </Row>
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/components/SearchBar/__snapshots__/FindMorePropertiesForm.test.tsx.snap
+++ b/frontend/src/components/SearchBar/__snapshots__/FindMorePropertiesForm.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`limited fast select renders correctly 1`] = `
+exports[`Testing FindMorePropertiesForm Snapshot Test 1`] = `
 <div
   id="find-more-properties"
 >

--- a/frontend/src/components/SearchBar/__snapshots__/FindMorePropertiesForm.test.tsx.snap
+++ b/frontend/src/components/SearchBar/__snapshots__/FindMorePropertiesForm.test.tsx.snap
@@ -1,0 +1,481 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`limited fast select renders correctly 1`] = `
+<div
+  id="find-more-properties"
+>
+  <p>
+    Search for properties within the Enhanced Referral Process (ERP) or Surplus Property List (SPL)
+  </p>
+  <p>
+    <strong>
+      Note: 
+    </strong>
+     The search results will
+    <strong>
+       only include properties in projects that have been identified as Tier 2, 3, or 4
+    </strong>
+    <br />
+     in the disposal process. For properties included in Tier 1, please contact
+    <em>
+       Strategic Real Estate Services
+    </em>
+     at
+    <br />
+    <a
+      href="mailto:RealPropertyDivision.Disposals@gov.bc.ca"
+    >
+      RealPropertyDivision.Disposals@gov.bc.ca
+    </a>
+  </p>
+  <div
+    className="form-section container"
+  >
+    <div
+      className="form-row form-row-centred row"
+    >
+      <div
+        className="col-md-auto"
+      >
+        <div
+          className=""
+        >
+          <div
+            className="check-field"
+          >
+            <label
+              className="form-label"
+              htmlFor="input-inEnhancedReferralProcess"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+            >
+              ERP Properties
+            </label>
+            <div
+              className=""
+            >
+              <input
+                checked={false}
+                className="form-check-input"
+                disabled={false}
+                id="input-inEnhancedReferralProcess"
+                name="inEnhancedReferralProcess"
+                onChange={[Function]}
+                type="checkbox"
+                value="false"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-md-auto"
+      >
+        <span
+          className="vertical-line"
+        />
+      </div>
+      <div
+        className="col-md-auto"
+      >
+        <div
+          className=""
+        >
+          <div
+            className="check-field"
+          >
+            <label
+              className="form-label"
+              htmlFor="input-inSurplusPropertyProgram"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+            >
+              SPL Properties
+            </label>
+            <div
+              className=""
+            >
+              <input
+                checked={false}
+                className="form-check-input"
+                disabled={false}
+                id="input-inSurplusPropertyProgram"
+                name="inSurplusPropertyProgram"
+                onChange={[Function]}
+                type="checkbox"
+                value="false"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="form-section container"
+  >
+    <div
+      className="row"
+    >
+      <h6>
+        Search By
+      </h6>
+    </div>
+    <div
+      className="form-row row"
+    >
+      <div
+        className="location-label-col col-md-auto"
+      >
+        <label
+          className="form-label"
+        >
+          Location
+        </label>
+      </div>
+      <div
+        className="location-col col-md-auto"
+      >
+        <div
+          className=""
+        >
+          <div
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <div
+              className="rbt"
+              style={
+                Object {
+                  "outline": "none",
+                  "position": "relative",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "flex": 1,
+                    "height": "100%",
+                    "position": "relative",
+                  }
+                }
+              >
+                <input
+                  aria-autocomplete="both"
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
+                  autoComplete="off"
+                  className="rbt-input-main form-control rbt-input"
+                  id="administrativeArea-field"
+                  name="administrativeArea"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Enter a location"
+                  role="combobox"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                  type="text"
+                  value=""
+                />
+                <input
+                  aria-hidden={true}
+                  className="rbt-input-hint"
+                  readOnly={true}
+                  style={
+                    Object {
+                      "backgroundColor": "transparent",
+                      "borderColor": "transparent",
+                      "boxShadow": "none",
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "left": 0,
+                      "pointerEvents": "none",
+                      "position": "absolute",
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                  tabIndex={-1}
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-md-auto"
+      >
+        <span
+          className="vertical-line"
+        />
+      </div>
+      <div
+        className="col-md-auto"
+      >
+        <div
+          className="input-flex"
+          id="input-projectNumber"
+        >
+          <label
+            className="form-label"
+          >
+            Project Number
+          </label>
+          <div
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <input
+              className="project-number-input form-control"
+              name="projectNumber"
+              onBlur={[Function]}
+              placeholder="SPP #"
+              value={0}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="form-section container"
+  >
+    <div
+      className="row"
+    >
+      <h6>
+        Land Search Criteria
+      </h6>
+    </div>
+    <div
+      className="form-row row"
+    >
+      <div
+        className="lot-size-col col-md-auto"
+      >
+        <div
+          className="input-flex"
+          id="input-minLotSize"
+        >
+          <label
+            className="form-label"
+          >
+            Lot Size
+          </label>
+          <div
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <input
+              className="number-input form-control"
+              name="minLotSize"
+              onBlur={[Function]}
+              placeholder="min"
+              value={0}
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="no-padding col-md-auto"
+      >
+        <span>
+          -
+        </span>
+      </div>
+      <div
+        className="lot-size-max-col col-md-auto"
+      >
+        <div
+          className="input-flex"
+          id="input-maxLotSize"
+        >
+          <div
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <input
+              className="number-input form-control"
+              name="maxLotSize"
+              onBlur={[Function]}
+              placeholder="max"
+              value={0}
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-md-auto"
+      >
+        <span
+          className="vertical-line"
+        />
+      </div>
+      <div
+        className="col-md-auto"
+      >
+        <div
+          className=""
+        >
+          <div
+            className="check-field"
+          >
+            <label
+              className="form-label"
+              htmlFor="input-bareLandOnly"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+            >
+              Land Only
+            </label>
+            <div
+              className=""
+            >
+              <input
+                checked={false}
+                className="form-check-input"
+                disabled={false}
+                id="input-bareLandOnly"
+                name="bareLandOnly"
+                onChange={[Function]}
+                type="checkbox"
+                value="false"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="form-section container"
+  >
+    <div
+      className="row"
+    >
+      <h6>
+        Building Search Criteria
+      </h6>
+    </div>
+    <div
+      className="form-row row"
+    >
+      <div
+        className="col-md-auto"
+      >
+        <div
+          className="select-row row"
+          controlid="input-predominateUseId"
+        >
+          <div
+            className="col-md-auto"
+          >
+            <label
+              className="form-label"
+            >
+              Predominate Use
+            </label>
+          </div>
+          <div
+            className="select-column col-md-auto"
+          >
+            <select
+              className="building-select form-select form-control"
+              name="predominateUseId"
+              onBlur={[Function]}
+              onChange={[Function]}
+              value={0}
+            >
+              <option
+                value=""
+              >
+                Any
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-md-auto"
+      >
+        <span
+          className="vertical-line"
+        />
+      </div>
+      <div
+        className="col-md-auto"
+      >
+        <div
+          className="input-flex"
+          id="input-rentableArea"
+        >
+          <label
+            className="form-label"
+          >
+            Net Usable Area
+          </label>
+          <div
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <input
+              className="number-input form-control"
+              name="rentableArea"
+              onBlur={[Function]}
+              value={0}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="col-12"
+    >
+      <button
+        className="Button search-button btn btn-primary"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        <div
+          className="Button__value"
+        >
+          Search
+        </div>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/features/admin/users/components/UsersFilterBar.scss
+++ b/frontend/src/features/admin/users/components/UsersFilterBar.scss
@@ -5,13 +5,13 @@
     max-width: 180px !important;
     margin: 0 !important;
   }
+  .select-row {
+    margin-left: 0.1em;
+  }
 }
 .parent-select {
   height: 40px;
 }
 .filter-bar-icon {
   max-width: 50px;
-}
-.select-row {
-  margin-left: 0.1em;
 }


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-336](https://citz-imb.atlassian.net/browse/PIMS-336?atlOrigin=eyJpIjoiOWQ3MDFmZDY0MDFmNGQwYWIwNDk4Yzk5YTRhYmU4MTQiLCJwIjoiaiJ9)

<!-- PROVIDE BELOW an explanation of your changes -->
Converted the styled-components in this file to scss. Adjusted styling for a more uniform look.

Had to scope a class from UsersFilterBar.scss. It would apply to the styles on the Surplus Properties popup if a user navigated to the Users page and back.

![image](https://github.com/bcgov/PIMS/assets/37922247/c08d4dbe-4c8a-493d-abaf-100aab38a75e)

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
