### PR TITLE
TES-795 Update script to add connection to epic

### DIFF
--- a/.github/helpers/jira-api/create_tickets.py
+++ b/.github/helpers/jira-api/create_tickets.py
@@ -36,7 +36,8 @@ def get_env_variables():
         dep_in,         # List of Dependencies to be updated.
         jira_api_key,   # Authorization token for Jira.
         project_key,    # Project board to post to.
-        jira_subtask    # Subtask type for specific board.
+        jira_subtask,   # Subtask type for specific board.
+        jira_epic       # Epic custom field id to link parent ticket to.
       ): tuple containing the above information pulled in from environment variables. 
     """
 
@@ -73,7 +74,12 @@ def get_env_variables():
     except KeyError:
         sys.exit( "Unable to get Jira Subtask number. " )
 
-    return ( level_flags, dep_in, jira_api_key, project_key, jira_subtask )
+    try:
+        jira_epic = os.environ["JIRA_EPIC"]
+    except KeyError:
+        sys.exit( "Unable to get Epic ID environment variable." )
+
+    return ( level_flags, dep_in, jira_api_key, project_key, jira_subtask, jira_epic )
 
 def refine_dep( level_flags, dep_in, summary_li ):
     """
@@ -123,7 +129,7 @@ def post_subtasks( conn, headers, subtask_lists ):
     for ele in json_major: 
         jira_con.post_subtasks( conn, headers, ele )
 
-def create_tickets( conn, headers, updates, project_key, issue_key ):
+def create_tickets( conn, headers, updates, project_key, issue_key, epic_id ):
     """
     This function captures the work necessary for creating, finalization, and posting tickets. 
 
@@ -132,6 +138,7 @@ def create_tickets( conn, headers, updates, project_key, issue_key ):
       headers (string): specifies authentication to post to JIRA
       updates (tuple(list)): a tuple of lists holding the dependency updates
       project_key (string): a string representing the key for the board we want to post to
+      epic_id: (id, key): a tuple containing epic id and ticket number we want to post under
 
     Returns:
       subtask_json (list[JSON], list[JSON], list[JSON]): a tuple containing 3 lists of json objects. 
@@ -140,7 +147,7 @@ def create_tickets( conn, headers, updates, project_key, issue_key ):
     # check the number of tickets to post
     updates = refine_tickets.check_num_tickets( updates )
     # create parent ticket and post it
-    parent_ticket_json = refine_tickets.create_parent_ticket( project_key, updates )
+    parent_ticket_json = refine_tickets.create_parent_ticket( project_key, updates, epic_id )
     parent_key = jira_con.post_parent_ticket( conn, headers, parent_ticket_json )
     # create sub tasks in Json format
     subtask_json = refine_tickets.create_tickets( updates, project_key, parent_key, issue_key )
@@ -150,7 +157,7 @@ def create_tickets( conn, headers, updates, project_key, issue_key ):
 def main():
     """ Works through the steps to refine dependency list and then create tickets in JIRA. """
 
-    level_flags, dep_in, jira_api_key, project_key, issue_key = get_env_variables()
+    level_flags, dep_in, jira_api_key, project_key, issue_key, epic_id = get_env_variables()
 
     # establish https connection and necessary variables
     conn = http.client.HTTPSConnection( "citz-imb.atlassian.net" )
@@ -166,7 +173,7 @@ def main():
     updates = refine_dep( level_flags, dep_in, summary_li )
 
     # create all tickets
-    json_lists = create_tickets( conn, headers, updates, project_key, issue_key )
+    json_lists = create_tickets( conn, headers, updates, project_key, issue_key, epic_id )
 
     # Post all tickets
     post_subtasks( conn, headers, json_lists )

--- a/.github/helpers/jira-api/create_tickets.py
+++ b/.github/helpers/jira-api/create_tickets.py
@@ -77,7 +77,7 @@ def get_env_variables():
     # check for epic id and key and seperate it into a tuple
     try:
         jira_epic = os.environ["JIRA_EPIC"]
-        jira_epic = jira_epic.str.split(", ")
+        jira_epic = jira_epic.split(", ")
     except KeyError:
         sys.exit( "Unable to get Epic ID environment variable." )
 

--- a/.github/helpers/jira-api/create_tickets.py
+++ b/.github/helpers/jira-api/create_tickets.py
@@ -37,7 +37,7 @@ def get_env_variables():
         jira_api_key,   # Authorization token for Jira.
         project_key,    # Project board to post to.
         jira_subtask,   # Subtask type for specific board.
-        jira_epic       # Epic custom field id to link parent ticket to.
+        jira_epic       # Epic custom field id and parent ticket to link to.
       ): tuple containing the above information pulled in from environment variables. 
     """
 
