### PR TITLE
PIMS-1799: Property Union API

### DIFF
--- a/express-api/src/controllers/properties/propertiesController.ts
+++ b/express-api/src/controllers/properties/propertiesController.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from 'express';
 import { stubResponse } from '@/utilities/stubResponse';
 import propertyServices from '@/services/properties/propertiesServices';
-import { MapFilterSchema } from '@/controllers/properties/mapFilterSchema';
+import {
+  MapFilterSchema,
+  PropertyUnionFilterSchema,
+} from '@/controllers/properties/propertiesSchema';
 import { checkUserAgencyPermission, isAdmin, isAuditor } from '@/utilities/authorizationChecks';
 import userServices from '@/services/users/usersServices';
 
@@ -115,7 +118,7 @@ export const getPropertiesForMap = async (req: Request, res: Response) => {
       }]
    */
   // parse for filter
-  const filter = await MapFilterSchema.safeParse(req.query);
+  const filter = MapFilterSchema.safeParse(req.query);
   if (filter.success == false) {
     return res.status(400).send(filter.error);
   }
@@ -164,4 +167,13 @@ export const getPropertiesForMap = async (req: Request, res: Response) => {
     },
   }));
   return res.status(200).send(mapFeatures);
+};
+
+export const getPropertyUnion = async (req: Request, res: Response) => {
+  const filter = PropertyUnionFilterSchema.safeParse(req.query);
+  if (filter.success == false) {
+    return res.status(400).send(filter.error);
+  }
+  const properties = await propertyServices.getPropertiesUnion(filter.data);
+  return res.status(200).send(properties);
 };

--- a/express-api/src/controllers/properties/propertiesSchema.ts
+++ b/express-api/src/controllers/properties/propertiesSchema.ts
@@ -33,3 +33,24 @@ export const MapFilterSchema = z.object({
   Name: z.string().optional(),
   RegionalDistrictIds: arrayFromString(numberSchema),
 });
+
+export type MapFilter = z.infer<typeof MapFilterSchema>;
+
+export const PropertyUnionFilterSchema = z.object({
+  pid: z.string().optional(),
+  pin: z.string().optional(),
+  status: z.string().optional(),
+  classification: z.string().optional(),
+  agency: z.string().optional(),
+  propertyType: z.string().optional(),
+  address: z.string().optional(),
+  administrativeArea: z.string().optional(),
+  landArea: z.string().optional(),
+  updatedOn: z.string().optional(),
+  sortKey: z.string().optional(),
+  sortOrder: z.string().optional(),
+  page: z.coerce.number().optional(),
+  quantity: z.coerce.number().optional(),
+});
+
+export type PropertyUnionFilter = z.infer<typeof PropertyUnionFilterSchema>;

--- a/express-api/src/routes/propertiesRouter.ts
+++ b/express-api/src/routes/propertiesRouter.ts
@@ -1,5 +1,4 @@
 import controllers from '@/controllers';
-import { getPropertiesFuzzySearch } from '@/controllers/properties/propertiesController';
 import activeUserCheck from '@/middleware/activeUserCheck';
 import catchErrors from '@/utilities/controllerErrorWrapper';
 import express from 'express';
@@ -12,6 +11,8 @@ const {
   getPropertiesForMap,
   getPropertiesPaged,
   getPropertiesPagedFilter,
+  getPropertiesFuzzySearch,
+  getPropertyUnion,
 } = controllers;
 
 // TODO: Could these just be GET requests with query params? Then no need for /filter routes. Would cut controllers in half too.
