### PR TITLE
Agencies Cannot Be Own Parent Zero ID Bug

### DIFF
--- a/express-api/src/controllers/agencies/agenciesController.ts
+++ b/express-api/src/controllers/agencies/agenciesController.ts
@@ -100,7 +100,7 @@ export const updateAgencyById = async (req: Request, res: Response) => {
     return res.status(400).send('The param ID does not match the request body.');
   }
   // Make sure you can't assign an agency as its own parent
-  if (updateInfo.ParentId && updateInfo.ParentId === updateInfo.Id) {
+  if (updateInfo.ParentId != null && updateInfo.ParentId === updateInfo.Id) {
     return res.status(403).send('An agency cannot be its own parent.');
   }
   const user = await userServices.getUser((req.user as KeycloakUser).preferred_username);

--- a/express-api/tests/unit/controllers/agencies/agenciesController.test.ts
+++ b/express-api/tests/unit/controllers/agencies/agenciesController.test.ts
@@ -151,7 +151,7 @@ describe('UNIT - Agencies Admin', () => {
       mockRequest.body = agency;
       expect(
         async () => await controllers.updateAgencyById(mockRequest, mockResponse),
-      ).rejects.toThrow();
+      ).rejects.toThrow('');
     });
   });
 


### PR DESCRIPTION
Fixed an issue where the controller would incorrectly skip the own parent check if the ID was set to zero. 

In Javascript, `0 == false` so the line `if (updateInfo.ParentId && updateInfo.ParentId === updateInfo.Id)` would evaluate false in this scenario.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
