### PR TITLE
Fix for coalesce in Sequence Migration

### DIFF
--- a/express-api/src/typeorm/Migrations/1713814960226-UpdateIDSequences.ts
+++ b/express-api/src/typeorm/Migrations/1713814960226-UpdateIDSequences.ts
@@ -20,7 +20,7 @@ export class UpdateIDSequences1713814960226 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     for (const table of tables) {
       await queryRunner.query(
-        `SELECT setval('${table}_id_seq', (SELECT COALESCE(MAX(id), 0) FROM ${table}));`,
+        `SELECT setval('${table}_id_seq', (SELECT COALESCE(MAX(id), 1) FROM ${table}));`,
       );
     }
   }
@@ -31,9 +31,9 @@ export class UpdateIDSequences1713814960226 implements MigrationInterface {
       try {
         // Query the maximum ID from the table
         const result = await queryRunner.query(
-          `SELECT COALESCE(MAX(id), 0) AS max_id FROM ${table};`,
+          `SELECT COALESCE(MAX(id), 1) AS max_id FROM ${table};`,
         );
-        const maxId = parseInt(result[0].max_id) || 0;
+        const maxId = parseInt(result[0].max_id) || 1;
 
         // Reset the sequence to max ID + 1
         await queryRunner.query(`ALTER SEQUENCE "${sequence}" RESTART WITH ${maxId + 1};`);


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

Fixed wrong coalesce from 0 to 1. Sequences can't start at 0, it's out of range.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
