### PR TITLE
Corrected vite env with prefix

### DIFF
--- a/openshift/templates/app-dc-template.yaml
+++ b/openshift/templates/app-dc-template.yaml
@@ -114,7 +114,7 @@ objects:
                   value: /api
                 - name: RealIpFrom
                   value: 172.51.0.0/16
-                - name: BCA_LAYER_URL
+                - name: VITE_BCA_LAYER_URL
                   valueFrom:
                     configMapKeyRef: 
                       name: pims-app-env


### PR DESCRIPTION
## 🎯 Summary

Missing VITE_ prefix necessary for the app to detect it.

## 🔰 Checklist

- [ ] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
