### PR TITLE
Notification services query runner maxing out conn pool fix

### DIFF
--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -133,7 +133,10 @@ const insertProjectNotificationQueue = async (
     ProjectId: project.Id,
     ToAgencyId: agency?.Id,
   };
-
+  if (queryRunner === undefined) {
+    //If no arg passed we spawned a new query runner and we must release that!
+    await query.release();
+  }
   const insertedNotif = await query.manager.save(NotificationQueue, queueObject);
   return insertedNotif;
 };
@@ -207,7 +210,14 @@ const generateProjectNotifications = async (
         .getMany();
       agencies.forEach((agc) =>
         returnNotifications.push(
-          insertProjectNotificationQueue(template, projStatusNotif, project, agc),
+          insertProjectNotificationQueue(
+            template,
+            projStatusNotif,
+            project,
+            agc,
+            undefined,
+            queryRunner,
+          ),
         ),
       );
     } else if (template.Audience == NotificationAudience.ParentAgencies) {
@@ -234,7 +244,14 @@ const generateProjectNotifications = async (
         .getMany();
       agencies.forEach((agc) =>
         returnNotifications.push(
-          insertProjectNotificationQueue(template, projStatusNotif, project, agc),
+          insertProjectNotificationQueue(
+            template,
+            projStatusNotif,
+            project,
+            agc,
+            undefined,
+            queryRunner,
+          ),
         ),
       );
     } else if (template.Audience == NotificationAudience.WatchingAgencies) {
@@ -256,7 +273,14 @@ const generateProjectNotifications = async (
         .getMany();
       agencies.forEach((agc) =>
         returnNotifications.push(
-          insertProjectNotificationQueue(template, projStatusNotif, project, agc),
+          insertProjectNotificationQueue(
+            template,
+            projStatusNotif,
+            project,
+            agc,
+            undefined,
+            queryRunner,
+          ),
         ),
       );
     } else if (template.Audience == NotificationAudience.Default) {
@@ -271,6 +295,9 @@ const generateProjectNotifications = async (
         ),
       );
     }
+  }
+  if (queryRunner === undefined) {
+    await query.release();
   }
   return await Promise.all(returnNotifications);
 };
@@ -313,6 +340,10 @@ const sendNotification = async (
       ...notification,
       Status: NotificationStatus.Failed,
     });
+  } finally {
+    if (queryRunner === undefined) {
+      await query.release();
+    }
   }
 };
 

--- a/express-api/tests/unit/services/notifications/notificationServices.test.ts
+++ b/express-api/tests/unit/services/notifications/notificationServices.test.ts
@@ -56,6 +56,7 @@ const _statusNotifFind = jest.fn().mockImplementation(async (options) => [
 
 jest.spyOn(AppDataSource, 'createQueryRunner').mockReturnValue({
   ...jest.requireActual('@/appDataSource').createQueryRunner,
+  release: () => {},
   manager: {
     find: async <Entity extends ObjectLiteral>(
       entityClass: EntityTarget<Entity>,


### PR DESCRIPTION
## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  

Fixed an issue where certain notification insertions were spawning new connections that would not be released upon function exit. This was happening because the queryRunner is an optional parameter to these functions, and it was not being passed in some instances of insertProjectNotificationQueue. There are a few functions that also take this as an arg, and I've applied the same fix to each so that the connection will be released when they spawn their own in the case of a missing arg. 

Admittedly, I don't know if we even need this arg if we don't want notifications wrapped into the same transaction block as the rest of the project update, but regardless this should no longer lock up the pool.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
