### PR TITLE
PIMS-1625: Parcel and Building view details agency authorization

### DIFF
--- a/express-api/src/controllers/buildings/buildingsController.ts
+++ b/express-api/src/controllers/buildings/buildingsController.ts
@@ -60,11 +60,10 @@ export const getBuilding = async (req: Request, res: Response) => {
 
   const kcUser = req.user as unknown as SSOUser;
   const building = await buildingService.getBuildingById(buildingId);
-  const userHasAccess = await checkUserAgencyPermission(kcUser, [building.AgencyId]);
 
   if (!building) {
     return res.status(404).send('Building matching this ID was not found.');
-  } else if (!userHasAccess) {
+  } else if (!(await checkUserAgencyPermission(kcUser, [building.AgencyId]))) {
     return res.status(403).send('You are not authorized to view this building.');
   }
   return res.status(200).send(building);

--- a/express-api/src/controllers/buildings/buildingsController.ts
+++ b/express-api/src/controllers/buildings/buildingsController.ts
@@ -57,9 +57,16 @@ export const getBuilding = async (req: Request, res: Response) => {
   if (isNaN(buildingId)) {
     return res.status(400).send('Building Id is invalid.');
   }
+
+  const kcUser = req.user as unknown as SSOUser;
+  const usersAgencies = await userServices.getAgencies(kcUser.preferred_username);
   const building = await buildingService.getBuildingById(buildingId);
+
   if (!building) {
     return res.status(404).send('Building matching this ID was not found.');
+  } else if (!usersAgencies.includes(building.AgencyId)) {
+    // check to see if the building's agency belongs to the users's agencies
+    return res.status(403).send('You are not authorized to view this building.');
   }
   return res.status(200).send(building);
 };

--- a/express-api/src/controllers/parcels/parcelsController.ts
+++ b/express-api/src/controllers/parcels/parcelsController.ts
@@ -28,10 +28,9 @@ export const getParcel = async (req: Request, res: Response) => {
 
   const kcUser = req.user as unknown as SSOUser;
   const parcel = await parcelServices.getParcelById(parcelId);
-  const userHasAccess = await checkUserAgencyPermission(kcUser, [parcel.AgencyId]);
   if (!parcel) {
     return res.status(404).send('Parcel matching this internal ID not found.');
-  } else if (!userHasAccess) {
+  } else if (!(await checkUserAgencyPermission(kcUser, [parcel.AgencyId]))) {
     return res.status(403).send('You are not authorized to view this parcel.');
   }
   return res.status(200).send(parcel);

--- a/express-api/src/controllers/parcels/parcelsController.ts
+++ b/express-api/src/controllers/parcels/parcelsController.ts
@@ -25,9 +25,15 @@ export const getParcel = async (req: Request, res: Response) => {
   if (isNaN(parcelId)) {
     return res.status(400).send('Parcel ID was invalid.');
   }
+
+  const kcUser = req.user as unknown as SSOUser;
+  const usersAgencies = await userServices.getAgencies(kcUser.preferred_username);
   const parcel = await parcelServices.getParcelById(parcelId);
   if (!parcel) {
     return res.status(404).send('Parcel matching this internal ID not found.');
+  } else if (!usersAgencies.includes(parcel.AgencyId)) {
+    // check to see if the building's agency belongs to the users's agencies
+    return res.status(403).send('You are not authorized to view this parcel.');
   }
   return res.status(200).send(parcel);
 };

--- a/express-api/src/controllers/parcels/parcelsController.ts
+++ b/express-api/src/controllers/parcels/parcelsController.ts
@@ -5,7 +5,7 @@ import { ParcelFilter, ParcelFilterSchema } from '@/services/parcels/parcelSchem
 import { SSOUser } from '@bcgov/citz-imb-sso-express';
 import userServices from '@/services/users/usersServices';
 import { Parcel } from '@/typeorm/Entities/Parcel';
-import { isAdmin, isAuditor } from '@/utilities/authorizationChecks';
+import { checkUserAgencyPermission, isAdmin, isAuditor } from '@/utilities/authorizationChecks';
 
 /**
  * @description Gets information about a particular parcel by the Id provided in the URL parameter.
@@ -27,12 +27,11 @@ export const getParcel = async (req: Request, res: Response) => {
   }
 
   const kcUser = req.user as unknown as SSOUser;
-  const usersAgencies = await userServices.getAgencies(kcUser.preferred_username);
   const parcel = await parcelServices.getParcelById(parcelId);
+  const userHasAccess = await checkUserAgencyPermission(kcUser, [parcel.AgencyId]);
   if (!parcel) {
     return res.status(404).send('Parcel matching this internal ID not found.');
-  } else if (!usersAgencies.includes(parcel.AgencyId)) {
-    // check to see if the building's agency belongs to the users's agencies
+  } else if (!userHasAccess) {
     return res.status(403).send('You are not authorized to view this parcel.');
   }
   return res.status(200).send(parcel);

--- a/express-api/tests/testUtils/factories.ts
+++ b/express-api/tests/testUtils/factories.ts
@@ -202,7 +202,7 @@ export const produceParcel = (): Parcel => {
     Description: faker.string.alphanumeric(),
     ClassificationId: undefined,
     Classification: undefined,
-    AgencyId: undefined,
+    AgencyId: 1,
     Agency: undefined,
     AdministrativeAreaId: undefined,
     AdministrativeArea: undefined,

--- a/express-api/tests/unit/controllers/buildings/buildingsController.test.ts
+++ b/express-api/tests/unit/controllers/buildings/buildingsController.test.ts
@@ -27,12 +27,14 @@ jest.mock('@/services/buildings/buildingServices', () => ({
 jest.mock('@/services/users/usersServices', () => ({
   getUser: jest.fn().mockImplementation(() => produceUser()),
   getAgencies: jest.fn().mockResolvedValue([1, 2]),
+  hasAgencies: jest.fn().mockImplementation(() => true),
 }));
 
 describe('UNIT - Buildings', () => {
   let mockRequest: Request & MockReq, mockResponse: Response & MockRes;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     const { mockReq, mockRes } = getRequestHandlerMocks();
     mockRequest = mockReq;
     mockResponse = mockRes;

--- a/express-api/tests/unit/controllers/buildings/buildingsController.test.ts
+++ b/express-api/tests/unit/controllers/buildings/buildingsController.test.ts
@@ -40,7 +40,11 @@ describe('UNIT - Buildings', () => {
 
   describe('GET /properties/buildings/:buildingId', () => {
     it('should return 200 with a correct response body', async () => {
+      const buildingWithAgencyId1 = {
+        AgencyId: 1,
+      };
       mockRequest.params.buildingId = '1';
+      _getBuildingById.mockImplementationOnce(() => buildingWithAgencyId1);
       await controllers.getBuilding(mockRequest, mockResponse);
       expect(mockResponse.statusValue).toBe(200);
     });

--- a/express-api/tests/unit/controllers/parcels/parcelsController.test.ts
+++ b/express-api/tests/unit/controllers/parcels/parcelsController.test.ts
@@ -26,11 +26,14 @@ jest.mock('@/services/parcels/parcelServices', () => ({
 jest.mock('@/services/users/usersServices', () => ({
   getUser: jest.fn().mockImplementation(() => produceUser()),
   getAgencies: jest.fn().mockResolvedValue([1, 2]),
+  hasAgencies: jest.fn().mockImplementation(() => true),
 }));
 describe('UNIT - Parcels', () => {
   let mockRequest: Request & MockReq, mockResponse: Response & MockRes;
 
   beforeEach(() => {
+    jest.clearAllMocks();
+
     const { mockReq, mockRes } = getRequestHandlerMocks();
     mockRequest = mockReq;
     mockResponse = mockRes;


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1625: ](https://citz-imb.atlassian.net/browse/PIMS-1625) - Parcel and Building view details agency authorization

<!-- PROVIDE BELOW an explanation of your changes -->
Adding authorization checks to prevent a user from viewing a parcel or a building not belonging to their agency.
To test you can try as a "General user" by editing the url and changing the id of the parcel or building to one that has an agency which doesn't belong to your user's agency.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