@@ -74,8 +74,10 @@ def get_env_variables():
     except KeyError:
         sys.exit( "Unable to get Jira Subtask number. " )
 
+    # check for epic id and key and seperate it into a tuple
     try:
         jira_epic = os.environ["JIRA_EPIC"]
+        jira_epic = jira_epic.str.split(", ")
     except KeyError:
         sys.exit( "Unable to get Epic ID environment variable." )
 

--- a/.github/helpers/jira-api/jira_con.py
+++ b/.github/helpers/jira-api/jira_con.py
@@ -123,9 +123,6 @@ def post_parent_ticket(conn, headers, parent_ticket):
         error_message = message + status + ": " + reason + "\n" + data
         raise error.APIError( error_message )
 
-    #REMOVE BEFORE MERGE
-    print(data)
-
     readable_data = json.loads( data )
     # get the key from the response and return it
     parent_key = readable_data["key"]

--- a/.github/helpers/jira-api/jira_con.py
+++ b/.github/helpers/jira-api/jira_con.py
@@ -123,6 +123,9 @@ def post_parent_ticket(conn, headers, parent_ticket):
         error_message = message + status + ": " + reason + "\n" + data
         raise error.APIError( error_message )
 
+    #REMOVE BEFORE MERGE
+    print(data)
+
     readable_data = json.loads( data )
     # get the key from the response and return it
     parent_key = readable_data["key"]

--- a/.github/helpers/jira-api/refine_tickets.py
+++ b/.github/helpers/jira-api/refine_tickets.py
@@ -111,7 +111,7 @@ def create_parent_ticket( project_key, updates, epic_id ):
             "priority": {
                 "name": "Medium"
             },
-            "customfield_10014": "PIMS-450",
+            "customfield_" + epic_id[0]: epic_id[1],
             "labels": [
                 "DependencyUpdates"
             ]

--- a/.github/helpers/jira-api/refine_tickets.py
+++ b/.github/helpers/jira-api/refine_tickets.py
@@ -111,14 +111,12 @@ def create_parent_ticket( project_key, updates, epic_id ):
             "priority": {
                 "name": "Medium"
             },
-            "customfield_" + epic_id[0]: epic_id[1],
+            "customfield_10014": "PIMS-450",
             "labels": [
                 "DependencyUpdates"
             ]
         }
     })
-    # REMOVE BEFORE MERGE
-    print("customfield_" + epic_id[0] + ":" + epic_id[1])
     return parent_ticket
 
 def create_subtasks( version, update_list, parent_key, project_key, jira_subtask ):

--- a/.github/helpers/jira-api/refine_tickets.py
+++ b/.github/helpers/jira-api/refine_tickets.py
@@ -62,13 +62,14 @@ def get_length(in_li):
 
     return len_in_li
 
