### PR TITLE
PIMS-1582 Options Filter Fix

### DIFF
--- a/react-app/src/components/form/AutocompleteFormField.tsx
+++ b/react-app/src/components/form/AutocompleteFormField.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Autocomplete, SxProps, TextField, Paper, Box, autocompleteClasses } from '@mui/material';
+import {
+  Autocomplete,
+  SxProps,
+  TextField,
+  Paper,
+  Box,
+  autocompleteClasses,
+  FilterOptionsState,
+} from '@mui/material';
 import { ISelectMenuItem } from './SelectFormField';
 import { Controller, useFormContext } from 'react-hook-form';
 
@@ -13,6 +21,10 @@ type AutocompleteFormProps = {
   disableOptionsFunction?: (option: ISelectMenuItem) => boolean;
   disableClearable?: boolean;
   defaultValue?: ISelectMenuItem | null;
+  customOptionsFilter?: (
+    options: ISelectMenuItem[],
+    state: FilterOptionsState<ISelectMenuItem>,
+  ) => ISelectMenuItem[];
 };
 
 const CustomPaper = (props) => {
@@ -30,8 +42,16 @@ const AutocompleteFormField = (props: AutocompleteFormProps) => {
     allowNestedIndent,
     disableClearable,
     disableOptionsFunction,
+    customOptionsFilter,
     ...rest
   } = props;
+
+  const defaultOptionsFilter = (
+    options: ISelectMenuItem[],
+    state: FilterOptionsState<ISelectMenuItem>,
+  ) => options.filter((item) => item.label.toLowerCase().includes(state.inputValue.toLowerCase()));
+
+  const optionsFilter = customOptionsFilter ? customOptionsFilter : defaultOptionsFilter;
 
   return (
     <Controller
@@ -48,7 +68,7 @@ const AutocompleteFormField = (props: AutocompleteFormProps) => {
           disableClearable={disableClearable}
           getOptionLabel={(option: ISelectMenuItem) => option.label}
           getOptionDisabled={disableOptionsFunction}
-          filterOptions={(x) => x}
+          filterOptions={optionsFilter}
           renderOption={(props, option, state, ownerState) => (
             <Box
               sx={{
@@ -74,7 +94,7 @@ const AutocompleteFormField = (props: AutocompleteFormProps) => {
             />
           )}
           onChange={(_, data) => {
-            onChange(data.value);
+            if (data) onChange(data.value);
           }}
           isOptionEqualToValue={(option, value) => option.value === value.value}
           value={options.find((option) => option.value === getValues()[name]) ?? null}

--- a/react-app/src/hooks/api/useGroupedAgenciesApi.ts
+++ b/react-app/src/hooks/api/useGroupedAgenciesApi.ts
@@ -52,12 +52,9 @@ export const useGroupedAgenciesApi = () => {
         children: agency.children.map((child) => child.Id),
       });
       if (agency.children && agency.children.length > 0) {
-        // Custom sorting logic for children agencies that contain numeric values
-        agency.children = agency.children.sort((a: Agency, b: Agency) => {
-          const numA = parseInt(a.Name.match(/\d+/)?.[0] || '0');
-          const numB = parseInt(b.Name.match(/\d+/)?.[0] || '0');
-          return numA - numB;
-        });
+        agency.children = agency.children.sort((a: Agency, b: Agency) =>
+          a.Name.localeCompare(b.Name, undefined, { numeric: true, sensitivity: 'base' }),
+        );
         agency.children.forEach((childAgency) => {
           options.push({
             label: childAgency.Name,


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1582](https://citz-imb.atlassian.net/browse/PIMS-1582?atlOrigin=eyJpIjoiNTkyYTBkNGQ3YWE3NGY4MDk0ZmRlODc2YjRmYjQwMDkiLCJwIjoiaiJ9)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Autocomplete field now filters on the label again. Not sure when this originally broke.
- Noticed that child agencies weren't sorted. Changed sorting code to make this work.

## Testing
- Play with the autocomplete fields (especially grouped agencies)
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
