### PR TITLE
PIMS-1590 Expand Parcel Layer Popup

### DIFF
--- a/react-app/src/components/map/MapPropertyDetails.tsx
+++ b/react-app/src/components/map/MapPropertyDetails.tsx
@@ -65,6 +65,16 @@ export interface GridColumnPairProps {
   rightValue: any;
   alignment?: string;
 }
+
+/**
+ * Renders a pair of grid columns with a left value and a right value.
+ *
+ * @param {GridColumnPairProps} props - The props for the GridColumnPair component.
+ * @param {any} props.leftValue - The value to be displayed in the left column.
+ * @param {any} props.rightValue - The value to be displayed in the right column.
+ * @param {string} [props.alignment] - The alignment of the columns. Defaults to 'center'.
+ * @returns {JSX.Element} The rendered GridColumnPair component.
+ */
 export const GridColumnPair = (props: GridColumnPairProps) => {
   return (
     <>

--- a/react-app/src/components/map/MapPropertyDetails.tsx
+++ b/react-app/src/components/map/MapPropertyDetails.tsx
@@ -1,4 +1,4 @@
-import { ParcelData } from '@/components/map/ParcelMap';
+import { ParcelData } from '@/hooks/api/useParcelLayerApi';
 import MetresSquared from '@/components/text/MetresSquared';
 import { PropertyTypes } from '@/constants/propertyTypes';
 import { Building } from '@/hooks/api/useBuildingsApi';
@@ -31,7 +31,7 @@ export interface MapPropertyDetailsProps {
 }
 
 const typographyStyle = (theme) => ({ ...theme.typography.body2 });
-const LeftGridColumn = (props: PropsWithChildren) => (
+export const LeftGridColumn = (props: PropsWithChildren & { alignment?: string }) => (
   <Grid
     item
     xs={4}
@@ -39,23 +39,36 @@ const LeftGridColumn = (props: PropsWithChildren) => (
     sx={{
       fontWeight: 'bold',
       display: 'flex',
-      alignItems: 'center',
+      alignItems: props.alignment ?? 'center',
     }}
   >
     {props.children}
   </Grid>
 );
-const RightGridColumn = (props: PropsWithChildren) => (
-  <Grid item xs={7} typography={typographyStyle}>
-    {props.children}
+export const RightGridColumn = (props: PropsWithChildren & { alignment?: string }) => (
+  <Grid
+    item
+    xs={7}
+    typography={typographyStyle}
+    sx={{
+      display: 'flex',
+      alignItems: props.alignment ?? 'center',
+    }}
+  >
+    {props.children ?? ''}
   </Grid>
 );
 
-const GridColumnPair = ({ leftValue, rightValue }) => {
+export interface GridColumnPairProps {
+  leftValue: any;
+  rightValue: any;
+  alignment?: string;
+}
+export const GridColumnPair = (props: GridColumnPairProps) => {
   return (
     <>
-      <LeftGridColumn>{leftValue}</LeftGridColumn>
-      <RightGridColumn>{rightValue}</RightGridColumn>
+      <LeftGridColumn alignment={props.alignment}>{props.leftValue}</LeftGridColumn>
+      <RightGridColumn alignment={props.alignment}>{props.rightValue}</RightGridColumn>
     </>
   );
 };
@@ -262,16 +275,24 @@ const DrawerContents = (props: ContentsProps) => {
             leftValue={'Description'}
             rightValue={(propertyData as Building)?.Description}
           />
-          <LeftGridColumn>Total Area</LeftGridColumn>
-          <RightGridColumn>
-            {(propertyData as Building)?.TotalArea}
-            <MetresSquared />
-          </RightGridColumn>
-          <LeftGridColumn>Rentable Area</LeftGridColumn>
-          <RightGridColumn>
-            {(propertyData as Building)?.RentableArea}
-            <MetresSquared />
-          </RightGridColumn>
+          <GridColumnPair
+            leftValue={'Total Area'}
+            rightValue={
+              <>
+                <span>{`${(propertyData as Building)?.TotalArea}`}</span>
+                <MetresSquared />
+              </>
+            }
+          />
+          <GridColumnPair
+            leftValue={'Rentable Area'}
+            rightValue={
+              <>
+                <span>{`${(propertyData as Building)?.RentableArea}`}</span>
+                <MetresSquared />
+              </>
+            }
+          />
           <GridColumnPair
             leftValue={'Tenancy'}
             rightValue={`${(propertyData as Building)?.BuildingTenancy} %`}

--- a/react-app/src/components/map/ParcelMap.tsx
+++ b/react-app/src/components/map/ParcelMap.tsx
@@ -17,12 +17,30 @@ type ParcelMapProps = {
 
 export const SelectedMarkerContext = createContext(null);
 
+/**
+ * ParcelMap component renders a map with various layers and functionalities.
+ *
+ * @param {ParcelMapProps} props - The props object containing the height, mapRef, movable, zoomable, and loadProperties properties.
+ * @returns {JSX.Element} The ParcelMap component.
+ *
+ * @example
+ * ```tsx
+ * <ParcelMap
+ *   height="500px"
+ *   mapRef={mapRef}
+ *   movable={true}
+ *   zoomable={true}
+ *   loadProperties={false}
+ * >
+ *   {children}
+ * </ParcelMap>
+ * ```
+ */
 const ParcelMap = (props: ParcelMapProps) => {
   const MapEvents = () => {
     useMapEvents({});
     return null;
   };
-  // const [clickPosition, setClickPosition] = useState<LatLng>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [selectedMarker, setSelectedMarker] = useState({
     id: undefined,

--- a/react-app/src/components/map/ParcelMap.tsx
+++ b/react-app/src/components/map/ParcelMap.tsx
@@ -1,33 +1,11 @@
 import { Box, CircularProgress } from '@mui/material';
 import React, { createContext, PropsWithChildren, useState } from 'react';
-import { MapContainer, useMapEvents, useMap } from 'react-leaflet';
+import { MapContainer, useMapEvents } from 'react-leaflet';
 import { Map } from 'leaflet';
-import usePimsApi from '@/hooks/usePimsApi';
 import MapLayers from '@/components/map/MapLayers';
-import { ParcelPopup, PopupData } from '@/components/map/ParcelPopup';
+import { ParcelPopup } from '@/components/map/ParcelPopup';
 import { InventoryLayer } from '@/components/map/InventoryLayer';
 import MapPropertyDetails from '@/components/map/MapPropertyDetails';
-
-export interface ParcelData {
-  PARCEL_FABRIC_POLY_ID: number;
-  PARCEL_NAME: string;
-  PLAN_NUMBER: string;
-  PIN: number;
-  PID: string;
-  PID_FORMATTED: string;
-  PID_NUMBER: number;
-  PARCEL_STATUS: string;
-  PARCEL_CLASS: string;
-  OWNER_TYPE: string;
-  PARCEL_START_DATE: string;
-  MUNICIPALITY: string;
-  REGIONAL_DISTRICT: string;
-  WHEN_UPDATED: string;
-  FEATURE_AREA_SQM: number;
-  FEATURE_LENGTH_M: number;
-  OBJECTID: number;
-  SE_ANNO_CAD_DATA: unknown;
-}
 
 type ParcelMapProps = {
   height: string;
@@ -40,29 +18,11 @@ type ParcelMapProps = {
 export const SelectedMarkerContext = createContext(null);
 
 const ParcelMap = (props: ParcelMapProps) => {
-  const api = usePimsApi();
   const MapEvents = () => {
-    const map = useMap();
-    useMapEvents({
-      click: (e) => {
-        //zoom check here since I don't think it makes sense to allow this at anything more zoomed out than this
-        //can't really click on any parcel with much accurancy beyond that point
-        if (map.getZoom() > 10) {
-          api.parcelLayer.getParcelByLatLng(e.latlng).then((response) => {
-            if (response.features.length) {
-              setClickPosition({
-                position: e.latlng,
-                pid: response.features[0].properties.PID_FORMATTED,
-                pin: response.features[0].properties.PIN,
-              });
-            }
-          });
-        }
-      },
-    });
+    useMapEvents({});
     return null;
   };
-  const [clickPosition, setClickPosition] = useState<PopupData>(null);
+  // const [clickPosition, setClickPosition] = useState<LatLng>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [selectedMarker, setSelectedMarker] = useState({
     id: undefined,
@@ -96,7 +56,7 @@ const ParcelMap = (props: ParcelMapProps) => {
           preferCanvas
         >
           <MapLayers />
-          {clickPosition?.position && <ParcelPopup clickPosition={clickPosition} />}
+          <ParcelPopup />
           <MapEvents />
           {loadProperties ? <InventoryLayer setLoading={setLoading} /> : <></>}
           {props.children}

--- a/react-app/src/components/map/ParcelPopup.tsx
+++ b/react-app/src/components/map/ParcelPopup.tsx
@@ -1,23 +1,160 @@
-import { Typography } from '@mui/material';
+import { GridColumnPair } from '@/components/map/MapPropertyDetails';
+import MetresSquared from '@/components/text/MetresSquared';
+import { ParcelData } from '@/hooks/api/useParcelLayerApi';
+import usePimsApi from '@/hooks/usePimsApi';
+import { Box, Grid, List, ListItem, Typography, useTheme } from '@mui/material';
 import { LatLng } from 'leaflet';
-import React from 'react';
-import { Popup } from 'react-leaflet';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Popup, useMap, useMapEvents } from 'react-leaflet';
+import './parcelPopup.css';
 
-export interface PopupData {
-  position: LatLng | null;
-  pin: number | string;
-  pid: number | string;
-}
+export const ParcelPopup = () => {
+  const [parcelData, setParcelData] = useState<ParcelData[]>(undefined);
+  const [clickPosition, setClickPosition] = useState<LatLng>(null);
+  const [parcelIndex, setParcelIndex] = useState<number>(0);
 
-export interface ParcelPopupProps {
-  clickPosition: PopupData;
-}
-export const ParcelPopup = (props: ParcelPopupProps) => {
-  const { clickPosition } = props;
+  const map = useMap();
+  const api = usePimsApi();
+
+  useEffect(() => {
+    getParcelData();
+  }, [clickPosition]);
+
+  useMapEvents({
+    click: (e) => {
+      setClickPosition(e.latlng);
+    },
+  });
+
+  const getParcelData = useCallback(() => {
+    //zoom check here since I don't think it makes sense to allow this at anything more zoomed out than this
+    //can't really click on any parcel with much accurancy beyond that point
+    if (map.getZoom() > 10) {
+      api.parcelLayer.getParcelByLatLng(clickPosition).then((response) => {
+        if (response.features.length) {
+          setParcelData(
+            response.features
+              .map((feature) => feature.properties as ParcelData)
+              .filter((feature) => feature.PID_FORMATTED || feature.PIN)
+              .sort((a, b) => {
+                if (a.PID_NUMBER && b.PID_NUMBER) return a.PID_NUMBER - b.PID_NUMBER;
+                else return 1;
+              }),
+          );
+          setParcelIndex(0);
+          map.setView(clickPosition);
+        }
+      });
+    }
+  }, [clickPosition]);
+
+  if (!clickPosition) return <></>;
   return (
-    <Popup autoPan={false} position={clickPosition.position}>
-      <Typography>{`PID: ${clickPosition?.pid ?? 'None'}`}</Typography>
-      <Typography>{`PIN: ${clickPosition?.pin ?? 'None'}`}</Typography>
+    <Popup autoPan={false} position={clickPosition} className="full-size">
+      <Box display={'inline-flex'}>
+        {parcelData ? (
+          <>
+            {parcelData.length > 1 ? (
+              <ParcelPopupSelect
+                parcelData={parcelData}
+                onClick={(index: number) => {
+                  setParcelIndex(index);
+                }}
+              />
+            ) : (
+              <></>
+            )}
+            <ParcelLayerDetails parcel={parcelData.at(parcelIndex)} />
+          </>
+        ) : (
+          <></>
+        )}
+      </Box>
     </Popup>
+  );
+};
+
+interface ParcelLayerDetailsProps {
+  parcel: ParcelData;
+}
+const ParcelLayerDetails = (props: ParcelLayerDetailsProps) => {
+  const { parcel } = props;
+  return (
+    <Box minWidth={'300px'}>
+      <Grid container gap={1}>
+        <Grid item xs={12}>
+          <Typography variant="h4">Parcel Layer</Typography>
+        </Grid>
+        {parcel.PID_FORMATTED ? (
+          <GridColumnPair leftValue={'PID'} rightValue={parcel.PID_FORMATTED} />
+        ) : (
+          <></>
+        )}
+        {parcel.PIN != null ? <GridColumnPair leftValue={'PIN'} rightValue={parcel.PIN} /> : <></>}
+        <GridColumnPair leftValue={'Name'} rightValue={parcel.PARCEL_NAME} />
+        {/* 
+        // TODO: Has to come from LTSA
+        <GridColumnPair leftValue={'Legal Description'} rightValue={parcel.} /> 
+        */}
+        <GridColumnPair leftValue={'Class'} rightValue={parcel.PARCEL_CLASS} />
+        <GridColumnPair leftValue={'Plan Number'} rightValue={parcel.PLAN_NUMBER} />
+        <GridColumnPair leftValue={'Owner Type'} rightValue={parcel.OWNER_TYPE} />
+        <GridColumnPair leftValue={'Municipality'} rightValue={parcel.MUNICIPALITY} />
+        <GridColumnPair leftValue={'Regional District'} rightValue={parcel.REGIONAL_DISTRICT} />
+        <GridColumnPair
+          leftValue={'Area'}
+          rightValue={
+            <>
+              <span>{`${parcel.FEATURE_AREA_SQM}`}</span>
+              <MetresSquared />
+            </>
+          }
+        />
+      </Grid>
+    </Box>
+  );
+};
+
+interface ParcelPopupSelectProps {
+  parcelData: ParcelData[];
+  onClick?: (index: number) => void;
+}
+
+const ParcelPopupSelect = (props: ParcelPopupSelectProps) => {
+  const theme = useTheme();
+  const { parcelData, onClick } = props;
+  return (
+    <Box minWidth={'200px'} marginRight={'2em'}>
+      <Typography variant="h4">Select Parcel</Typography>
+      <Typography variant="caption">(PID/PIN)</Typography>
+      <List
+        sx={{
+          overflowY: 'scroll',
+          maxHeight: '300px',
+          border: `3px solid ${theme.palette.divider}`,
+          borderRadius: '10px',
+        }}
+      >
+        {parcelData.map((parcel, index) => (
+          <ListItem
+            key={parcel.PARCEL_FABRIC_POLY_ID}
+            sx={{
+              height: '2em',
+              borderTop: `solid 1px ${theme.palette.divider}`,
+              cursor: 'pointer',
+              '&:hover': {
+                backgroundColor: theme.palette.divider,
+              },
+            }}
+            onClick={() => {
+              onClick(index);
+            }}
+          >
+            <Typography> {parcel.PID_FORMATTED ?? parcel.PIN}</Typography>
+          </ListItem>
+        ))}
+        <ListItem></ListItem>
+      </List>
+    </Box>
   );
 };

--- a/react-app/src/components/map/ParcelPopup.tsx
+++ b/react-app/src/components/map/ParcelPopup.tsx
@@ -8,14 +8,22 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Popup, useMap, useMapEvents } from 'react-leaflet';
 import './parcelPopup.css';
 
+/**
+ * Renders a popup component that displays information about a parcel on the map.
+ * The popup is triggered by a click event on the map and shows details such as parcel ID, name, class, plan number, owner type, municipality, regional district, and area.
+ * If there are multiple parcels at the clicked location, a select component is displayed to allow the user to choose a specific parcel.
+ *
+ * @returns {JSX.Element} The ParcelPopup component.
+ */
 export const ParcelPopup = () => {
-  const [parcelData, setParcelData] = useState<ParcelData[]>(undefined);
+  const [parcelData, setParcelData] = useState<ParcelData[]>(undefined); // All parcels at that click location.
   const [clickPosition, setClickPosition] = useState<LatLng>(null);
-  const [parcelIndex, setParcelIndex] = useState<number>(0);
+  const [parcelIndex, setParcelIndex] = useState<number>(0); // If multiple, which parcel to show info for.
 
   const map = useMap();
   const api = usePimsApi();
 
+  // If click position changes, refresh parcelData
   useEffect(() => {
     getParcelData();
   }, [clickPosition]);
@@ -54,6 +62,7 @@ export const ParcelPopup = () => {
       <Box display={'inline-flex'}>
         {parcelData ? (
           <>
+            {/* Render a list of PIDs/PINs if there's more than one parcel feature here. */}
             {parcelData.length > 1 ? (
               <ParcelPopupSelect
                 parcelData={parcelData}
@@ -77,6 +86,14 @@ export const ParcelPopup = () => {
 interface ParcelLayerDetailsProps {
   parcel: ParcelData;
 }
+
+/**
+ * Renders the details of a parcel layer.
+ *
+ * @param {ParcelLayerDetailsProps} props - The props for the component.
+ * @param {ParcelData} props.parcel - The parcel data to display.
+ * @returns {JSX.Element} The rendered component.
+ */
 const ParcelLayerDetails = (props: ParcelLayerDetailsProps) => {
   const { parcel } = props;
   return (
@@ -120,6 +137,14 @@ interface ParcelPopupSelectProps {
   onClick?: (index: number) => void;
 }
 
+/**
+ * Renders a list of parcels for selection in the ParcelPopup component.
+ *
+ * @param {ParcelPopupSelectProps} props - The props for the ParcelPopupSelect component.
+ * @param {ParcelData[]} props.parcelData - The array of parcel data to be displayed.
+ * @param {function} props.onClick - The function to be called when a parcel is clicked.
+ * @returns {JSX.Element} The rendered ParcelPopupSelect component.
+ */
 const ParcelPopupSelect = (props: ParcelPopupSelectProps) => {
   const theme = useTheme();
   const { parcelData, onClick } = props;

--- a/react-app/src/components/map/parcelPopup.css
+++ b/react-app/src/components/map/parcelPopup.css
@@ -1,7 +1,7 @@
 /* Overriding unsettable popup width of 301px */
 .full-size {
   width: auto;
-  .leaflet-popup-content-wrapper{
+  .leaflet-popup-content-wrapper {
     .leaflet-popup-content {
       width: auto !important;
       min-width: 400px;

--- a/react-app/src/components/map/parcelPopup.css
+++ b/react-app/src/components/map/parcelPopup.css
@@ -1,0 +1,11 @@
+/* Overriding unsettable popup width of 301px */
+.full-size {
+  width: auto;
+  .leaflet-popup-content-wrapper{
+    .leaflet-popup-content {
+      width: auto !important;
+      min-width: 400px;
+      max-width: 800px;
+    }
+  }
+}

--- a/react-app/src/components/text/MetresSquared.tsx
+++ b/react-app/src/components/text/MetresSquared.tsx
@@ -7,22 +7,25 @@ import React from 'react';
  * @returns The component that renders the unit for square meters.
  */
 const MetresSquared = () => (
-  <Typography
-    sx={{
-      display: 'inline',
+  <div
+    style={{
+      display: 'inline-flex',
+      alignItems: 'self-start',
       marginLeft: '0.5em',
     }}
   >
-    m
-    <span
-      style={{
-        verticalAlign: 'super',
-        fontSize: 'small',
-      }}
-    >
-      2
-    </span>
-  </Typography>
+    <Typography variant="body2">
+      m
+      <span
+        style={{
+          verticalAlign: 'super',
+          fontSize: '8pt',
+        }}
+      >
+        2
+      </span>
+    </Typography>
+  </div>
 );
 
 export default MetresSquared;

--- a/react-app/src/hooks/api/useParcelLayerApi.ts
+++ b/react-app/src/hooks/api/useParcelLayerApi.ts
@@ -2,34 +2,55 @@ import { FeatureCollection } from 'geojson';
 import { IFetch } from '../useFetch';
 import { LatLng } from 'leaflet';
 
+export interface ParcelData {
+  PARCEL_FABRIC_POLY_ID: number;
+  PARCEL_NAME: string;
+  PLAN_NUMBER: string;
+  PIN: number;
+  PID: string;
+  PID_FORMATTED: string;
+  PID_NUMBER: number;
+  PARCEL_STATUS: string;
+  PARCEL_CLASS: string;
+  OWNER_TYPE: string;
+  PARCEL_START_DATE: string;
+  MUNICIPALITY: string;
+  REGIONAL_DISTRICT: string;
+  WHEN_UPDATED: string;
+  FEATURE_AREA_SQM: number;
+  FEATURE_LENGTH_M: number;
+  OBJECTID: number;
+  SE_ANNO_CAD_DATA: unknown;
+}
+
 const useParcelLayerApi = (absoluteFetch: IFetch) => {
   const getFeatureUrl =
     'https://openmaps.gov.bc.ca/geo/pub/WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW/wfs?service=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW';
 
-  const getParcelByPid = async (pid: string) => {
+  const getParcelsByPid = async (pid: string) => {
     const formattedPid = pid.replace(/-/g, '');
-    const finalUrl = `${getFeatureUrl}&srsName=EPSG:4326&count=1&CQL_FILTER=PID_NUMBER=${+formattedPid}`;
+    const finalUrl = `${getFeatureUrl}&srsName=EPSG:4326&CQL_FILTER=PID_NUMBER=${+formattedPid}`;
     const { parsedBody } = await absoluteFetch.get(finalUrl, {}, { headers: {} });
     return parsedBody as FeatureCollection;
   };
 
-  const getParcelByPin = async (pin: string) => {
+  const getParcelsByPin = async (pin: string) => {
     const formattedPin = pin.replace(/-/g, '');
-    const finalUrl = `${getFeatureUrl}&srsName=EPSG:4326&count=1&CQL_FILTER=PIN=${+formattedPin}`;
+    const finalUrl = `${getFeatureUrl}&srsName=EPSG:4326&CQL_FILTER=PIN=${+formattedPin}`;
     const { parsedBody } = await absoluteFetch.get(finalUrl, {}, { headers: {} });
     return parsedBody as FeatureCollection;
   };
 
-  const getParcelByLatLng = async (latlng: LatLng) => {
-    const finalUrl = `${getFeatureUrl}&srsName=EPSG:4326&count=1&&cql_filter=CONTAINS(SHAPE, SRID=4326;POINT ( ${latlng.lng} ${latlng.lat}))`;
+  const getParcelsByLatLng = async (latlng: LatLng) => {
+    const finalUrl = `${getFeatureUrl}&srsName=EPSG:4326&cql_filter=CONTAINS(SHAPE, SRID=4326;POINT ( ${latlng.lng} ${latlng.lat}))`;
     const { parsedBody } = await absoluteFetch.get(finalUrl, {}, { headers: {} });
     return parsedBody as FeatureCollection;
   };
 
   return {
-    getParcelByPid,
-    getParcelByPin,
-    getParcelByLatLng,
+    getParcelByPid: getParcelsByPid,
+    getParcelByPin: getParcelsByPin,
+    getParcelByLatLng: getParcelsByLatLng,
   };
 };
 

--- a/react-app/src/pages/DevZone.tsx
+++ b/react-app/src/pages/DevZone.tsx
@@ -4,7 +4,7 @@ import ParcelMap from '@/components/map/ParcelMap';
 import React from 'react';
 
 const Dev = () => {
-  return <ParcelMap height="100%" loadProperties />;
+  return <ParcelMap height="100%" loadProperties={false} />;
 };
 
 export default Dev;


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1590](https://citz-imb.atlassian.net/browse/PIMS-1590?atlOrigin=eyJpIjoiNTMwZWMyNzUwMGQwNGE4ZDg1OTFhOGM2YzgyN2M2ODciLCJwIjoiaiJ9)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Fixed some styling issues with the MapPropertyDetails (MetresSquared fits in grids better)
- Added more info to view on the parcel layer popup
- Changed the state control for the popup so the map doesn't rerender upon click
- Added a PID list to the popup when a parcel has multiple parcels (aka a strata)
- Changed the hooks so they return more than one feature from the parcel layer

## Testing
- Navigate to /dev and click on parcels

I noticed that there isn't often differences in the parcel layer data when many parcels are stacked, like in a strata.
This popup might benefit from some changes in UI if it seems too repetitive. I want to see how the LTSA and BCA data fits in first though.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
