### PR TITLE
PIMS-1714: Hide edit/delete buttons for Auditor Role

### DIFF
--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import DataCard from '../display/DataCard';
 import { Box, Checkbox, FormControlLabel, FormGroup, Typography, Skeleton } from '@mui/material';
 import DeleteDialog from '../dialog/DeleteDialog';
@@ -22,6 +22,8 @@ import useGroupedAgenciesApi from '@/hooks/api/useGroupedAgenciesApi';
 import { enumReverseLookup } from '@/utilities/helperFunctions';
 import { AgencyResponseType } from '@/constants/agencyResponseTypes';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
+import { Roles } from '@/constants/roles';
+import { AuthContext } from '@/contexts/authContext';
 
 interface IProjectDetail {
   onClose: () => void;
@@ -41,6 +43,7 @@ interface ProjectInfo extends Project {
 const ProjectDetail = (props: IProjectDetail) => {
   const navigate = useNavigate();
   const { id } = useParams();
+  const { keycloak } = useContext(AuthContext);
   const api = usePimsApi();
   // const theme = useTheme();
   const { data, refreshData, isLoading } = useDataLoader(() =>
@@ -53,6 +56,8 @@ const ProjectDetail = (props: IProjectDetail) => {
       navigate('/'); // look into maybe using redirect
     }
   }, [data]);
+
+  const isAuditor = keycloak.hasRoles([Roles.AUDITOR]);
 
   const { data: tasks, loadOnce: loadTasks } = useDataLoader(() => api.lookup.getTasks());
   loadTasks();
@@ -159,6 +164,7 @@ const ProjectDetail = (props: IProjectDetail) => {
           deleteTitle={'Delete project'}
           onDeleteClick={() => setOpenDeleteDialog(true)}
           onBackClick={() => props.onClose()}
+          disableDelete={isAuditor}
         />
         <DataCard
           loading={isLoading}
@@ -167,12 +173,14 @@ const ProjectDetail = (props: IProjectDetail) => {
           id={projectInformation}
           title={projectInformation}
           onEdit={() => setOpenProjectInfoDialog(true)}
+          disableEdit={isAuditor}
         />
         <DataCard
           values={undefined}
           id={disposalProperties}
           title={disposalProperties}
           onEdit={() => setOpenDisposalPropDialog(true)}
+          disableEdit={isAuditor}
         >
           {isLoading ? (
             <Skeleton variant="rectangular" height={'150px'} />
@@ -194,6 +202,7 @@ const ProjectDetail = (props: IProjectDetail) => {
           title={financialInformation}
           id={financialInformation}
           onEdit={() => setOpenFinancialInfoDialog(true)}
+          disableEdit={isAuditor}
         />
         <DataCard
           loading={isLoading}
@@ -201,6 +210,7 @@ const ProjectDetail = (props: IProjectDetail) => {
           values={undefined}
           id={agencyInterest}
           onEdit={() => setOpenAgencyInterestDialog(true)}
+          disableEdit={isAuditor}
         >
           {!data?.parsedBody.AgencyResponses?.length ? ( //TODO: Logic will depend on precense of agency responses
             <Box display={'flex'} justifyContent={'center'}>

--- a/react-app/src/components/property/PropertyDetail.tsx
+++ b/react-app/src/components/property/PropertyDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import DetailViewNavigation from '../display/DetailViewNavigation';
 import { Box, Skeleton, Typography } from '@mui/material';
 import DataCard from '../display/DataCard';
@@ -27,6 +27,8 @@ import { Map } from 'leaflet';
 import { Room } from '@mui/icons-material';
 import TitleOwnership from '../ltsa/TitleOwnership';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
+import { AuthContext } from '@/contexts/authContext';
+import { Roles } from '@/constants/roles';
 
 interface IPropertyDetail {
   onClose: () => void;
@@ -35,6 +37,7 @@ interface IPropertyDetail {
 const PropertyDetail = (props: IPropertyDetail) => {
   const navigate = useNavigate();
   const params = useParams();
+  const { keycloak } = useContext(AuthContext);
   const parcelId = isNaN(Number(params.parcelId)) ? null : Number(params.parcelId);
   const buildingId = isNaN(Number(params.buildingId)) ? null : Number(params.buildingId);
   const api = usePimsApi();
@@ -73,6 +76,9 @@ const PropertyDetail = (props: IPropertyDetail) => {
   const { data: relatedBuildings, refreshData: refreshRelated } = useDataLoader(
     () => parcel?.PID && api.buildings.getBuildings({ pid: parcel.PID, includeRelations: true }),
   );
+
+  const isAuditor = keycloak.hasRoles([Roles.AUDITOR]);
+
   const refreshEither = () => {
     if (parcelId) {
       refreshParcel();
@@ -238,6 +244,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
       >
         <DetailViewNavigation
           navigateBackTitle={'Back to Property Overview'}
+          disableDelete={isAuditor}
           deleteTitle={`Delete ${buildingOrParcel}`}
           onDeleteClick={() => setOpenDeleteDialog(true)}
           onBackClick={() => props.onClose()}
@@ -249,6 +256,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
           values={mainInformation}
           title={`${buildingOrParcel} Information`}
           onEdit={() => setOpenInformationDialog(true)}
+          disableEdit={isAuditor}
         />
         {buildingOrParcel === 'Parcel' && (
           <DataCard
@@ -267,6 +275,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
           values={undefined}
           title={`${buildingOrParcel} Net Book Value`}
           onEdit={() => setOpenNetBookDialog(true)}
+          disableEdit={isAuditor}
         >
           <PropertyNetValueTable rows={netBookValues} />
         </DataCard>
@@ -276,6 +285,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
           values={undefined}
           title={'Assessed Value'}
           onEdit={() => setOpenAssessedValueDialog(true)}
+          disableEdit={isAuditor}
         >
           <PropertyAssessedValueTable
             rows={assessedValues}


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1714: ](https://citz-imb.atlassian.net/browse/PIMS-1714)

<!-- PROVIDE BELOW an explanation of your changes -->
Hiding the delete and edit buttons on the property details and the project details pages when the user has the "Auditor" role.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