@@ -25,5 +26,7 @@ router.route('/search/geo').get(activeUserCheck, catchErrors(getPropertiesForMap
 
 router.route('/search/page').get(activeUserCheck, catchErrors(getPropertiesPaged));
 router.route('/search/page/filter').post(activeUserCheck, catchErrors(getPropertiesPagedFilter));
+
+router.route('/').get(activeUserCheck, catchErrors(getPropertyUnion));
 
 export default router;

--- a/express-api/src/services/properties/propertiesServices.ts
+++ b/express-api/src/services/properties/propertiesServices.ts
@@ -95,7 +95,8 @@ const collectFindOptions = (filter: PropertyUnionFilter) => {
   if (filter.address) options.push(constructFindOptionFromQuery('Address', filter.address));
   if (filter.updatedOn) options.push(constructFindOptionFromQuery('UpdatedOn', filter.updatedOn));
   if (filter.classification)
-    options.push(constructFindOptionFromQuery('LandArea', filter.landArea));
+    options.push(constructFindOptionFromQuery('Classification', filter.classification));
+  if (filter.landArea) options.push(constructFindOptionFromQuery('LandArea', filter.landArea));
   if (filter.administrativeArea)
     options.push(constructFindOptionFromQuery('AdministrativeArea', filter.administrativeArea));
   if (filter.propertyType)

--- a/express-api/src/services/properties/propertiesServices.ts
+++ b/express-api/src/services/properties/propertiesServices.ts
@@ -1,8 +1,11 @@
 import { AppDataSource } from '@/appDataSource';
+import { MapFilter, PropertyUnionFilter } from '@/controllers/properties/propertiesSchema';
 import { Building } from '@/typeorm/Entities/Building';
 import { Parcel } from '@/typeorm/Entities/Parcel';
 import { MapProperties } from '@/typeorm/Entities/views/MapPropertiesView';
-import { ILike, In } from 'typeorm';
+import { PropertyUnion } from '@/typeorm/Entities/views/PropertyUnionView';
+import { constructFindOptionFromQuery } from '@/utilities/helperFunctions';
+import { FindOptionsOrder, FindOptionsOrderValue, ILike, In } from 'typeorm';
 
 const propertiesFuzzySearch = async (keyword: string, limit?: number) => {
   const parcels = await AppDataSource.getRepository(Parcel)
@@ -37,24 +40,12 @@ const propertiesFuzzySearch = async (keyword: string, limit?: number) => {
   };
 };
 
-export interface MapPropertiesFilter {
-  PID?: number;
-  PIN?: number;
-  Address?: string;
-  AgencyIds?: number[];
-  AdministrativeAreaIds?: number[];
-  ClassificationIds?: number[];
-  PropertyTypeIds?: number[];
-  Name?: string;
-  RegionalDistrictIds?: number[];
-}
-
 /**
  * Retrieves properties based on the provided filter criteria to render map markers.
  * @param filter - An optional object containing filter criteria for properties.
  * @returns A promise that resolves to an array of properties matching the filter criteria.
  */
-const getPropertiesForMap = async (filter?: MapPropertiesFilter) => {
+const getPropertiesForMap = async (filter?: MapFilter) => {
   const properties = await AppDataSource.getRepository(MapProperties).find({
     // Select only the properties needed to render map markers and sidebar
     select: {
@@ -89,9 +80,42 @@ const getPropertiesForMap = async (filter?: MapPropertiesFilter) => {
   return properties;
 };
 
+const sortKeyMapping = (
+  sortKey: string,
+  sortDirection: FindOptionsOrderValue,
+): FindOptionsOrder<PropertyUnion> => {
+  return { [sortKey]: sortDirection };
+};
+
+const collectFindOptions = (filter: PropertyUnionFilter) => {
+  const options = [];
+  if (filter.agency) options.push(constructFindOptionFromQuery('Agency', filter.agency));
+  if (filter.pid) options.push(constructFindOptionFromQuery('PID', filter.pid));
+  if (filter.pin) options.push(constructFindOptionFromQuery('PIN', filter.pin));
+  if (filter.address) options.push(constructFindOptionFromQuery('Address', filter.address));
+  if (filter.updatedOn) options.push(constructFindOptionFromQuery('UpdatedOn', filter.updatedOn));
+  if (filter.classification)
+    options.push(constructFindOptionFromQuery('LandArea', filter.landArea));
+  if (filter.administrativeArea)
+    options.push(constructFindOptionFromQuery('AdministrativeArea', filter.administrativeArea));
+  if (filter.propertyType)
+    options.push(constructFindOptionFromQuery('PropertyType', filter.propertyType));
+  return options;
+};
+
+const getPropertiesUnion = async (filter: PropertyUnionFilter) => {
+  return AppDataSource.getRepository(PropertyUnion).find({
+    where: collectFindOptions(filter),
+    take: filter.quantity,
+    skip: (filter.page ?? 0) * (filter.quantity ?? 0),
+    order: sortKeyMapping(filter.sortKey, filter.sortOrder as FindOptionsOrderValue),
+  });
+};
+
 const propertyServices = {
   propertiesFuzzySearch,
   getPropertiesForMap,
+  getPropertiesUnion,
 };
 
 export default propertyServices;

--- a/express-api/src/utilities/helperFunctions.ts
+++ b/express-api/src/utilities/helperFunctions.ts
@@ -78,7 +78,7 @@ export const ILikeWrapper = (query: string | undefined, mode: ILikeWrapperMode =
     } else {
       searchText = `%${query}%`;
     }
-    return Raw((alias) => `${fixColumnAlias(alias)}::text ILIKE '${searchText}'`);
+    return Raw((alias) => `(${alias})::TEXT ILIKE '${searchText}'`);
   }
 };
 
@@ -91,15 +91,9 @@ type TimestampOperator = '=' | '!=' | '<=' | '>=' | '<' | '>';
  */
 export const TimestampComparisonWrapper = (tsValue: string, operator: TimestampOperator) => {
   if (operator === '=') {
-    return Raw(
-      (alias) =>
-        `${fixColumnAlias(alias)}::date = '${toPostgresTimestamp(new Date(tsValue))}'::date`,
-    );
+    return Raw((alias) => `(${alias})::DATE = '${toPostgresTimestamp(new Date(tsValue))}'::DATE`);
   } else if (operator === '!=') {
-    return Raw(
-      (alias) =>
-        `${fixColumnAlias(alias)}::date != '${toPostgresTimestamp(new Date(tsValue))}'::date`,
-    );
+    return Raw((alias) => `(${alias})::DATE != '${toPostgresTimestamp(new Date(tsValue))}'::DATE`);
   }
   return Raw((alias) => `${alias} ${operator} '${toPostgresTimestamp(new Date(tsValue))}'`);
 };
@@ -109,6 +103,7 @@ export const TimestampComparisonWrapper = (tsValue: string, operator: TimestampO
 //ie. It will pass Project.ProjectNumber instead of "Project_project_number" (correct column alias constructed by TypeORM)
 //or "Project".project_number (correct table alias plus non-aliased column access)
 //Thankfully, it's not too difficult to manually format this.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const fixColumnAlias = (str: string) => {
   const [tableAlias, columnAlias] = str.split('.');
   const fixedColumn = columnAlias

--- a/express-api/tests/testUtils/factories.ts
+++ b/express-api/tests/testUtils/factories.ts
@@ -50,6 +50,7 @@ import { ProjectRisk } from '@/typeorm/Entities/ProjectRisk';
 import { PropertyType } from '@/typeorm/Entities/PropertyType';
 import { ProjectType } from '@/typeorm/Entities/ProjectType';
 import { ProjectStatus } from '@/typeorm/Entities/ProjectStatus';
+import { PropertyUnion } from '@/typeorm/Entities/views/PropertyUnionView';
 
 export class MockRes {
   statusValue: any;
@@ -956,6 +957,27 @@ export const produceAgencyResponse = (props?: Partial<ProjectAgencyResponse>) =>
   };
 
   return response;
+};
+
+export const producePropertyUnion = (props: Partial<PropertyUnion>) => {
+  const union: PropertyUnion = {
+    Id: faker.number.int(),
+    PID: faker.number.int({ max: 999999999 }),
+    PIN: faker.number.int({ max: 999999999 }),
+    PropertyType: ['Building', 'Parcel'][faker.number.int({ min: 0, max: 1 })],
+    AgencyId: faker.number.int(),
+    Agency: faker.company.name(),
+    Address: faker.location.streetAddress(),
+    IsSensitive: false,
+    UpdatedOn: new Date(),
+    ClassificationId: faker.number.int(),
+    Classification: faker.company.buzzNoun(),
+    AdministrativeAreaId: faker.number.int(),
+    AdministrativeArea: faker.location.city(),
+    LandArea: faker.number.float({ max: 99999 }),
+    ...props,
+  };
+  return union;
 };
 
 export const produceLtsaOrder = (): ILtsaOrder => ({

--- a/express-api/tests/unit/controllers/properties/propertiesController.test.ts
+++ b/express-api/tests/unit/controllers/properties/propertiesController.test.ts
@@ -7,12 +7,14 @@ import {
   produceAgency,
   produceBuilding,
   produceParcel,
+  producePropertyUnion,
   produceUser,
 } from '../../../testUtils/factories';
 import { Roles } from '@/constants/roles';
 import { AppDataSource } from '@/appDataSource';
 import { User } from '@/typeorm/Entities/User';
 import { Agency } from '@/typeorm/Entities/Agency';
+import { getPropertyUnion } from '@/controllers/properties/propertiesController';
 
 const {
   getProperties,
@@ -39,9 +41,12 @@ const _getPropertiesForMap = jest.fn().mockImplementation(async () => [
   },
 ]);
 
+const _getPropertyUnion = jest.fn().mockImplementation(async () => [producePropertyUnion]);
+
 jest.mock('@/services/properties/propertiesServices', () => ({
   propertiesFuzzySearch: () => _propertiesFuzzySearch(),
   getPropertiesForMap: () => _getPropertiesForMap(),
+  getPropertiesUnion: () => _getPropertyUnion(),
 }));
 
 describe('UNIT - Properties', () => {
@@ -179,6 +184,14 @@ describe('UNIT - Properties', () => {
       await getPropertiesPagedFilter(mockRequest, mockResponse);
       expect(mockResponse.statusValue).toBe(200);
       expect(mockResponse.jsonValue.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('GET /properties/', () => {
+    it('should return status 200', async () => {
+      await getPropertyUnion(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(Array.isArray(mockResponse.sendValue)).toBe(true);
     });
   });
 });

--- a/express-api/tests/unit/services/properties/propertyServices.test.ts
+++ b/express-api/tests/unit/services/properties/propertyServices.test.ts
@@ -3,7 +3,8 @@ import propertyServices from '@/services/properties/propertiesServices';
 import { Building } from '@/typeorm/Entities/Building';
 import { Parcel } from '@/typeorm/Entities/Parcel';
 import { MapProperties } from '@/typeorm/Entities/views/MapPropertiesView';
-import { produceParcel, produceBuilding } from 'tests/testUtils/factories';
+import { PropertyUnion } from '@/typeorm/Entities/views/PropertyUnionView';
+import { produceParcel, produceBuilding, producePropertyUnion } from 'tests/testUtils/factories';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _parcelsCreateQueryBuilder: any = {
@@ -45,6 +46,10 @@ jest.spyOn(AppDataSource.getRepository(MapProperties), 'find').mockImplementatio
   } as MapProperties,
 ]);
 
+jest
+  .spyOn(AppDataSource.getRepository(PropertyUnion), 'find')
+  .mockImplementation(async () => [producePropertyUnion({})]);
+
 describe('UNIT - Property Services', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -55,6 +60,30 @@ describe('UNIT - Property Services', () => {
       const result = await propertyServices.propertiesFuzzySearch('123', 3);
       expect(Array.isArray(result.Parcels)).toBe(true);
       expect(Array.isArray(result.Buildings)).toBe(true);
+    });
+  });
+
+  describe('getPropertyUnion', () => {
+    it('should return a list of buildings and parcels', async () => {
+      const result = await propertyServices.getPropertiesUnion({
+        pid: 'contains,123',
+        pin: 'contains,456',
+        administrativeArea: 'contains,aaa',
+        agency: 'startsWith,aaa',
+        propertyType: 'contains,Building',
+        sortKey: 'Agency',
+        sortOrder: 'DESC',
+        landArea: 'startsWith,1',
+        updatedOn: 'after,' + new Date(),
+      });
+      expect(Array.isArray(result));
+      expect(result.at(0)).toHaveProperty('PropertyType');
+      expect(result.at(0)).toHaveProperty('Id');
+      expect(result.at(0)).toHaveProperty('PIN');
+      expect(result.at(0)).toHaveProperty('PID');
+      expect(result.at(0)).toHaveProperty('Agency');
+      expect(result.at(0)).toHaveProperty('Classification');
+      expect(result.at(0)).toHaveProperty('AdministrativeArea');
     });
   });
 


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1799](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-1799)

* Added new endpoint at `properties/`
* Added controller and service for query PropertyUnion view. Lets you filter and sort on all columns you might expect.
* Includes a change to the helper function for construction find options from the filter that makes us not need to manually correct the column alias. For whatever reason, `${alias}::TEXT ... ` breaks it, while `(${alias})::TEXT ... ` is perfectly fine.
## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
