### PR TITLE
PIMS-530: Error when trying to approve access requests

### DIFF
--- a/backend/dal/Services/Admin/Concrete/UserService.cs
+++ b/backend/dal/Services/Admin/Concrete/UserService.cs
@@ -400,12 +400,14 @@ namespace Pims.Dal.Services.Admin
             // Keycloak Gold only wants the clientID as a number, which is always at the end of the id, after a "-"
             string frontendId = this.configuration["Keycloak:FrontendClientId"].Split("-").Last();
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, $"https://api.loginproxy.gov.bc.ca/api/v1/{getEnv()}/{idp}/users?email={email}");
+            _logger.LogDebug($"Test Logging the request for username to Keycloak '{request}'");
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             HttpResponseMessage response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode) throw new Exception("Unable to get user's username from Keycloak Gold");
             string payload = await response.Content.ReadAsStringAsync();
 
             JsonDocument json = JsonDocument.Parse(payload);
+            _logger.LogDebug($"Test Logging the response for username from Keycloak '{json.RootElement.ToString()}'");
             string username = json.RootElement.GetProperty("data").EnumerateArray().First().GetProperty("username").GetString();
 
             return username;

--- a/backend/dal/Services/Admin/Concrete/UserService.cs
+++ b/backend/dal/Services/Admin/Concrete/UserService.cs
@@ -28,6 +28,8 @@ namespace Pims.Dal.Services.Admin
         private IConfiguration configuration;
         #region Variables
         private string access_token = "";
+
+        private readonly ILogger<UserService> _logger;
         #endregion
 
         #region Constructors
@@ -38,7 +40,11 @@ namespace Pims.Dal.Services.Admin
         /// <param name="user"></param>
         /// <param name="service"></param>
         /// <param name="logger"></param>
-        public UserService(PimsContext dbContext, ClaimsPrincipal user, IPimsService service, ILogger<UserService> logger, IConfiguration configuration) : base(dbContext, user, service, logger) { this.configuration = configuration; }
+        public UserService(PimsContext dbContext, ClaimsPrincipal user, IPimsService service, ILogger<UserService> logger, IConfiguration configuration) : base(dbContext, user, service, logger)
+        {
+            this.configuration = configuration;
+            _logger = logger;
+        }
         #endregion
 
         #region Methods
@@ -335,13 +341,17 @@ namespace Pims.Dal.Services.Admin
             // Keycloak Gold only wants the clientID as a number, which is always at the end of the id, after a "-"
             string frontendId = this.configuration["Keycloak:FrontendClientId"].Split("-").Last();
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, this.configuration["Keycloak:BaseURL"] + $"integrations/{frontendId}/{getEnv()}/users/{preferred_username}/roles");
+            _logger.LogDebug($"Test Logging the request to Keycloak '{request}'");
+
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             HttpResponseMessage response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode) throw new Exception("Unable to fetch roles from Keycloak Gold");
             string payload = await response.Content.ReadAsStringAsync();
             JsonDocument json = JsonDocument.Parse(payload);
 
+            _logger.LogDebug($"Test Logging the response from Keycloak '{json.ToString()}'");
             IEnumerable<string> roles = json.RootElement.GetProperty("data").EnumerateArray().Select(r => r.GetProperty("name").GetString());
+            _logger.LogDebug($"Test Logging the Keycloak roles: '{roles}'");
 
             return roles;
         }

--- a/backend/dal/Services/Admin/Concrete/UserService.cs
+++ b/backend/dal/Services/Admin/Concrete/UserService.cs
@@ -349,9 +349,9 @@ namespace Pims.Dal.Services.Admin
             string payload = await response.Content.ReadAsStringAsync();
             JsonDocument json = JsonDocument.Parse(payload);
 
-            _logger.LogDebug($"Test Logging the response from Keycloak '{json.ToString()}'");
+            _logger.LogDebug($"Test Logging the response from Keycloak '{json.RootElement.ToString()}'");
             IEnumerable<string> roles = json.RootElement.GetProperty("data").EnumerateArray().Select(r => r.GetProperty("name").GetString());
-            _logger.LogDebug($"Test Logging the Keycloak roles: '{roles}'");
+            _logger.LogDebug($"Test Logging the Keycloak roles: '{string.Join(", ", roles)}'");
 
             return roles;
         }


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-530:](https://citz-imb.atlassian.net/browse/PIMS-530) Error when trying to approve access requests

<!-- PROVIDE BELOW an explanation of your changes -->
This ticket is to help debug the issue when trying to approve users that don't have any "roles".

We are currently unable to approve a user access request, because according to the application it's unable to retrieve the roles from Keycloak.
![image](https://github.com/bcgov/PIMS/assets/68400651/7d7cb8be-0a0b-4cbe-a4ca-1269e26793a2)

It looks like this is not the only user it happens to, but if a user doesn't have any roles, then we can't approve their access request using the access request page and get an error (see the Jira ticket for specifics). We are also unable to view or change the user's roles from PIMS. Strange thing is that the user can see his role, when clicking on the drop down by his username.

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
