### PR TITLE
PIMS-1597 PID Formatting & Map Adjustments

### DIFF
--- a/react-app/src/components/form/TextFormField.tsx
+++ b/react-app/src/components/form/TextFormField.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { TextField, TextFieldProps } from '@mui/material';
 import { Controller, FieldValues, RegisterOptions, useFormContext } from 'react-hook-form';
+import { pidFormatter } from '@/utilities/formatters';
 
 type TextFormFieldProps = {
   defaultVal?: string;
   name: string;
   label: string;
   numeric?: boolean;
+  isPid?: boolean;
   rules?: Omit<
     RegisterOptions<FieldValues, string>,
     'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'
@@ -15,7 +17,7 @@ type TextFormFieldProps = {
 
 const TextFormField = (props: TextFormFieldProps) => {
   const { control, setValue } = useFormContext();
-  const { name, label, rules, numeric, defaultVal, ...restProps } = props;
+  const { name, label, rules, numeric, isPid, defaultVal, ...restProps } = props;
   return (
     <Controller
       control={control}
@@ -24,19 +26,27 @@ const TextFormField = (props: TextFormFieldProps) => {
       render={({ field: { onChange, value }, fieldState: { error } }) => {
         return (
           <TextField
-            {...restProps}
             onBlur={(event) => {
               if (numeric && parseFloat(event.currentTarget.value)) {
                 setValue(name, parseFloat(event.currentTarget.value));
               }
             }}
             onChange={(event) => {
-              if (numeric === undefined) {
+              if (
+                isPid &&
+                (event.target.value === '' || /^[0-9-]*\.?[0-9]{0,2}$/.test(event.target.value))
+              ) {
+                event.target.value = pidFormatter(parseInt(event.target.value.replace(/-/g, '')));
                 onChange(event);
                 return;
-              }
-              if (event.target.value === '' || /^[0-9]*\.?[0-9]{0,2}$/.test(event.target.value)) {
+              } else if (
+                numeric &&
+                (event.target.value === '' || /^[0-9]*\.?[0-9]{0,2}$/.test(event.target.value))
+              ) {
                 onChange(event);
+              } else if (numeric === undefined) {
+                onChange(event);
+                return;
               }
             }}
             value={value ?? defaultVal}
@@ -45,6 +55,7 @@ const TextFormField = (props: TextFormFieldProps) => {
             type={'text'}
             error={!!error && !!error.message}
             helperText={error?.message}
+            {...restProps}
           />
         );
       }}

--- a/react-app/src/components/form/TextFormField.tsx
+++ b/react-app/src/components/form/TextFormField.tsx
@@ -32,10 +32,7 @@ const TextFormField = (props: TextFormFieldProps) => {
               }
             }}
             onChange={(event) => {
-              if (
-                isPid &&
-                (event.target.value === '' || /^[0-9-]*\.?[0-9]{0,2}$/.test(event.target.value))
-              ) {
+              if (isPid) {
                 event.target.value = pidFormatter(parseInt(event.target.value.replace(/-/g, '')));
                 onChange(event);
                 return;

--- a/react-app/src/components/map/ParcelMap.tsx
+++ b/react-app/src/components/map/ParcelMap.tsx
@@ -85,7 +85,7 @@ const ParcelMap = (props: ParcelMapProps) => {
           ]}
           dragging={movable}
           zoomControl={zoomable}
-          scrollWheelZoom={zoomable}
+          scrollWheelZoom={false}
           touchZoom={zoomable}
           boxZoom={zoomable}
           doubleClickZoom={zoomable}

--- a/react-app/src/components/map/ParcelMap.tsx
+++ b/react-app/src/components/map/ParcelMap.tsx
@@ -18,6 +18,7 @@ type ParcelMapProps = {
   popupSize?: 'small' | 'large';
   scrollOnClick?: boolean;
   zoomOnScroll?: boolean;
+  hideControls?: boolean;
 } & PropsWithChildren;
 
 export const SelectedMarkerContext = createContext(null);
@@ -62,6 +63,7 @@ const ParcelMap = (props: ParcelMapProps) => {
     popupSize,
     scrollOnClick,
     zoomOnScroll = true,
+    hideControls = false,
   } = props;
 
   return (
@@ -74,9 +76,13 @@ const ParcelMap = (props: ParcelMapProps) => {
       <Box height={height}>
         <LoadingCover show={loading} />
         {/* All map controls fit here */}
-        <ControlsGroup position="topleft">
-          <FilterControl setFilter={setFilter} />
-        </ControlsGroup>
+        {hideControls ? (
+          <></>
+        ) : (
+          <ControlsGroup position="topleft">
+            <FilterControl setFilter={setFilter} />
+          </ControlsGroup>
+        )}
         <MapPropertyDetails property={selectedMarker} />
         <MapContainer
           style={{ height: '100%' }}

--- a/react-app/src/components/map/ParcelMap.tsx
+++ b/react-app/src/components/map/ParcelMap.tsx
@@ -17,6 +17,7 @@ type ParcelMapProps = {
   loadProperties?: boolean;
   popupSize?: 'small' | 'large';
   scrollOnClick?: boolean;
+  zoomOnScroll?: boolean;
 } & PropsWithChildren;
 
 export const SelectedMarkerContext = createContext(null);
@@ -60,6 +61,7 @@ const ParcelMap = (props: ParcelMapProps) => {
     loadProperties = false,
     popupSize,
     scrollOnClick,
+    zoomOnScroll = true,
   } = props;
 
   return (
@@ -85,7 +87,7 @@ const ParcelMap = (props: ParcelMapProps) => {
           ]}
           dragging={movable}
           zoomControl={zoomable}
-          scrollWheelZoom={false}
+          scrollWheelZoom={zoomOnScroll}
           touchZoom={zoomable}
           boxZoom={zoomable}
           doubleClickZoom={zoomable}

--- a/react-app/src/components/projects/DisposalPropertiesSearchTable.tsx
+++ b/react-app/src/components/projects/DisposalPropertiesSearchTable.tsx
@@ -8,6 +8,7 @@ import { GridColDef, DataGrid } from '@mui/x-data-grid';
 import { useState, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import React from 'react';
+import { pidFormatter } from '@/utilities/formatters';
 
 interface IDisposalProjectSearch {
   rows: any[];
@@ -36,7 +37,7 @@ const DisposalProjectSearch = (props: IDisposalProjectSearch) => {
     }
 
     if (input.PID) {
-      return `${input.Type} - PID: ${input.PID}`;
+      return `${input.Type} - PID: ${pidFormatter(input.PID)}`;
     } else if (input.PIN) {
       return `${input.Type} - PIN: ${input.PIN}`;
     } else if (input.Address1) {
@@ -67,7 +68,7 @@ const DisposalProjectSearch = (props: IDisposalProjectSearch) => {
           >
             {params.row.Type === 'Building' && params.row.Address1
               ? params.row.Address1
-              : params.row.PID}
+              : pidFormatter(params.row.PID)}
           </Link>
         ) as ReactNode;
       },

--- a/react-app/src/components/projects/DisposalPropertiesSimpleTable.tsx
+++ b/react-app/src/components/projects/DisposalPropertiesSimpleTable.tsx
@@ -1,4 +1,6 @@
+import { PropertyTypes } from '@/constants/propertyTypes';
 import { Agency } from '@/hooks/api/useAgencyApi';
+import { pidFormatter } from '@/utilities/formatters';
 import { Box, Typography } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import React from 'react';
@@ -17,7 +19,10 @@ const DisposalPropertiesTable = (props: IDisposalPropertiesTable) => {
       field: 'PID/Address',
       headerName: 'PID/Address',
       flex: 1,
-      valueGetter: (value, row) => row.PID ?? row.PIN ?? row.Address1,
+      valueGetter: (value, row) =>
+        row.PropertyTypeId === PropertyTypes.BUILDING && row.Address1
+          ? row.Address1
+          : pidFormatter(row.PID) ?? row.PIN,
     },
     {
       field: 'Agency',

--- a/react-app/src/components/property/AddProperty.tsx
+++ b/react-app/src/components/property/AddProperty.tsx
@@ -171,7 +171,7 @@ const AddProperty = () => {
               const addParcel: ParcelAdd = {
                 ...formValues,
                 LandArea: parseFloatOrNull(formValues.LandArea),
-                PID: parseIntOrNull(formValues.PID),
+                PID: parseIntOrNull(formValues.PID.replace(/-/g, '')),
                 PIN: parseIntOrNull(formValues.PIN),
                 PropertyTypeId: 0,
                 AgencyId: userContext.pimsUser.data.AgencyId,
@@ -190,7 +190,7 @@ const AddProperty = () => {
               const formValues = formMethods.getValues();
               const addBuilding: BuildingAdd = {
                 ...formValues,
-                PID: parseIntOrNull(formValues.PID),
+                PID: parseIntOrNull(formValues.PID.replace(/-/g, '')),
                 PIN: parseIntOrNull(formValues.PIN),
                 RentableArea: parseFloatOrNull(formValues.RentableArea),
                 TotalArea: parseFloatOrNull(formValues.TotalArea),

--- a/react-app/src/components/property/PropertyDetail.tsx
+++ b/react-app/src/components/property/PropertyDetail.tsx
@@ -256,6 +256,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
           mapRef={setMap}
           movable={false}
           zoomable={false}
+          zoomOnScroll={false}
           popupSize="small"
         >
           <Box display={'flex'} alignItems={'center'} justifyContent={'center'} height={'100%'}>

--- a/react-app/src/components/property/PropertyDetail.tsx
+++ b/react-app/src/components/property/PropertyDetail.tsx
@@ -258,6 +258,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
           zoomable={false}
           zoomOnScroll={false}
           popupSize="small"
+          hideControls
         >
           <Box display={'flex'} alignItems={'center'} justifyContent={'center'} height={'100%'}>
             <Room

--- a/react-app/src/components/property/PropertyDetail.tsx
+++ b/react-app/src/components/property/PropertyDetail.tsx
@@ -21,7 +21,7 @@ import {
 } from './PropertyDialog';
 import { PropertyType } from './PropertyForms';
 import MetresSquared from '@/components/text/MetresSquared';
-import { zeroPadPID } from '@/utilities/formatters';
+import { pidFormatter, zeroPadPID } from '@/utilities/formatters';
 import ParcelMap from '../map/ParcelMap';
 import { Map } from 'leaflet';
 import { Room } from '@mui/icons-material';
@@ -135,6 +135,8 @@ const PropertyDetail = (props: IPropertyDetail) => {
 
   const customFormatter = (key: any, val: any) => {
     switch (key) {
+      case 'PID':
+        return <Typography>{pidFormatter(val)}</Typography>;
       case 'Agency':
         return <Typography>{val.Name}</Typography>;
       case 'Classification':

--- a/react-app/src/components/property/PropertyDialog.tsx
+++ b/react-app/src/components/property/PropertyDialog.tsx
@@ -15,7 +15,7 @@ import {
   PropertyType,
   NetBookValue,
 } from './PropertyForms';
-import { parseFloatOrNull, parseIntOrNull, zeroPadPID } from '@/utilities/formatters';
+import { parseFloatOrNull, parseIntOrNull, pidFormatter } from '@/utilities/formatters';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
 
 interface IParcelInformationEditDialog {
@@ -60,7 +60,7 @@ export const ParcelInformationEditDialog = (props: IParcelInformationEditDialog)
     infoFormMethods.reset({
       NotOwned: initialValues?.NotOwned,
       Address1: initialValues?.Address1,
-      PID: initialValues?.PID ? zeroPadPID(initialValues.PID) : '',
+      PID: initialValues?.PID ? pidFormatter(initialValues.PID) : '',
       PIN: String(initialValues?.PIN ?? ''),
       Postal: initialValues?.Postal,
       AdministrativeAreaId: initialValues?.AdministrativeAreaId,
@@ -80,7 +80,7 @@ export const ParcelInformationEditDialog = (props: IParcelInformationEditDialog)
         const isValid = await infoFormMethods.trigger();
         if (isValid) {
           const formValues: any = { ...infoFormMethods.getValues(), Id: initialValues.Id };
-          formValues.PID = parseIntOrNull(formValues.PID);
+          formValues.PID = parseIntOrNull(formValues.PID.replace(/-/g, ''));
           formValues.PIN = parseIntOrNull(formValues.PIN);
           formValues.LandArea = parseFloatOrNull(formValues.LandArea);
           submit(initialValues.Id, formValues).then(() => postSubmit());
@@ -167,7 +167,7 @@ export const BuildingInformationEditDialog = (props: IBuildingInformationEditDia
     infoFormMethods.reset({
       Address1: initialValues?.Address1,
       PIN: String(initialValues?.PIN ?? ''),
-      PID: initialValues?.PID ? zeroPadPID(initialValues.PID) : '',
+      PID: initialValues?.PID ? pidFormatter(initialValues.PID) : '',
       Postal: initialValues?.Postal,
       AdministrativeAreaId: initialValues?.AdministrativeAreaId,
       IsSensitive: initialValues?.IsSensitive,
@@ -195,7 +195,7 @@ export const BuildingInformationEditDialog = (props: IBuildingInformationEditDia
         const isValid = await infoFormMethods.trigger();
         if (isValid) {
           const formValues: any = { ...infoFormMethods.getValues(), Id: initialValues.Id };
-          formValues.PID = parseIntOrNull(formValues.PID);
+          formValues.PID = parseIntOrNull(formValues.PID.replace(/-/g, ''));
           formValues.PIN = parseIntOrNull(formValues.PIN);
           formValues.TotalArea = parseFloatOrNull(formValues.TotalArea);
           formValues.RentableArea = parseFloatOrNull(formValues.RentableArea);

--- a/react-app/src/components/property/PropertyForms.tsx
+++ b/react-app/src/components/property/PropertyForms.tsx
@@ -252,6 +252,7 @@ export const GeneralInformationForm = (props: IGeneralInformationForm) => {
             mapRef={setMap}
             movable={true}
             zoomable={true}
+            zoomOnScroll={false}
             popupSize="small"
           >
             <Box display={'flex'} alignItems={'center'} justifyContent={'center'} height={'100%'}>

--- a/react-app/src/components/property/PropertyForms.tsx
+++ b/react-app/src/components/property/PropertyForms.tsx
@@ -254,6 +254,7 @@ export const GeneralInformationForm = (props: IGeneralInformationForm) => {
             zoomable={true}
             zoomOnScroll={false}
             popupSize="small"
+            hideControls
           >
             <Box display={'flex'} alignItems={'center'} justifyContent={'center'} height={'100%'}>
               <Room

--- a/react-app/src/components/property/PropertyForms.tsx
+++ b/react-app/src/components/property/PropertyForms.tsx
@@ -182,16 +182,19 @@ export const GeneralInformationForm = (props: IGeneralInformationForm) => {
             fullWidth
             name={'PID'}
             label={'PID'}
-            numeric
+            isPid
             onBlur={(event) => {
-              map.closePopup();
-              api.parcelLayer
-                .getParcelByPid(event.target.value)
-                .then(handleFeatureCollectionResponse);
+              // Only do this if there's a value here
+              if (event.target.value) {
+                map.closePopup();
+                api.parcelLayer
+                  .getParcelByPid(event.target.value)
+                  .then(handleFeatureCollectionResponse);
+              }
             }}
             rules={{
               validate: (val, formVals) =>
-                (String(val).length <= 9 &&
+                (String(val.replace(/-/g, '')).length <= 9 &&
                   (String(val).length > 0 ||
                     String(formVals['PIN']).length > 0 ||
                     propertyType === 'Building')) ||
@@ -206,10 +209,13 @@ export const GeneralInformationForm = (props: IGeneralInformationForm) => {
             name={'PIN'}
             label={'PIN'}
             onBlur={(event) => {
-              map.closePopup();
-              api.parcelLayer
-                .getParcelByPin(event.target.value)
-                .then(handleFeatureCollectionResponse);
+              // Only do this if there's a value here
+              if (event.target.value) {
+                map.closePopup();
+                api.parcelLayer
+                  .getParcelByPin(event.target.value)
+                  .then(handleFeatureCollectionResponse);
+              }
             }}
             rules={{
               validate: (val, formVals) =>
@@ -244,8 +250,8 @@ export const GeneralInformationForm = (props: IGeneralInformationForm) => {
           <ParcelMap
             height={'500px'}
             mapRef={setMap}
-            movable={false}
-            zoomable={false}
+            movable={true}
+            zoomable={true}
             popupSize="small"
           >
             <Box display={'flex'} alignItems={'center'} justifyContent={'center'} height={'100%'}>

--- a/react-app/src/utilities/formatters.tsx
+++ b/react-app/src/utilities/formatters.tsx
@@ -96,7 +96,7 @@ export const parseFloatOrNull = (flt: string | number) => {
 };
 
 export const zeroPadPID = (pid: number | string): string => {
-  return String(pid).padStart(9, '0');
+  return String(pid).replace(/[^\d]/g, '').padStart(9, '0');
 };
 
 export const pidFormatter = (pid: number | string): string => {

--- a/react-app/src/utilities/formatters.tsx
+++ b/react-app/src/utilities/formatters.tsx
@@ -100,5 +100,6 @@ export const zeroPadPID = (pid: number | string): string => {
 };
 
 export const pidFormatter = (pid: number | string): string => {
+  if (pid == null) return '';
   return zeroPadPID(pid).match(/\d{3}/g).join('-');
 };


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1567](https://citz-imb.atlassian.net/browse/PIMS-1597?atlOrigin=eyJpIjoiY2QwMWZkMjVkN2YxNDA4OGEzYjM1NzI5MmI4YjI3MzAiLCJwIjoiaiJ9)

## Changes
- Used pidFormatter utility where possible to make sure PID is always presented with hyphens
- Modified the PID text fields to format as values are typed in
  - I felt this was a little hacky, but it seems to work.
- Addressed concerns with map on property pages not zooming/dragging. Users had an issue with accidentally zooming as they scrolled, so I added a prop that focus on that directly. Map on property pages now can zoom and drag, but not from scrolling.
- Added ParcelMap prop to hide the controls. Because they were moved out of the InventoryLayer, they were visible on pages that didn't load properties. This prop hides those controls if wanted.

## Testing
- Find areas where PID is used. Make sure it is formatted correctly.
- Test PID form fields to make sure the function is as desired.
<!-- PROVIDE BELOW an explanation of your changes -->

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
