### PR TITLE
PIMS-1605 - set table length to 100 

### DIFF
--- a/react-app/src/components/adminAreas/AdministrativeAreasTable.tsx
+++ b/react-app/src/components/adminAreas/AdministrativeAreasTable.tsx
@@ -132,9 +132,6 @@ const AdministrativeAreasTable = () => {
       getRowId={(row) => row.Id}
       rows={data ?? []}
       initialState={{
-        pagination: {
-          paginationModel: { pageSize: 10, page: 0 },
-        },
         sorting: {
           sortModel: [{ field: 'Name', sort: 'asc' }],
         },


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1605: ](https://citz-imb.atlassian.net/browse/PIMS-1605)

<!-- PROVIDE BELOW an explanation of your changes -->
removed initial state table length 10 for Admin Areas. Data grid has a length default of 100 and PO requested 100 as the set length for all tables. 
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
