### PR TITLE
PIMS-1312 Encumbrance Field Width

### DIFF
--- a/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/BuildingForm.test.tsx.snap
+++ b/frontend/src/features/mapSideBar/SidebarContents/__snapshots__/BuildingForm.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`Building Form component renders correctly 1`] = `
   text-align: left;
   padding: 8px 12px 10px;
   margin-bottom: 10px;
+  font-size: 11px;
 }
 
 .c0 {
@@ -604,49 +605,42 @@ exports[`Building Form component renders correctly 1`] = `
                   class="row"
                 >
                   <div
-                    class="col-md-6"
+                    class="col-md-3"
+                    style="text-align: left;"
+                  >
+                    <label
+                      class="label"
+                      style="padding: 0px;"
+                    >
+                      Building Classification
+                    </label>
+                  </div>
+                  <div
+                    class="col-md-4"
                   >
                     <div
-                      class="row"
+                      class="required"
                     >
-                      <div
-                        class="col-md-4"
-                        style="text-align: right;"
-                      >
-                        <label
-                          class="label"
+                      <div>
+                        <select
+                          class="form-select form-control"
+                          id="input-building.classificationId-fast"
+                          name="building.classificationId"
+                          required=""
+                          style="margin-top: 5px; display: flex;"
+                          type="number"
                         >
-                          Building Classification
-                        </label>
-                      </div>
-                      <div
-                        class="col-md-auto"
-                      >
-                        <div
-                          class="required"
-                        >
-                          <div>
-                            <select
-                              class="form-select form-control"
-                              id="input-building.classificationId-fast"
-                              name="building.classificationId"
-                              required=""
-                              style="margin-top: 5px; display: flex;"
-                              type="number"
-                            >
-                              <option
-                                value=""
-                              >
-                                Must Select One
-                              </option>
-                            </select>
-                          </div>
-                        </div>
+                          <option
+                            value=""
+                          >
+                            Must Select One
+                          </option>
+                        </select>
                       </div>
                     </div>
                   </div>
                   <div
-                    class="col-md-6"
+                    class="col-md-5"
                   >
                     <div
                       class="c4"

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.tsx
@@ -31,26 +31,7 @@ const InfoBox = styled.div`
   text-align: left;
   padding: 8px 12px 10px;
   margin-bottom: 10px;
-`;
-
-/** formatted field description that will appear underneath the select input */
-const FieldDescription = styled.p`
-  margin-left: 166px;
-  margin-top: 10px;
-  font-size: 12px;
-  text-align: left;
-`;
-
-const Encumberance = styled(Col)`
-  .form-label {
-    min-width: 140px;
-  }
-  .form-group {
-    display: flex;
-    textarea.form-control {
-      width: 100%;
-    }
-  }
+  font-size: 11px;
 `;
 
 /** used to conditionally render the information display box with the desired content */
@@ -167,43 +148,51 @@ export const ClassificationForm: React.FC<IClassificationFormProps> = ({
         <Title>{title}</Title>
       </Row>
       <Row>
-        <Col md={6}>
-          <Row>
-            <Col md="4" style={{ textAlign: 'right' }}>
-              <Label>{fieldLabel}</Label>
-            </Col>
-            <Col md="auto">
-              <FastSelect
-                className="form-select"
-                formikProps={formikProps}
-                type="number"
-                style={{ marginTop: '5px', display: 'flex' }}
-                placeholder="Must Select One"
-                field={field}
-                options={filteredClassifications}
-                disabled={disabled}
-                required
-                displayErrorTooltips
-              />
-            </Col>
-            {toolTip && (
-              <div style={{ marginTop: '8px' }}>
-                <TooltipIcon toolTip={toolTip} toolTipId="classificationToolTip" />
-              </div>
-            )}
-          </Row>
+        <Col md={3} style={{ textAlign: 'left' }}>
+          <Label style={{ padding: 0 }}>{fieldLabel}</Label>
         </Col>
-        <Col md={6}>{renderInfo()}</Col>
+        <Col md={4}>
+          <FastSelect
+            className="form-select"
+            formikProps={formikProps}
+            type="number"
+            style={{ marginTop: '5px', display: 'flex' }}
+            placeholder="Must Select One"
+            field={field}
+            options={filteredClassifications}
+            disabled={disabled}
+            required
+            displayErrorTooltips
+          />
+        </Col>
+        {toolTip && (
+          <div style={{ marginTop: '8px' }}>
+            <TooltipIcon toolTip={toolTip} toolTipId="classificationToolTip" />
+          </div>
+        )}
+
+        <Col md={5}>{renderInfo()}</Col>
       </Row>
       {getIn(formikProps.values, field) === Classifications.SurplusEncumbered && (
         <Row>
-          <Encumberance>
-            <TextArea field={encumbranceField} label="Reason for Encumbrance"></TextArea>
-          </Encumberance>
+          <Col md={3} style={{ textAlign: 'left' }}>
+            <Label style={{ padding: 0 }}>Reason for Encumbrance</Label>
+          </Col>
+          <Col md={4}>
+            {' '}
+            <TextArea
+              field={encumbranceField}
+              style={{
+                minHeight: '86px',
+              }}
+            ></TextArea>
+          </Col>
+          {surplusActiveOrEncumbered && (
+            <Col md={5}>
+              <InfoBox>{SurplusEncumberedOrActive}</InfoBox>
+            </Col>
+          )}
         </Row>
-      )}
-      {surplusActiveOrEncumbered && (
-        <FieldDescription>{SurplusEncumberedOrActive}</FieldDescription>
       )}
     </>
   );

--- a/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.tsx
+++ b/frontend/src/features/mapSideBar/SidebarContents/subforms/ClassificationForm.tsx
@@ -179,11 +179,11 @@ export const ClassificationForm: React.FC<IClassificationFormProps> = ({
             <Label style={{ padding: 0 }}>Reason for Encumbrance</Label>
           </Col>
           <Col md={4}>
-            {' '}
             <TextArea
               field={encumbranceField}
               style={{
                 minHeight: '86px',
+                minWidth: '270px',
               }}
             ></TextArea>
           </Col>


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1312](https://citz-imb.atlassian.net/browse/PIMS-1312?atlOrigin=eyJpIjoiMzU5ODQzZWVlOTI2NDNmNjgxYjJhZGI4MWU5NWIzZDEiLCJwIjoiaiJ9)

Fixes some bad styling of the encumbrance reason field. It was very narrow before.
<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Specified minimum width and height for encumbrance field
- Removed some unneeded styled components, using just bootstrap layouts instead.
- Elements are now aligned into evenly-space rows.

## Testing
Try submitting new parcels and buildings. Select the Surplus Encumbered classification to see this field.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