-def create_parent_ticket( project_key, updates ):
+def create_parent_ticket( project_key, updates, epic_id ):
     """
     POST API to create a parent ticket on the specified board
 
     Args:
       project_key (string): defines project key of JIRA board we want to post to
       updates (tuple(lists)): tuple of the three update lists
+      epic_id (id, key): tuple containing field id and issue number of epic we want to post under
 
     Returns:
       parent_key (string): captures json object holding parent ticket request.
@@ -110,6 +111,7 @@ def create_parent_ticket( project_key, updates ):
             "priority": {
                 "name": "Medium"
             },
+            "customfield_" + epic_id[0]: epic_id[1],
             "labels": [
                 "DependencyUpdates"
             ]

--- a/.github/helpers/jira-api/refine_tickets.py
+++ b/.github/helpers/jira-api/refine_tickets.py
@@ -117,7 +117,8 @@ def create_parent_ticket( project_key, updates, epic_id ):
             ]
         }
     })
-
+    # REMOVE BEFORE MERGE
+    print("customfield_" + epic_id[0] + ":" + epic_id[1])
     return parent_ticket
 
 def create_subtasks( version, update_list, parent_key, project_key, jira_subtask ):

--- a/.github/workflows/app-npm-dep-check.yml
+++ b/.github/workflows/app-npm-dep-check.yml
@@ -121,7 +121,7 @@ jobs:
           LEVEL_FLAGS: "MINOR MAJOR" # used to determine what updates to post
           JIRA_BOARD: "PIMS" # sets what JIRA board to post and pull from
           JIRA_SUBTASK: "10003" # each Jira board has a different issue type for subtasks
-          JIRA_EPIC: ("10014", "PIMS-450)" # epic links are technically a custom field with this specific id and ticket number (for PIMS)
+          JIRA_EPIC: "10014, PIMS-450" # epic links are technically a custom field with this specific id and ticket number (for PIMS)
           JIRA_API_KEY: ${{ secrets.JIRA_API_KEY }} # key used to access JIRA API
           ISSUE_BODY: ${{ env.ISSUE_BODY }} # dependency update list
         run: |

--- a/.github/workflows/app-npm-dep-check.yml
+++ b/.github/workflows/app-npm-dep-check.yml
@@ -121,6 +121,7 @@ jobs:
           LEVEL_FLAGS: "MINOR MAJOR" # used to determine what updates to post
           JIRA_BOARD: "PIMS" # sets what JIRA board to post and pull from
           JIRA_SUBTASK: "10003" # each Jira board has a different issue type for subtasks
+          JIRA_EPIC: ("10014", "PIMS-450)" # epic links are technically a custom field with this specific id and ticket number (for PIMS)
           JIRA_API_KEY: ${{ secrets.JIRA_API_KEY }} # key used to access JIRA API
           ISSUE_BODY: ${{ env.ISSUE_BODY }} # dependency update list
         run: |


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[TES-795: ](https://citz-imb.atlassian.net/browse/TES-795)

<!-- PROVIDE BELOW an explanation of your changes -->
Adding link to epic for parent task
<!-- PROVIDE ABOVE an explanation of your changes -->

## Testing
1. go to the [Actions](https://github.com/bcgov/PIMS/actions) tab for the PIMS repo 
2. on the left menu select "[App NPM Dependency Updates](https://github.com/bcgov/PIMS/actions/workflows/app-npm-dep-check.yml)"
3. select the dropdown menu labeled "Run Workflow"
4. select the dropdown menu labeled "Branch: main"
5. select this branch: "TES-795-add-epic-field"
6. then select the green button labeled "Run workflow"
7. wait for all jobs to accomplish
8. check the backlog of [PIMS Jira board](https://citz-imb.atlassian.net/jira/software/c/projects/PIMS/boards/26/backlog)
9. There should be a new ticket labeled "Dependency Updates - <todays date>" that is linked to the Epic "NPM Dependency Updates"

NOTE 

- I deleted one ticket from the past run but left the rest of the old tickets in the backlog so that the script would run faster for testing. The ticket created now should contain at least one ticket for updating vite 
    - (there may be more updates by the time we test this". 
- Sub tasks can not be associated to Epics this way so we can only connect the parent ticket to the Epic

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
