### PR TITLE
PIMS-1744: Projects API support timestamps and monetary 

### DIFF
--- a/express-api/src/services/projects/projectsServices.ts
+++ b/express-api/src/services/projects/projectsServices.ts
@@ -512,7 +512,7 @@ const handleProjectTimestamps = async (
     const saveTimestamps = newProject.Timestamps.map(
       async (timestamp): Promise<InsertResult | void> => {
         if (timestamp.TimestampTypeId == null) {
-          throw new ErrorWithCode('Provided note was missing a required field.', 400);
+          throw new ErrorWithCode('Provided timestamp was missing a required field.', 400);
         }
         const exists = await queryRunner.manager.findOne(ProjectTimestamp, {
           where: { ProjectId: newProject.Id, TimestampTypeId: timestamp.TimestampTypeId },
@@ -542,7 +542,7 @@ const handleProjectMonetary = async (
     const saveTimestamps = newProject.Monetaries.map(
       async (monetary): Promise<InsertResult | void> => {
         if (monetary.MonetaryTypeId == null) {
-          throw new ErrorWithCode('Provided note was missing a required field.', 400);
+          throw new ErrorWithCode('Provided monetary was missing a required field.', 400);
         }
         const exists = await queryRunner.manager.findOne(ProjectMonetary, {
           where: { ProjectId: newProject.Id, MonetaryTypeId: monetary.MonetaryTypeId },

--- a/express-api/src/services/projects/projectsServices.ts
+++ b/express-api/src/services/projects/projectsServices.ts
@@ -29,6 +29,8 @@ import { ProjectRisk } from '@/constants/projectRisk';
 import notificationServices from '../notifications/notificationServices';
 import { SSOUser } from '@bcgov/citz-imb-sso-express';
 import userServices from '../users/usersServices';
+import { ProjectTimestamp } from '@/typeorm/Entities/ProjectTimestamp';
+import { ProjectMonetary } from '@/typeorm/Entities/ProjectMonetary';
 
 const projectRepo = AppDataSource.getRepository(Project);
 
@@ -120,12 +122,24 @@ const getProjectById = async (id: number) => {
       ProjectId: id,
     },
   });
+  const projectMonetary = await AppDataSource.getRepository(ProjectMonetary).find({
+    where: {
+      ProjectId: id,
+    },
+  });
+  const projectTimestamps = await AppDataSource.getRepository(ProjectTimestamp).find({
+    where: {
+      ProjectId: id,
+    },
+  });
   return {
     ...project,
     ProjectProperties: projectProperties,
     AgencyResponses: agencyResponses,
     Tasks: projectTasks,
     Notes: projectNotes,
+    Monetaries: projectMonetary,
+    Timestamps: projectTimestamps,
   };
 };
 
@@ -174,6 +188,9 @@ const addProject = async (project: DeepPartial<Project>, propertyIds: ProjectPro
     if (parcels) await addProjectParcelRelations(newProject, parcels, queryRunner);
     if (buildings) await addProjectBuildingRelations(newProject, buildings, queryRunner);
     await handleProjectTasks(newProject, queryRunner);
+    await handleProjectMonetary(newProject, queryRunner);
+    await handleProjectNotes(newProject, queryRunner);
+    await handleProjectTimestamps(newProject, queryRunner);
     await queryRunner.commitTransaction();
     return newProject;
   } catch (e) {
@@ -487,6 +504,66 @@ const handleProjectNotes = async (newProject: DeepPartial<Project>, queryRunner:
   }
 };
 
+const handleProjectTimestamps = async (
+  newProject: DeepPartial<Project>,
+  queryRunner: QueryRunner,
+) => {
+  if (newProject?.Timestamps?.length) {
+    const saveTimestamps = newProject.Timestamps.map(
+      async (timestamp): Promise<InsertResult | void> => {
+        if (timestamp.TimestampTypeId == null) {
+          throw new ErrorWithCode('Provided note was missing a required field.', 400);
+        }
+        const exists = await queryRunner.manager.findOne(ProjectTimestamp, {
+          where: { ProjectId: newProject.Id, TimestampTypeId: timestamp.TimestampTypeId },
+        });
+        return queryRunner.manager.upsert(
+          ProjectTimestamp,
+          {
+            ProjectId: newProject.Id,
+            Date: timestamp.Date,
+            TimestampTypeId: timestamp.TimestampTypeId,
+            CreatedById: exists ? exists.CreatedById : newProject.CreatedById,
+            UpdatedById: exists ? newProject.UpdatedById : undefined,
+          },
+          ['ProjectId', 'TimestampTypeId'],
+        );
+      },
+    );
+    return Promise.all(saveTimestamps);
+  }
+};
+
+const handleProjectMonetary = async (
+  newProject: DeepPartial<Project>,
+  queryRunner: QueryRunner,
+) => {
+  if (newProject?.Monetaries?.length) {
+    const saveTimestamps = newProject.Monetaries.map(
+      async (monetary): Promise<InsertResult | void> => {
+        if (monetary.MonetaryTypeId == null) {
+          throw new ErrorWithCode('Provided note was missing a required field.', 400);
+        }
+        const exists = await queryRunner.manager.findOne(ProjectMonetary, {
+          where: { ProjectId: newProject.Id, MonetaryTypeId: monetary.MonetaryTypeId },
+        });
+        return queryRunner.manager.upsert(
+          ProjectMonetary,
+          {
+            ProjectId: newProject.Id,
+            Value: monetary.Value,
+            MonetaryTypeId: monetary.MonetaryTypeId,
+            CreatedById: exists ? exists.CreatedById : newProject.CreatedById,
+            UpdatedById: exists ? newProject.UpdatedById : undefined,
+          },
+          ['ProjectId', 'MonetaryTypeId'],
+        );
+      },
+    );
+    return Promise.all(saveTimestamps);
+  }
+};
+
 /**
  * Updates a project with the given changes and property IDs.
  *
@@ -535,6 +612,8 @@ const updateProject = async (
       queryRunner,
     );
     await handleProjectNotes({ ...project, CreatedById: project.UpdatedById }, queryRunner);
+    await handleProjectMonetary({ ...project, CreatedById: project.UpdatedById }, queryRunner);
+    await handleProjectTimestamps({ ...project, CreatedById: project.UpdatedById }, queryRunner);
 
     // Update Project
     await queryRunner.manager.save(Project, {
@@ -543,6 +622,8 @@ const updateProject = async (
       Tasks: undefined,
       AgencyResponses: undefined,
       Notes: undefined,
+      Timestamps: undefined,
+      Monetaries: undefined,
     });
     //Seems this save will also try to save Tasks array if present, but if missing the ProjectId it will do weird stuff.
     //So we could consolidate handleProjectTasks to here if we wanted, but then it might be annoying trying to get the more specific behavior in that function.
@@ -647,6 +728,18 @@ const deleteProjectById = async (id: number, username: string) => {
     // Remove Project Tasks
     await queryRunner.manager.update(
       ProjectTask,
+      { ProjectId: id },
+      { DeletedById: user.Id, DeletedOn: new Date() },
+    );
+    // Remove Project Timestamps
+    await queryRunner.manager.update(
+      ProjectTimestamp,
+      { ProjectId: id },
+      { DeletedById: user.Id, DeletedOn: new Date() },
+    );
+    // Remove Project Monetary
+    await queryRunner.manager.update(
+      ProjectMonetary,
       { ProjectId: id },
       { DeletedById: user.Id, DeletedOn: new Date() },
     );

--- a/express-api/src/typeorm/Entities/Project.ts
+++ b/express-api/src/typeorm/Entities/Project.ts
@@ -19,6 +19,8 @@ import { ProjectStatusHistory } from '@/typeorm/Entities/ProjectStatusHistory';
 import { ProjectNote } from '@/typeorm/Entities/ProjectNote';
 import { ProjectAgencyResponse } from './ProjectAgencyResponse';
 import { SoftDeleteEntity } from './abstractEntities/SoftDeleteEntity';
+import { ProjectTimestamp } from './ProjectTimestamp';
+import { ProjectMonetary } from './ProjectMonetary';
 
 export interface ProjectMetadata {
   // Exemption Fields
@@ -199,6 +201,16 @@ export class Project extends SoftDeleteEntity {
     nullable: true,
   })
   Notes: ProjectNote[];
+
+  @OneToMany(() => ProjectTimestamp, (ProjectTimestamp) => ProjectTimestamp.Project, {
+    nullable: true,
+  })
+  Timestamps: ProjectTimestamp[];
+
+  @OneToMany(() => ProjectMonetary, (ProjectMonetary) => ProjectMonetary.Project, {
+    nullable: true,
+  })
+  Monetaries: ProjectMonetary[];
 
   @OneToMany(
     () => ProjectAgencyResponse,

--- a/express-api/tests/testUtils/factories.ts
+++ b/express-api/tests/testUtils/factories.ts
@@ -42,6 +42,8 @@ import { ProjectAgencyResponse } from '@/typeorm/Entities/ProjectAgencyResponse'
 import { ProjectNote } from '@/typeorm/Entities/ProjectNote';
 import { ILtsaOrder } from '@/services/ltsa/interfaces/ILtsaOrder';
 import { NoteType } from '@/typeorm/Entities/NoteType';
+import { ProjectTimestamp } from '@/typeorm/Entities/ProjectTimestamp';
+import { ProjectMonetary } from '@/typeorm/Entities/ProjectMonetary';
 
 export class MockRes {
   statusValue: any;
@@ -592,6 +594,8 @@ export const produceProject = (
         ProjectId: projectId,
       }),
     ],
+    Timestamps: [produceProjectTimestamp()],
+    Monetaries: [produceProjectMonetary()],
     Notifications: [],
     StatusHistory: [],
     Notes: [produceNote()],
@@ -694,6 +698,48 @@ export const produceProjectTask = (props?: Partial<ProjectTask>) => {
     ...props,
   };
   return task;
+};
+
+export const produceProjectTimestamp = (props?: Partial<ProjectTimestamp>) => {
+  const ts: ProjectTimestamp = {
+    ProjectId: faker.number.int(),
+    Project: undefined,
+    TimestampType: undefined,
+    TimestampTypeId: faker.number.int(),
+    Date: undefined,
+    CreatedById: randomUUID(),
+    CreatedBy: undefined,
+    CreatedOn: new Date(),
+    UpdatedById: randomUUID(),
+    UpdatedBy: undefined,
+    UpdatedOn: new Date(),
+    DeletedById: null,
+    DeletedOn: null,
+    DeletedBy: undefined,
+    ...props,
+  };
+  return ts;
+};
+
+export const produceProjectMonetary = (props?: Partial<ProjectMonetary>) => {
+  const monetary: ProjectMonetary = {
+    ProjectId: faker.number.int(),
+    Project: undefined,
+    MonetaryType: undefined,
+    MonetaryTypeId: faker.number.int(),
+    Value: Number(faker.commerce.price()),
+    CreatedById: randomUUID(),
+    CreatedBy: undefined,
+    CreatedOn: new Date(),
+    UpdatedById: randomUUID(),
+    UpdatedBy: undefined,
+    UpdatedOn: new Date(),
+    DeletedById: null,
+    DeletedOn: null,
+    DeletedBy: undefined,
+    ...props,
+  };
+  return monetary;
 };
 
 export const produceProjectNotification = (props?: Partial<ProjectStatusNotification>) => {

--- a/express-api/tests/unit/services/projects/projectsServices.test.ts
+++ b/express-api/tests/unit/services/projects/projectsServices.test.ts
@@ -10,9 +10,11 @@ import { NotificationQueue } from '@/typeorm/Entities/NotificationQueue';
 import { Parcel } from '@/typeorm/Entities/Parcel';
 import { Project } from '@/typeorm/Entities/Project';
 import { ProjectAgencyResponse } from '@/typeorm/Entities/ProjectAgencyResponse';
+import { ProjectMonetary } from '@/typeorm/Entities/ProjectMonetary';
 import { ProjectNote } from '@/typeorm/Entities/ProjectNote';
 import { ProjectProperty } from '@/typeorm/Entities/ProjectProperty';
 import { ProjectTask } from '@/typeorm/Entities/ProjectTask';
+import { ProjectTimestamp } from '@/typeorm/Entities/ProjectTimestamp';
 import { ErrorWithCode } from '@/utilities/customErrors/ErrorWithCode';
 import { faker } from '@faker-js/faker';
 import {
@@ -22,8 +24,10 @@ import {
   produceNotificationQueue,
   produceParcel,
   produceProject,
+  produceProjectMonetary,
   produceProjectProperty,
   produceProjectTask,
+  produceProjectTimestamp,
   produceSSO,
   produceUser,
 } from 'tests/testUtils/factories';
@@ -79,6 +83,14 @@ jest
 jest
   .spyOn(AppDataSource.getRepository(ProjectTask), 'find')
   .mockImplementation(async () => [produceProjectTask()]);
+
+jest
+  .spyOn(AppDataSource.getRepository(ProjectTimestamp), 'find')
+  .mockImplementation(async () => [produceProjectTimestamp()]);
+
+jest
+  .spyOn(AppDataSource.getRepository(ProjectMonetary), 'find')
+  .mockImplementation(async () => [produceProjectMonetary()]);
 
 jest
   .spyOn(AppDataSource.getRepository(ProjectAgencyResponse), 'find')


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1744 ](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-1744)

* Can now include an array of Monetary and/or Timestamps in the body of a PUT or POST request to projects to have those records upserted.
* Monetary and Timestamps now included in the response of the GET endpoint.
* Monetary and Timestamps are soft deleted when a project is soft deleted.
* Tests and factories updated to accommodate.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
