### PR TITLE
PIMS-1719: Send notifications for access request

### DIFF
--- a/express-api/src/constants/config.ts
+++ b/express-api/src/constants/config.ts
@@ -16,6 +16,9 @@ const config = {
     password: process.env.LTSA_PASSWORD,
   },
   accessRequest: {
+    // In previous PIMS, this is also a hardcoded value.
+    // May be more robust to make this an environment variable or even a name, but I imagine these values
+    // will basically never change.
     notificationTemplate: 15,
     notificationTemplateRPD: 17,
   },

--- a/express-api/src/constants/config.ts
+++ b/express-api/src/constants/config.ts
@@ -15,6 +15,10 @@ const config = {
     username: process.env.LTSA_USERNAME,
     password: process.env.LTSA_PASSWORD,
   },
+  accessRequest: {
+    notificationTemplate: 15,
+    notificationTemplateRPD: 17,
+  },
 };
 
 const getConfig = () => {

--- a/express-api/src/controllers/users/usersController.ts
+++ b/express-api/src/controllers/users/usersController.ts
@@ -119,7 +119,10 @@ export const submitUserAccessRequest = async (req: Request, res: Response) => {
     role: 'Administrator',
     agencyId: user.AgencyId,
   });
-
+  const adminEmails = adminUsers.map((user) => user.Email);
+  while (adminEmails.join(';').length > 500) {
+    adminEmails.shift();
+  }
   try {
     const notif = await notificationServices.generateAccessRequestNotification(
       {
@@ -127,7 +130,7 @@ export const submitUserAccessRequest = async (req: Request, res: Response) => {
         LastName: user.LastName,
       },
       config.accessRequest.notificationTemplate,
-      adminUsers.map((user) => user.Email).join(';'),
+      adminEmails.join(';'),
     );
     const notifRPD = await notificationServices.generateAccessRequestNotification(
       {

--- a/express-api/src/controllers/users/usersController.ts
+++ b/express-api/src/controllers/users/usersController.ts
@@ -115,23 +115,9 @@ export const submitUserAccessRequest = async (req: Request, res: Response) => {
   );
   const config = getConfig();
   const user = await userServices.getUser(req.user.preferred_username);
-  const adminUsers = await userServices.getUsers({
-    role: 'Administrator',
-    agencyId: user.AgencyId,
-  });
-  const adminEmails = adminUsers.map((user) => user.Email);
-  while (adminEmails.join(';').length > 500) {
-    adminEmails.shift();
-  }
+  //Note: old PIMS has code that suggests administrator users should be enumerated here and sent notifications.
+  //However, current POs no longer desire this functionality. Just the one notification to the common RPD mailbox is fine.
   try {
-    const notif = await notificationServices.generateAccessRequestNotification(
-      {
-        FirstName: user.FirstName,
-        LastName: user.LastName,
-      },
-      config.accessRequest.notificationTemplate,
-      adminEmails.join(';'),
-    );
     const notifRPD = await notificationServices.generateAccessRequestNotification(
       {
         FirstName: user.FirstName,
@@ -139,7 +125,6 @@ export const submitUserAccessRequest = async (req: Request, res: Response) => {
       },
       config.accessRequest.notificationTemplateRPD,
     );
-    await notificationServices.sendNotification(notif, req.user);
     await notificationServices.sendNotification(notifRPD, req.user);
   } catch (e) {
     logger.error(`Failed to deliver access request notification: ${e.message}`);

--- a/express-api/src/services/ches/chesServices.ts
+++ b/express-api/src/services/ches/chesServices.ts
@@ -158,7 +158,7 @@ const sendEmailAsync = async (email: IEmail, user: SSOUser): Promise<IEmailSentR
         .split(';')
         .map((email) => email.trim())
         .filter((email) => !!email)
-    : [user.email];
+    : email.to?.filter((a) => !!a);
   email.cc = cfg.ches.overrideTo ? [] : email.cc?.filter((a) => !!a);
   email.bcc = cfg.ches.overrideTo ? [] : email.bcc?.filter((a) => !!a);
 

--- a/express-api/src/services/ches/chesServices.ts
+++ b/express-api/src/services/ches/chesServices.ts
@@ -127,10 +127,7 @@ export interface IEmailSentResponse {
   txId: string;
 }
 
-const sendEmailAsync = async (
-  email: IEmail,
-  user?: SSOUser,
-): Promise<IEmailSentResponse | null> => {
+const sendEmailAsync = async (email: IEmail, user: SSOUser): Promise<IEmailSentResponse | null> => {
   const cfg = config();
   if (email == null) {
     throw new ErrorWithCode('Null argument for email.', 400);
@@ -139,7 +136,7 @@ const sendEmailAsync = async (
   email.from = email.from ?? cfg.ches.defaultFrom;
 
   if (cfg.ches.bccCurrentUser) {
-    email.bcc = [user?.email, ...(email.bcc ?? [])];
+    email.bcc = [user.email, ...(email.bcc ?? [])];
   }
   if (cfg.ches.usersToBcc && typeof cfg.ches.usersToBcc === 'string') {
     email.bcc = [
@@ -160,8 +157,8 @@ const sendEmailAsync = async (
     ? cfg.ches.overrideTo
         .split(';')
         .map((email) => email.trim())
-        .filter((email) => email !== '') // needed to add this because without it, we would be sending an array with the original to email along with an empty string
-    : email.to?.filter((a) => !!a);
+        .filter((email) => !!email)
+    : [user.email];
   email.cc = cfg.ches.overrideTo ? [] : email.cc?.filter((a) => !!a);
   email.bcc = cfg.ches.overrideTo ? [] : email.bcc?.filter((a) => !!a);
 

--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -307,7 +307,7 @@ const generateProjectNotifications = async (
 
 const sendNotification = async (
   notification: NotificationQueue,
-  user?: SSOUser,
+  user: SSOUser,
   queryRunner?: QueryRunner,
 ) => {
   const query = queryRunner ?? AppDataSource.createQueryRunner();

--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -18,7 +18,7 @@ import { SSOUser } from '@bcgov/citz-imb-sso-express';
 import { ProjectAgencyResponse } from '@/typeorm/Entities/ProjectAgencyResponse';
 import logger from '@/utilities/winstonLogger';
 
-interface AccessRequestData {
+export interface AccessRequestData {
   FirstName: string;
   LastName: string;
 }
@@ -307,16 +307,16 @@ const generateProjectNotifications = async (
 
 const sendNotification = async (
   notification: NotificationQueue,
-  user: SSOUser,
+  user?: SSOUser,
   queryRunner?: QueryRunner,
 ) => {
   const query = queryRunner ?? AppDataSource.createQueryRunner();
   let retNotif: NotificationQueue = null;
   try {
     const email: IEmail = {
-      to: notification.To.split(';').map((a) => a.trim()),
-      cc: notification.Cc.split(';').map((a) => a.trim()),
-      bcc: notification.Bcc.split(';').map((a) => a.trim()),
+      to: notification.To?.split(';').map((a) => a.trim()) ?? [],
+      cc: notification.Cc?.split(';').map((a) => a.trim()) ?? [],
+      bcc: notification.Bcc?.split(';').map((a) => a.trim()) ?? [],
       bodyType: EmailBody[notification.BodyType as keyof typeof EmailBody],
       subject: notification.Subject,
       body: notification.Body,

--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -16,6 +16,7 @@ import chesServices, {
 } from '../ches/chesServices';
 import { SSOUser } from '@bcgov/citz-imb-sso-express';
 import { ProjectAgencyResponse } from '@/typeorm/Entities/ProjectAgencyResponse';
+import logger from '@/utilities/winstonLogger';
 
 interface AccessRequestData {
   FirstName: string;
@@ -93,6 +94,8 @@ const generateAccessRequestNotification = async (
     Subject: template.Subject,
     BodyType: template.BodyType,
     To: to ?? template.To,
+    Cc: template.Cc,
+    Bcc: template.Bcc,
     Body: body,
     TemplateId: template.Id,
     CreatedById: systemUser.Id,
@@ -308,6 +311,7 @@ const sendNotification = async (
   queryRunner?: QueryRunner,
 ) => {
   const query = queryRunner ?? AppDataSource.createQueryRunner();
+  let retNotif: NotificationQueue = null;
   try {
     const email: IEmail = {
       to: notification.To.split(';').map((a) => a.trim()),
@@ -324,19 +328,20 @@ const sendNotification = async (
     const response = await chesServices.sendEmailAsync(email, user);
     if (response) {
       // Note: Email may be intentionally disabled, thus yielding null response.
-      return query.manager.save(NotificationQueue, {
+      retNotif = await query.manager.save(NotificationQueue, {
         ...notification,
         ChesTransactionId: response.txId as UUID,
         ChesMessageId: response.messages[0].msgId as UUID,
       });
     } else {
-      return query.manager.save(NotificationQueue, {
+      retNotif = await query.manager.save(NotificationQueue, {
         ...notification,
         Status: NotificationStatus.Failed,
       });
     }
   } catch (e) {
-    return query.manager.save(NotificationQueue, {
+    logger.error(e.message);
+    retNotif = await query.manager.save(NotificationQueue, {
       ...notification,
       Status: NotificationStatus.Failed,
     });
@@ -345,6 +350,7 @@ const sendNotification = async (
       await query.release();
     }
   }
+  return retNotif;
 };
 
 const notificationServices = {

--- a/express-api/src/services/users/usersServices.ts
+++ b/express-api/src/services/users/usersServices.ts
@@ -7,6 +7,7 @@ import { randomUUID, UUID } from 'crypto';
 import KeycloakService from '@/services/keycloak/keycloakService';
 import { ErrorWithCode } from '@/utilities/customErrors/ErrorWithCode';
 import { UserFiltering } from '@/controllers/users/usersSchema';
+import notificationServices, { AccessRequestData } from '../notifications/notificationServices';
 
 interface NormalizedKeycloakUser {
   first_name: string;
@@ -150,6 +151,19 @@ const addKeycloakUserOnHold = async (
     Note: note,
     CreatedById: systemUser.Id,
   });
+  const newAccessRequest: AccessRequestData = {
+    FirstName: normalizedKc.first_name,
+    LastName: normalizedKc.last_name,
+  };
+  // The notification template name that will be used when sending an email to administrators.
+  const RPDNotificationTemplate = 17;
+  if (result) {
+    const notif = await notificationServices.generateAccessRequestNotification(
+      newAccessRequest,
+      RPDNotificationTemplate,
+    );
+    await notificationServices.sendNotification(notif);
+  }
   return result.generatedMaps[0];
 };
 

--- a/express-api/src/services/users/usersServices.ts
+++ b/express-api/src/services/users/usersServices.ts
@@ -7,7 +7,6 @@ import { randomUUID, UUID } from 'crypto';
 import KeycloakService from '@/services/keycloak/keycloakService';
 import { ErrorWithCode } from '@/utilities/customErrors/ErrorWithCode';
 import { UserFiltering } from '@/controllers/users/usersSchema';
-import notificationServices, { AccessRequestData } from '../notifications/notificationServices';
 
 interface NormalizedKeycloakUser {
   first_name: string;
@@ -55,11 +54,6 @@ const normalizeKeycloakUser = (kcUser: SSOUser): NormalizedKeycloakUser => {
       throw new Error();
   }
 };
-
-// const getUserFromKeycloak = async (kcUser: KeycloakUser) => {
-//   const normalized = normalizeKeycloakUser(kcUser);
-//   return getUser(normalized.guid ?? normalized.username);
-// };
 
 const activateUser = async (ssoUser: SSOUser) => {
   const normalizedUser = normalizeKeycloakUser(ssoUser);
@@ -151,19 +145,6 @@ const addKeycloakUserOnHold = async (
     Note: note,
     CreatedById: systemUser.Id,
   });
-  const newAccessRequest: AccessRequestData = {
-    FirstName: normalizedKc.first_name,
-    LastName: normalizedKc.last_name,
-  };
-  // The notification template name that will be used when sending an email to administrators.
-  const RPDNotificationTemplate = 17;
-  if (result) {
-    const notif = await notificationServices.generateAccessRequestNotification(
-      newAccessRequest,
-      RPDNotificationTemplate,
-    );
-    await notificationServices.sendNotification(notif);
-  }
   return result.generatedMaps[0];
 };
 

--- a/react-app/src/pages/AccessRequest.tsx
+++ b/react-app/src/pages/AccessRequest.tsx
@@ -129,7 +129,7 @@ export const AccessRequest = () => {
   }
 
   const selectPageContent = () => {
-    switch (auth.pimsUser.data.Status) {
+    switch (auth.pimsUser.data?.Status) {
       case 'OnHold':
         return (
           <>


### PR DESCRIPTION
Fixed some bugs in the access request notif generation service. Added…function calls for submitting notifications when a user submits an access request. Fixed a minor frontend issue causing the access request page to crash.

<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1719](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-1719)

* Fixed some bugs in the access request notif generation service. 
* Added function calls for submitting notifications when a user submits an access request. 
* Fixed a minor frontend issue causing the access request page to crash.

## Needs discussion
* How to handle administrators under new role format? Previously notifications would be sent to "system administrators" plus relevant users that were both administrators and part of the same agency. Now everyone is just an administrator without differentiating systems level.
* The to column of notification_queue has max length of 500. Most agencies with any admin users have enough of them to quickly overflow this value.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
