### PR TITLE
PIMS-405 Add Logging to Express API

### DIFF
--- a/express-api/.eslintrc.cjs
+++ b/express-api/.eslintrc.cjs
@@ -20,6 +20,7 @@ module.exports = {
     'no-extra-boolean-cast': 'off',
     'no-unsafe-optional-chaining': 'off',
     'no-prototype-builtins': 'off',
+    'no-console': 'error',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-inferrable-types': 'off', // ie. const val: number = 4;
     '@typescript-eslint/no-empty-function': 'off', // ie. {}

--- a/express-api/constants/switches.ts
+++ b/express-api/constants/switches.ts
@@ -1,5 +1,5 @@
-const { TESTING } = process.env;
+const { NODE_ENV } = process.env;
 
 export default {
-  TESTING: `${TESTING}`.toLowerCase() === 'true', // Can be used to disable certain features
+  TESTING: NODE_ENV === 'test', // Can be used to disable certain features when testing
 };

--- a/express-api/express.ts
+++ b/express-api/express.ts
@@ -5,7 +5,7 @@ import compression from 'compression';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
 import router from './routes';
-import headerHandler from './middleware/headerHandler';
+import middleware from './middleware';
 import constants from './constants';
 
 const app: Application = express();
@@ -33,13 +33,18 @@ const corsOptions = {
 // Incoming CORS Filter
 app.use(cors(corsOptions));
 
-// Express middleware
+// Express Middleware
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(compression());
 
-// TODO: Add logger here
+// Get Custom Middleware
+const { headerHandler, morganMiddleware } = middleware;
+
+// Logging Middleware
+app.use(morganMiddleware);
+
 // TODO: Add Swagger here
 
 // Set headers for response

--- a/express-api/express.ts
+++ b/express-api/express.ts
@@ -13,7 +13,7 @@ const app: Application = express();
 const { TESTING, FRONTEND_URL } = constants;
 
 // Express Rate Limiter Configuration
-const limiter = rateLimit({
+export const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 1000, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
   standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers

--- a/express-api/jest.config.ts
+++ b/express-api/jest.config.ts
@@ -28,6 +28,9 @@ const jestConfig: JestConfigWithTsJest = {
       lines: 80,
       statements: 80,
     },
+    'express.ts': {
+      branches: 0, // Because rate limiter is omitted when testing
+    },
   },
   randomize: true, // Randomizes order of tests,
 };

--- a/express-api/jest.config.ts
+++ b/express-api/jest.config.ts
@@ -1,4 +1,4 @@
-import type { JestConfigWithTsJest } from 'ts-jest'
+import type { JestConfigWithTsJest } from 'ts-jest';
 
 const jestConfig: JestConfigWithTsJest = {
   testEnvironment: 'node',
@@ -15,6 +15,7 @@ const jestConfig: JestConfigWithTsJest = {
   collectCoverageFrom: [
     'controllers/**/*.ts',
     'middleware/**/*.ts',
+    'utilities/**/*.ts',
     'routes/**/*.ts',
     'express.ts',
   ],
@@ -28,7 +29,7 @@ const jestConfig: JestConfigWithTsJest = {
       statements: 80,
     },
   },
-  randomize: true, // Randomizes order of tests
-}
+  randomize: true, // Randomizes order of tests,
+};
 
 export default jestConfig;

--- a/express-api/middleware/index.ts
+++ b/express-api/middleware/index.ts
@@ -1,5 +1,7 @@
 import headerHandler from './headerHandler';
+import morganMiddleware from './morganHttpLogging';
 
 export default {
   headerHandler,
+  morganMiddleware,
 };

--- a/express-api/middleware/morganHttpLogging.ts
+++ b/express-api/middleware/morganHttpLogging.ts
@@ -11,7 +11,7 @@ const morganMiddleware = morgan(':method :url :status :response-time', {
     // Configure Morgan to use our custom logger with the http severity
     write: (message) => {
       const trimmedMessage = message.trim(); // Because there's a \n at the end.
-      // Break message from into parts for JSON
+      // Break message from morgan into parts for JSON
       const method = trimmedMessage.split(' ').at(0);
       const route = trimmedMessage.split(' ').at(1);
       const status = +trimmedMessage.split(' ').at(2);

--- a/express-api/middleware/morganHttpLogging.ts
+++ b/express-api/middleware/morganHttpLogging.ts
@@ -1,0 +1,31 @@
+import morgan from 'morgan';
+import logger from '../utilities/winstonLogger';
+
+/**
+ * Middleware function that configures Morgan to use a custom logger with the http severity.
+ * It takes a message as input, trims it, and then splits it into parts to create a JSON object.
+ * Finally, it uses the winston logger to log the HTTP call.
+ */
+const morganMiddleware = morgan(':method :url :status :response-time', {
+  stream: {
+    // Configure Morgan to use our custom logger with the http severity
+    write: (message) => {
+      const trimmedMessage = message.trim(); // Because there's a \n at the end.
+      // Break message from into parts for JSON
+      const method = trimmedMessage.split(' ').at(0);
+      const route = trimmedMessage.split(' ').at(1);
+      const status = +trimmedMessage.split(' ').at(2);
+      const responseTime = +trimmedMessage.split(' ').at(3);
+      const morganJSON = {
+        method,
+        route,
+        status,
+        responseTimeMs: responseTime,
+      };
+      // Use the winston logger to log http call
+      logger.http(morganJSON);
+    },
+  },
+});
+
+export default morganMiddleware;

--- a/express-api/package.json
+++ b/express-api/package.json
@@ -25,7 +25,9 @@
     "cors": "2.8.5",
     "dotenv": "16.3.1",
     "express": "4.18.2",
-    "express-rate-limit": "7.1.1"
+    "express-rate-limit": "7.1.1",
+    "morgan": "1.10.0",
+    "winston": "3.11.0"
   },
   "devDependencies": {
     "@types/compression": "1.7.4",
@@ -33,6 +35,7 @@
     "@types/cors": "2.8.15",
     "@types/express": "4.17.20",
     "@types/jest": "29.5.10",
+    "@types/morgan": "1.9.9",
     "@types/node": "20.8.7",
     "@types/supertest": "2.0.16",
     "@typescript-eslint/eslint-plugin": "6.12.0",

--- a/express-api/server.ts
+++ b/express-api/server.ts
@@ -1,9 +1,10 @@
+import logger from './utilities/winstonLogger';
 import constants from './constants';
 import app from './express';
 
 const { API_PORT } = constants;
 
 app.listen(API_PORT, (err?: Error) => {
-  if (err) console.log(err);
-  console.info(`Server started on port ${API_PORT}.`);
+  if (err) logger.error(err);
+  logger.info(`Server started on port ${API_PORT}.`);
 });

--- a/express-api/tests/integration/express/express.test.ts
+++ b/express-api/tests/integration/express/express.test.ts
@@ -1,0 +1,13 @@
+import app, { limiter } from '../../../express';
+import supertest from 'supertest';
+
+const request = supertest(app);
+
+describe('INTEGRATION - Express', () => {
+  const appSpy = jest.spyOn(app, 'use');
+
+  it('should not use the rate limiter when testing', async () => {
+    await request.get('/api/v2/health');
+    expect(appSpy).not.toHaveBeenCalledWith(limiter);
+  });
+});

--- a/express-api/tests/unit/utilities/winstonLogger.test.ts
+++ b/express-api/tests/unit/utilities/winstonLogger.test.ts
@@ -1,0 +1,8 @@
+import logger from '../../../utilities/winstonLogger';
+
+describe('UNIT - winston logger', () => {
+  it('should be created with the expected settings', () => {
+    expect(logger.level).toBe('http');
+    expect(logger.transports).toHaveLength(1); // Only Console
+  });
+});

--- a/express-api/tsconfig.json
+++ b/express-api/tsconfig.json
@@ -6,11 +6,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
+    "outDir": "dist"
   },
   "include": ["./**/*"]
 }

--- a/express-api/utilities/winstonLogger.ts
+++ b/express-api/utilities/winstonLogger.ts
@@ -1,0 +1,25 @@
+import { format, createLogger, transports } from 'winston';
+
+const { timestamp, combine, json } = format;
+
+/**
+ * Creates a logger object that can be called to generate log messages.
+ * Log messages are formatted as JSON.
+ * @returns {Logger} A Logger instance from winston.
+ * @example
+ * logger.info("Here's some info!");
+ * logger.warn("Here's a warning!");
+ * logger.error("Here's an error!");
+ */
+const logger = createLogger({
+  level: 'http', // Defines a custom level
+  format: combine(
+    timestamp({
+      format: 'YYYY-MM-DD hh:mm:ss.SSS A',
+    }),
+    json(),
+  ),
+  transports: [new transports.Console()],
+});
+
+export default logger;

--- a/express-api/utilities/winstonLogger.ts
+++ b/express-api/utilities/winstonLogger.ts
@@ -1,6 +1,8 @@
 import { format, createLogger, transports } from 'winston';
+import constants from '../constants';
 
 const { timestamp, combine, json } = format;
+const { TESTING } = constants;
 
 /**
  * Creates a logger object that can be called to generate log messages.
@@ -20,6 +22,7 @@ const logger = createLogger({
     json(),
   ),
   transports: [new transports.Console()],
+  silent: TESTING,
 });
 
 export default logger;


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-405](https://citz-imb.atlassian.net/browse/PIMS-405?atlOrigin=eyJpIjoiMzYwNDQ0MmE4NDBmNDUzOGExNzU0NTMxNDQ4NWRhZTMiLCJwIjoiaiJ9)

<!-- PROVIDE BELOW an explanation of your changes -->
Decided to use both `morgan` and `winston` because they excel at different areas. `morgan` works with Express natively to get the details of http requests, which I don't see `winston` doing nicely. `winston` gives better output with more configurations, can replace console.log statements, and will be easier to eventually send to a service like Kibana if desired.

## Changes
- Added `morgan` and `winston` logging packages.
- Created middleware that takes `morgan` http logs and uses `winston` to log as JSON to the console
- Switched the source of the TESTING env. It is now dependant on the NODE_ENV, which is automatically `test` when running Jest tests. This will prevent the rate limiter and the logging from happening during tests.
- Added a no console.log rule to ESLint. You can still use them for local debugging, but final code should use the logger if there's a need to print something to console or log it.

Logger can be used like this:
``` ts
logger.info("Here's some info!");
logger.warn("Here's a warning!");
logger.error("Here's an error!");
```
There are other logger functions as well, although these should cover most situations.

Log output looks like this:
<img width="1037" alt="image" src="https://github.com/bcgov/PIMS/assets/37922247/77e076a1-d5f8-4870-b919-c927be5eed89">

There was one line I couldn't get coverage on, because the NODE_ENV is `test` while the tests run, but that line only runs when not testing. I had to lower the branches test threshold in order to pass. This is something we might have to review later unless anyone wants to try and get coverage on that line.

## Testing
1. Stop the .NET API if it's running.
2. In `express-api`, run `npm test` to see that tests pass.
3. Start the API with `npm run dev`.
4. Use a tool like Postman or Thunderclient to send a GET request to localhost:5000/api/v2/health, and observe the console for a log message.

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
