### PR TITLE
PIMS-421 Routes - Properties

### DIFF
--- a/express-api/src/controllers/index.ts
+++ b/express-api/src/controllers/index.ts
@@ -4,6 +4,7 @@ import * as ltsa from '@/controllers/ltsa/ltsaController';
 import * as parcels from '@/controllers/parcels/parcelsController';
 import * as lookup from '@/controllers/lookup/lookupController';
 import * as users from '@/controllers/users/usersController';
+import * as properties from '@/controllers/properties/propertiesController';
 
 export default {
   healthCheck,
@@ -12,4 +13,5 @@ export default {
   ...lookup,
   admin,
   ...users,
+  ...properties,
 };

--- a/express-api/src/controllers/properties/propertiesController.ts
+++ b/express-api/src/controllers/properties/propertiesController.ts
@@ -1,0 +1,116 @@
+import { Request, Response } from 'express';
+import { stubResponse } from '@/utilities/stubResponse';
+
+/**
+ * @description Used to retrieve all properties.
+ * @param   {Request}     req Incoming request
+ * @param   {Response}    res Outgoing response
+ * @returns {Response}        A 200 status with a list of properties.
+ */
+export const getProperties = async (req: Request, res: Response) => {
+  /**
+   * #swagger.tags = ['Properties']
+   * #swagger.description = 'Returns a list of all properties.'
+   * #swagger.security = [{
+            "bearerAuth": []
+      }]
+   */
+
+  // TODO: Replace stub response with controller logic
+  return stubResponse(res);
+};
+
+/**
+ * @description Used to retrieve all properties that match the incoming filter.
+ * @param   {Request}     req Incoming request
+ * @param   {Response}    res Outgoing response
+ * @returns {Response}        A 200 status with a list of properties.
+ */
+export const getPropertiesFilter = async (req: Request, res: Response) => {
+  /**
+   * #swagger.tags = ['Properties']
+   * #swagger.description = 'Returns a list of properties that match the incoming filter.'
+   * #swagger.security = [{
+            "bearerAuth": []
+      }]
+   */
+
+  // TODO: Replace stub response with controller logic
+  return stubResponse(res);
+};
+
+/**
+ * @description Used to a paged list of all properties.
+ * @param   {Request}     req Incoming request
+ * @param   {Response}    res Outgoing response
+ * @returns {Response}        A 200 status with a paged list of properties.
+ */
+export const getPropertiesPaged = async (req: Request, res: Response) => {
+  /**
+   * #swagger.tags = ['Properties']
+   * #swagger.description = 'Returns a paged list of all properties.'
+   * #swagger.security = [{
+            "bearerAuth": []
+      }]
+   */
+
+  // TODO: Replace stub response with controller logic
+  return stubResponse(res);
+};
+
+/**
+ * @description Used to a paged list of properties that match the incoming filter.
+ * @param   {Request}     req Incoming request
+ * @param   {Response}    res Outgoing response
+ * @returns {Response}        A 200 status with a paged list of properties.
+ */
+export const getPropertiesPagedFilter = async (req: Request, res: Response) => {
+  /**
+   * #swagger.tags = ['Properties']
+   * #swagger.description = 'Returns a paged list of properties that match the incoming filter.'
+   * #swagger.security = [{
+            "bearerAuth": []
+      }]
+   */
+
+  // TODO: Replace stub response with controller logic
+  return stubResponse(res);
+};
+
+/**
+ * @description Used to retrieve all property geolocation information.
+ * @param   {Request}     req Incoming request
+ * @param   {Response}    res Outgoing response
+ * @returns {Response}        A 200 status with a list of property geolocation information.
+ */
+export const getPropertiesForMap = async (req: Request, res: Response) => {
+  /**
+   * #swagger.tags = ['Properties']
+   * #swagger.description = 'Returns a list of all property geolocation information.'
+   * #swagger.security = [{
+            "bearerAuth": []
+      }]
+   */
+
+  // TODO: Replace stub response with controller logic
+  return stubResponse(res);
+};
+
+/**
+ * @description Used to retrieve all property geolocation information that matches the incoming filter.
+ * @param   {Request}     req Incoming request
+ * @param   {Response}    res Outgoing response
+ * @returns {Response}        A 200 status with a list of property geolocation information.
+ */
+export const getPropertiesForMapFilter = async (req: Request, res: Response) => {
+  /**
+   * #swagger.tags = ['Properties']
+   * #swagger.description = 'Returns a list of all property geolocation information that matches the incoming filter.'
+   * #swagger.security = [{
+            "bearerAuth": []
+      }]
+   */
+
+  // TODO: Replace stub response with controller logic
+  return stubResponse(res);
+};

--- a/express-api/src/express.ts
+++ b/express-api/src/express.ts
@@ -70,5 +70,6 @@ app.use(`/api/v2`, protectedRoute([Roles.ADMIN]), router.adminRouter);
 app.use(`/api/v2`, protectedRoute(), router.parcelsRouter);
 app.use('/api/v2', protectedRoute(), router.lookupRouter);
 app.use(`/api/v2`, protectedRoute(), router.usersRouter);
+app.use(`/api/v2`, protectedRoute(), router.propertiesRouter);
 
 export default app;

--- a/express-api/src/routes/index.ts
+++ b/express-api/src/routes/index.ts
@@ -4,6 +4,7 @@ import parcelsRouter from '@/routes/parcelsRouter';
 import lookupRouter from '@/routes/lookupRouter';
 import adminRouter from '@/routes/adminRouter';
 import usersRouter from '@/routes/usersRouter';
+import propertiesRouter from '@/routes/propertiesRouter';
 
 const router = {
   healthRouter,
@@ -12,6 +13,7 @@ const router = {
   lookupRouter,
   adminRouter,
   usersRouter,
+  propertiesRouter,
 };
 
 export default router;

--- a/express-api/src/routes/propertiesRouter.ts
+++ b/express-api/src/routes/propertiesRouter.ts
@@ -1,0 +1,26 @@
+import controllers from '@/controllers';
+import express from 'express';
+
+const router = express.Router();
+
+const {
+  getProperties,
+  getPropertiesFilter,
+  getPropertiesForMap,
+  getPropertiesForMapFilter,
+  getPropertiesPaged,
+  getPropertiesPagedFilter,
+} = controllers;
+
+// TODO: Could these just be GET requests with query params? Then no need for /filter routes. Would cut controllers in half too.
+
+router.route('/properties/search').get(getProperties);
+router.route('/properties/search/filter').post(getPropertiesFilter);
+
+router.route('/properties/search/geo').get(getPropertiesForMap); // Formerly wfs route
+router.route('/properties/search/geo/filter').post(getPropertiesForMapFilter);
+
+router.route('/properties/search/page').get(getPropertiesPaged);
+router.route('/properties/search/page/filter').post(getPropertiesPagedFilter);
+
+export default router;

--- a/express-api/tests/integration/properties/properties.test.ts
+++ b/express-api/tests/integration/properties/properties.test.ts
@@ -1,0 +1,123 @@
+import supertest from 'supertest';
+import app from '@/express';
+
+const request = supertest(app);
+const PROPERTIES_PATH = '/api/v2/properties';
+
+describe('INTEGRATION - Properties', () => {
+  // TODO: Need to figure out how to get token populated or Keycloak mocked
+  const TOKEN = '';
+  describe('GET /properties/search', () => {
+    it('should return 401 Unauthorized if invalid token provided', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}`)
+        .set('Authorization', `Bearer notAToken`);
+      expect(response.status).toBe(401);
+    });
+
+    xit('should return status 200 with the list of properties', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}`)
+        .set('Authorization', `Bearer ${TOKEN}`);
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('POST /properties/search/filter', () => {
+    it('should return 401 Unauthorized if invalid token provided', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}/filter`)
+        .set('Authorization', `Bearer notAToken`);
+      expect(response.status).toBe(401);
+    });
+
+    xit('should return status 200 with the list of properties', async () => {
+      const filter = {
+        pid: '002002002',
+      };
+      const response = await request
+        .get(`${PROPERTIES_PATH}/filter`)
+        .set('Authorization', `Bearer ${TOKEN}`)
+        .send(filter);
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('GET /properties/search/geo', () => {
+    it('should return 401 Unauthorized if invalid token provided', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}/geo`)
+        .set('Authorization', `Bearer notAToken`);
+      expect(response.status).toBe(401);
+    });
+
+    xit('should return status 200 with the list of properties', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}/geo`)
+        .set('Authorization', `Bearer ${TOKEN}`);
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('POST /properties/search/geo/filter', () => {
+    it('should return 401 Unauthorized if invalid token provided', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}/geo/filter`)
+        .set('Authorization', `Bearer notAToken`);
+      expect(response.status).toBe(401);
+    });
+
+    xit('should return status 200 with the list of properties', async () => {
+      const filter = {
+        pid: '002002002',
+      };
+      const response = await request
+        .get(`${PROPERTIES_PATH}/geo/filter`)
+        .set('Authorization', `Bearer ${TOKEN}`)
+        .send(filter);
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('GET /properties/search/page', () => {
+    it('should return 401 Unauthorized if invalid token provided', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}/page`)
+        .set('Authorization', `Bearer notAToken`);
+      expect(response.status).toBe(401);
+    });
+
+    xit('should return status 200 with the list of properties', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}/page`)
+        .set('Authorization', `Bearer ${TOKEN}`);
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('POST /properties/search/page/filter', () => {
+    it('should return 401 Unauthorized if invalid token provided', async () => {
+      const response = await request
+        .get(`${PROPERTIES_PATH}/page/filter`)
+        .set('Authorization', `Bearer notAToken`);
+      expect(response.status).toBe(401);
+    });
+
+    xit('should return status 200 with the list of properties', async () => {
+      const filter = {
+        pid: '002002002',
+      };
+      const response = await request
+        .get(`${PROPERTIES_PATH}/page/filter`)
+        .set('Authorization', `Bearer ${TOKEN}`)
+        .send(filter);
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/express-api/tests/unit/controllers/properties/propertiesController.test.ts
+++ b/express-api/tests/unit/controllers/properties/propertiesController.test.ts
@@ -1,0 +1,103 @@
+import controllers from '@/controllers';
+import { Request, Response } from 'express';
+import { MockReq, MockRes, getRequestHandlerMocks } from '../../../testUtils/factories';
+
+const {
+  getProperties,
+  getPropertiesFilter,
+  getPropertiesForMap,
+  getPropertiesForMapFilter,
+  getPropertiesPaged,
+  getPropertiesPagedFilter,
+} = controllers;
+
+describe('UNIT - Properties', () => {
+  let mockRequest: Request & MockReq, mockResponse: Response & MockRes;
+
+  beforeEach(() => {
+    const { mockReq, mockRes } = getRequestHandlerMocks();
+    mockRequest = mockReq;
+    mockResponse = mockRes;
+  });
+
+  describe('GET /properties/search', () => {
+    it('should return the stub response of 501', async () => {
+      await getProperties(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(501);
+    });
+
+    xit('should return 200 with a list of properties', async () => {
+      await getProperties(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(mockResponse.jsonValue.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('POST /properties/search/filter', () => {
+    it('should return the stub response of 501', async () => {
+      await getPropertiesFilter(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(501);
+    });
+
+    xit('should return 200 with a list of properties', async () => {
+      mockRequest.body = {}; // Add filter parameters
+      await getPropertiesFilter(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(mockResponse.jsonValue.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('GET /properties/search/geo', () => {
+    it('should return the stub response of 501', async () => {
+      await getPropertiesForMap(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(501);
+    });
+
+    xit('should return 200 with a list of properties', async () => {
+      await getPropertiesForMap(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(mockResponse.jsonValue.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('POST /properties/search/geo/filter', () => {
+    it('should return the stub response of 501', async () => {
+      await getPropertiesForMapFilter(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(501);
+    });
+
+    xit('should return 200 with a list of properties', async () => {
+      mockRequest.body = {}; // Add filter parameters
+      await getPropertiesForMapFilter(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(mockResponse.jsonValue.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('GET /properties/search/page', () => {
+    it('should return the stub response of 501', async () => {
+      await getPropertiesPaged(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(501);
+    });
+
+    xit('should return 200 with a list of properties', async () => {
+      await getPropertiesPaged(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(mockResponse.jsonValue.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('POST /properties/search/page/filter', () => {
+    it('should return the stub response of 501', async () => {
+      await getPropertiesPagedFilter(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(501);
+    });
+
+    xit('should return 200 with a list of properties', async () => {
+      mockRequest.body = {}; // Add filter parameters
+      await getPropertiesPagedFilter(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(mockResponse.jsonValue.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-421](https://citz-imb.atlassian.net/browse/PIMS-421?atlOrigin=eyJpIjoiNDU3NzhmMWM5MDg2NDhjN2E3YmQyN2ExOTMzZDBkZmEiLCJwIjoiaiJ9)

<!-- PROVIDE BELOW an explanation of your changes -->
These were all search routes. There was one, `properties/search/names` that I don't think is actually used currently (at least I can't find an example), so I omitted it. 

Additionally, I changed the routes with `wfs` to `geo`. These are the ones that retrieve the lists of properties for map marker population right now. `wfs` isn't a very descriptive name, so I'm hoping that `geo` will make it a little more obvious what it's used for.

Some other considerations when we start implementing controllers...
It feels like the filter routes could just be part of the GET routes, but with some query parameters. There doesn't appear to be anything confidential transmitted, so the use of a POST might not be necessary.

## Changes
- Added stub controllers for properties
- Added routes that expose these controllers
- Added stub integration and unit tests.

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
