### PR TITLE
PIMS-1801 Replace Joins with Lookup

### DIFF
--- a/express-api/src/controllers/lookup/lookupController.ts
+++ b/express-api/src/controllers/lookup/lookupController.ts
@@ -357,7 +357,7 @@ export const lookupAll = async (req: Request, res: Response) => {
   });
   const ProjectStatuses = await AppDataSource.getRepository(ProjectStatus).find({
     select: { Name: true, Id: true },
-    order: { SortOrder: 'asc' },
+    order: { SortOrder: 'asc', Name: 'asc' },
     where: { IsDisabled: false },
   });
   const ProjectTiers = await AppDataSource.getRepository(TierLevel).find({
@@ -365,7 +365,7 @@ export const lookupAll = async (req: Request, res: Response) => {
       Name: true,
       Id: true,
     },
-    order: { SortOrder: 'asc' },
+    order: { SortOrder: 'asc', Name: 'asc' },
     where: { IsDisabled: false },
   });
   const RegionalDistricts = await AppDataSource.getRepository(RegionalDistrict).find({
@@ -379,7 +379,7 @@ export const lookupAll = async (req: Request, res: Response) => {
       Name: true,
       Id: true,
     },
-    order: { SortOrder: 'asc' },
+    order: { SortOrder: 'asc', Name: 'asc' },
     where: { IsDisabled: false },
   });
   const PredominateUses = await AppDataSource.getRepository(BuildingPredominateUse).find({
@@ -387,12 +387,12 @@ export const lookupAll = async (req: Request, res: Response) => {
       Id: true,
       Name: true,
     },
-    order: { SortOrder: 'asc' },
+    order: { SortOrder: 'asc', Name: 'asc' },
     where: { IsDisabled: false },
   });
   const Classifications = await AppDataSource.getRepository(PropertyClassification).find({
     select: { Id: true, Name: true, IsVisible: true },
-    order: { SortOrder: 'asc' },
+    order: { SortOrder: 'asc', Name: 'asc' },
     where: { IsDisabled: false },
   });
   const Roles = await AppDataSource.getRepository(Role).find({
@@ -400,7 +400,7 @@ export const lookupAll = async (req: Request, res: Response) => {
       Id: true,
       Name: true,
     },
-    order: { SortOrder: 'asc' },
+    order: { SortOrder: 'asc', Name: 'asc' },
     where: { IsDisabled: false },
   });
   const Agencies = await AppDataSource.getRepository(Agency).find({
@@ -410,7 +410,7 @@ export const lookupAll = async (req: Request, res: Response) => {
       Code: true,
       ParentId: true,
     },
-    order: { SortOrder: 'asc' },
+    order: { SortOrder: 'asc', Name: 'asc' },
     where: { IsDisabled: false },
   });
   const AdministrativeAreas = await AppDataSource.getRepository(AdministrativeArea).find({
@@ -419,7 +419,7 @@ export const lookupAll = async (req: Request, res: Response) => {
       Name: true,
       RegionalDistrictId: true,
     },
-    order: { SortOrder: 'asc' },
+    order: { SortOrder: 'asc', Name: 'asc' },
     where: { IsDisabled: false },
   });
 

--- a/express-api/src/services/administrativeAreas/administrativeAreaSchema.ts
+++ b/express-api/src/services/administrativeAreas/administrativeAreaSchema.ts
@@ -8,6 +8,7 @@ export const AdministrativeAreaFilterSchema = z.object({
   sortRelation: z.string().optional(),
   name: z.string().optional(),
   provinceId: z.string().optional(),
+  regionalDistrictId: z.number().int().optional(),
   regionalDistrict: z.string().optional(),
   isDisabled: z.string().optional(),
 });

--- a/express-api/src/services/administrativeAreas/administrativeAreasServices.ts
+++ b/express-api/src/services/administrativeAreas/administrativeAreasServices.ts
@@ -53,9 +53,6 @@ const addAdministrativeArea = async (adminArea: AdministrativeArea) => {
 
 const getAdministrativeAreaById = (id: number) => {
   return AppDataSource.getRepository(AdministrativeArea).findOne({
-    relations: {
-      RegionalDistrict: true,
-    },
     where: { Id: id },
   });
 };

--- a/express-api/src/services/agencies/agencyServices.ts
+++ b/express-api/src/services/agencies/agencyServices.ts
@@ -74,9 +74,6 @@ export const addAgency = async (agency: Agency) => {
 export const getAgencyById = async (agencyId: number) => {
   const findAgency = await agencyRepo.findOne({
     where: { Id: agencyId },
-    relations: {
-      Parent: true,
-    },
   });
   return findAgency;
 };

--- a/express-api/src/services/buildings/buildingServices.ts
+++ b/express-api/src/services/buildings/buildingServices.ts
@@ -41,15 +41,6 @@ export const getBuildingById = async (buildingId: number) => {
     order: { FiscalYear: 'DESC' },
   });
   const findBuilding = await buildingRepo.findOne({
-    relations: {
-      Agency: true,
-      AdministrativeArea: true,
-      Classification: true,
-      PropertyType: true,
-      BuildingConstructionType: true,
-      BuildingPredominateUse: true,
-      BuildingOccupantType: true,
-    },
     where: { Id: buildingId },
   });
   if (findBuilding) {

--- a/express-api/src/services/parcels/parcelServices.ts
+++ b/express-api/src/services/parcels/parcelServices.ts
@@ -287,17 +287,6 @@ const getParcelById = async (parcelId: number) => {
     where: { ParcelId: parcelId },
   });
   const parcel = await parcelRepo.findOne({
-    relations: {
-      ParentParcel: true,
-      Agency: {
-        Parent: true,
-      },
-      AdministrativeArea: {
-        RegionalDistrict: true,
-      },
-      Classification: true,
-      PropertyType: true,
-    },
     where: { Id: parcelId },
   });
   if (parcel) {

--- a/express-api/src/services/projects/projectsServices.ts
+++ b/express-api/src/services/projects/projectsServices.ts
@@ -53,36 +53,11 @@ const getProjectById = async (id: number) => {
       Id: id,
     },
     relations: {
-      Agency: true,
-      Workflow: true,
-      TierLevel: true,
-      Status: true,
-      Risk: true,
       StatusHistory: true,
       Notifications: true,
     },
     select: {
       Workflow: {
-        Name: true,
-        Code: true,
-        Description: true,
-      },
-      Agency: {
-        Name: true,
-        Code: true,
-      },
-      TierLevel: {
-        Name: true,
-        Description: true,
-      },
-      Status: {
-        Name: true,
-        GroupName: true,
-        Description: true,
-        IsTerminal: true,
-        IsMilestone: true,
-      },
-      Risk: {
         Name: true,
         Code: true,
         Description: true,

--- a/react-app/src/components/adminAreas/AddAdministrativeArea.tsx
+++ b/react-app/src/components/adminAreas/AddAdministrativeArea.tsx
@@ -1,21 +1,18 @@
 import { Box, Grid, Typography } from '@mui/material';
-import React from 'react';
+import React, { useContext } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import TextFormField from '../form/TextFormField';
 import AutocompleteFormField from '../form/AutocompleteFormField';
 import usePimsApi from '@/hooks/usePimsApi';
-import useDataLoader from '@/hooks/useDataLoader';
 import { NavigateBackButton } from '../display/DetailViewNavigation';
 import { useNavigate } from 'react-router-dom';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
 import { LoadingButton } from '@mui/lab';
+import { LookupContext } from '@/contexts/lookupContext';
 
 const AddAdministrativeArea = () => {
   const api = usePimsApi();
-  const { data: regionalDistricts, loadOnce: loadRegional } = useDataLoader(
-    api.lookup.getRegionalDistricts,
-  );
-  loadRegional();
+  const { data: lookupData } = useContext(LookupContext);
   const { submit, submitting } = useDataSubmitter(api.administrativeAreas.addAdministrativeArea);
   const navigate = useNavigate();
   const formMethods = useForm({
@@ -53,7 +50,10 @@ const AddAdministrativeArea = () => {
               required
               name={'RegionalDistrictId'}
               label={'Regional District'}
-              options={regionalDistricts?.map((reg) => ({ value: reg.Id, label: reg.Name })) ?? []}
+              options={
+                lookupData?.RegionalDistricts?.map((reg) => ({ value: reg.Id, label: reg.Name })) ??
+                []
+              }
             />
           </Grid>
         </Grid>

--- a/react-app/src/components/adminAreas/AdministrativeAreaDetail.tsx
+++ b/react-app/src/components/adminAreas/AdministrativeAreaDetail.tsx
@@ -1,6 +1,6 @@
 import useDataLoader from '@/hooks/useDataLoader';
 import usePimsApi from '@/hooks/usePimsApi';
-import { Box, Checkbox, Grid } from '@mui/material';
+import { Box, Checkbox, Grid, Typography } from '@mui/material';
 import React, { useContext, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import DetailViewNavigation from '../display/DetailViewNavigation';
@@ -13,6 +13,7 @@ import SingleSelectBoxFormField from '../form/SingleSelectBoxFormField';
 import AutocompleteFormField from '../form/AutocompleteFormField';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
 import { LookupContext } from '@/contexts/lookupContext';
+import { dateFormatter } from '@/utilities/formatters';
 
 const AdministrativeAreaDetail = () => {
   const { id } = useParams();
@@ -39,6 +40,7 @@ const AdministrativeAreaDetail = () => {
         />
       );
     }
+    if (key === 'CreatedOn') return <Typography>{dateFormatter(val)}</Typography>;
   };
 
   const adminAreaData = {

--- a/react-app/src/components/agencies/AddAgency.tsx
+++ b/react-app/src/components/agencies/AddAgency.tsx
@@ -1,7 +1,7 @@
 import TextFormField from '@/components/form/TextFormField';
 import { Box, Grid, Typography } from '@mui/material';
 import { FormProvider, useForm } from 'react-hook-form';
-import React, { useState } from 'react';
+import React from 'react';
 import AutocompleteFormField from '@/components/form/AutocompleteFormField';
 import usePimsApi from '@/hooks/usePimsApi';
 import useGroupedAgenciesApi from '@/hooks/api/useGroupedAgenciesApi';
@@ -14,8 +14,6 @@ import useDataSubmitter from '@/hooks/useDataSubmitter';
 import { LoadingButton } from '@mui/lab';
 
 const AddAgency = () => {
-  const [showErrorText, setShowErrorText] = useState(false);
-
   const api = usePimsApi();
   const navigate = useNavigate();
   const { submit, submitting } = useDataSubmitter(api.agencies.addAgency);
@@ -102,17 +100,11 @@ const AddAgency = () => {
           </Grid>
         </Grid>
       </FormProvider>
-      {showErrorText && (
-        <Typography alignSelf={'center'} variant="h5" color={'error'}>
-          Please correct issues in the form input.
-        </Typography>
-      )}
       <LoadingButton
         loading={submitting}
         onClick={async () => {
           const isValid = await formMethods.trigger();
           if (isValid) {
-            setShowErrorText(false);
             const formValues = formMethods.getValues();
             const newAgency: AgencyAdd = {
               Name: formValues.Name,
@@ -127,11 +119,7 @@ const AddAgency = () => {
             };
             submit(newAgency).then((res) => {
               if (res && res.ok) navigate('/admin/agencies');
-              // TODO: What do we do if it wasn't successful?
             });
-          } else {
-            console.log('Error!');
-            setShowErrorText(true);
           }
         }}
         variant="contained"

--- a/react-app/src/components/agencies/AgencyDetails.tsx
+++ b/react-app/src/components/agencies/AgencyDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import DataCard from '../display/DataCard';
 import { Box, Checkbox, Chip, Grid, Typography } from '@mui/material';
 import { dateFormatter } from '@/utilities/formatters';
@@ -15,6 +15,7 @@ import { useParams } from 'react-router-dom';
 import EmailChipFormField from '@/components/form/EmailChipFormField';
 import SingleSelectBoxFormField from '@/components/form/SingleSelectBoxFormField';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
+import { LookupContext } from '@/contexts/lookupContext';
 
 interface IAgencyDetail {
   onClose: () => void;
@@ -29,6 +30,7 @@ interface AgencyStatus extends Agency {
 const AgencyDetail = ({ onClose }: IAgencyDetail) => {
   const { id } = useParams();
   const api = usePimsApi();
+  const { getLookupValueById } = useContext(LookupContext);
 
   const [openStatusDialog, setOpenStatusDialog] = useState(false);
   const [openNotificationsDialog, setOpenNotificationsDialog] = useState(false);
@@ -43,7 +45,7 @@ const AgencyDetail = ({ onClose }: IAgencyDetail) => {
     Name: data?.Name,
     Code: data?.Code,
     Description: data?.Description,
-    Parent: data?.Parent,
+    Parent: getLookupValueById('Agencies', data?.ParentId),
     IsDisabled: data?.IsDisabled,
     UpdatedOn: data?.UpdatedOn,
   };

--- a/react-app/src/components/form/MultiselectFormField.tsx
+++ b/react-app/src/components/form/MultiselectFormField.tsx
@@ -52,7 +52,6 @@ const MultiselectFormField = (props: MultiselectFormFieldProps) => {
           sx={sx}
           limitTags={2}
           fullWidth
-          disableClearable={true}
           getOptionLabel={(option: ISelectMenuItem) => option.label}
           isOptionEqualToValue={(sourceOption, selectedOption) =>
             sourceOption.value === selectedOption.value
@@ -76,20 +75,20 @@ const MultiselectFormField = (props: MultiselectFormFieldProps) => {
               helperText={(formState.errors?.[name]?.message as string) ?? undefined}
             />
           )}
-          renderOption={(props, option) => (
+          renderOption={(props, option, state, ownerState) => (
             <Box
-              {...props}
               sx={{
-                fontWeight: option.parent ? 900 : 500,
+                fontWeight: allowNestedIndent && !option.parentId ? 900 : 500,
                 [`&.${autocompleteClasses.option}`]: {
                   padding: 1,
-                  paddingLeft: allowNestedIndent && !option.parent ? 2 : 1,
+                  paddingLeft: allowNestedIndent && option.parentId ? 2 : 1,
                 },
               }}
               component="li"
-              key={option.value}
+              {...props}
+              key={option.label}
             >
-              {option.label ?? 'N/A'}
+              {ownerState.getOptionLabel(option)}
             </Box>
           )}
           onChange={(_, data) => {

--- a/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
+++ b/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
@@ -170,9 +170,9 @@ const ClusterPopup = (props: ClusterPopupProps) => {
             }
             content={[
               property.properties.Address1,
-              adminAreaData?.find((aa) => aa.Id === property.properties.AdministrativeAreaId)
+              getLookupValueById('AdministrativeAreas', property.properties.AdministrativeAreaId)
                 ?.Name ?? 'No Administrative Area',
-              agencyData?.find((a) => a.Id === property.properties.AgencyId)?.Name ?? 'No Agency',
+              getLookupValueById('Agencies', property.properties.AgencyId)?.Name ?? 'No Agency',
             ]}
           />
         ))}

--- a/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
+++ b/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
@@ -1,14 +1,13 @@
 import { ClusterGeo } from '@/components/map/InventoryLayer';
 import PropertyRow from '@/components/map/propertyRow/PropertyRow';
 import { PropertyTypes } from '@/constants/propertyTypes';
+import { LookupContext } from '@/contexts/lookupContext';
 import { PropertyGeo } from '@/hooks/api/usePropertiesApi';
-import useDataLoader from '@/hooks/useDataLoader';
-import usePimsApi from '@/hooks/usePimsApi';
 import { formatNumber, pidFormatter } from '@/utilities/formatters';
 import { ArrowCircleLeft, ArrowCircleRight } from '@mui/icons-material';
 import { Box, Grid, IconButton, Typography } from '@mui/material';
 import { Point } from 'leaflet';
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 
 export interface PopupState {
   open: boolean;
@@ -36,13 +35,7 @@ interface ClusterPopupProps {
  */
 const ClusterPopup = (props: ClusterPopupProps) => {
   const { popupState, setPopupState } = props;
-  const api = usePimsApi();
-  const { data: agencyData, loadOnce: loadAgencies } = useDataLoader(api.agencies.getAgencies);
-  const { data: adminAreaData, loadOnce: loadAdminAreas } = useDataLoader(
-    api.administrativeAreas.getAdministrativeAreas,
-  );
-  loadAgencies({});
-  loadAdminAreas({});
+  const { getLookupValueById } = useContext(LookupContext);
 
   /**
    * The following block of code determines which direction and position the popup should open with.
@@ -176,11 +169,11 @@ const ClusterPopup = (props: ClusterPopupProps) => {
                 : pidFormatter(property.properties.PID) ?? String(property.properties.PIN)
             }
             content1={
-              adminAreaData?.find((aa) => aa.Id === property.properties.AdministrativeAreaId)
+              getLookupValueById('AdministrativeAreas', property.properties.AdministrativeAreaId)
                 ?.Name ?? 'No Administrative Area'
             }
             content2={
-              agencyData?.find((a) => a.Id === property.properties.AgencyId)?.Name ?? 'No Agency'
+              getLookupValueById('Agencies', property.properties.AgencyId)?.Name ?? 'No Agency'
             }
           />
         ))}

--- a/react-app/src/components/map/controls/FilterControl.tsx
+++ b/react-app/src/components/map/controls/FilterControl.tsx
@@ -2,6 +2,7 @@ import MultiselectFormField from '@/components/form/MultiselectFormField';
 import TextFormField from '@/components/form/TextFormField';
 import { Roles } from '@/constants/roles';
 import { AuthContext } from '@/contexts/authContext';
+import { LookupContext } from '@/contexts/lookupContext';
 import useGroupedAgenciesApi from '@/hooks/api/useGroupedAgenciesApi';
 import { MapFilter } from '@/hooks/api/usePropertiesApi';
 import useDataLoader from '@/hooks/useDataLoader';
@@ -27,29 +28,15 @@ const FilterControl = (props: FilterControlProps) => {
   const { setFilter } = props;
   const api = usePimsApi();
   const user = useContext(AuthContext);
+  const { data: lookupData } = useContext(LookupContext);
 
   // Get lists for dropdowns
-  const agencyOptions = useGroupedAgenciesApi().agencyOptions;
-  const { data: adminAreasData, loadOnce: loadAdminAreas } = useDataLoader(
-    api.administrativeAreas.getAdministrativeAreas,
-  );
-  const { data: classificationsData, loadOnce: loadClassifications } = useDataLoader(
-    api.lookup.getClassifications,
-  );
-  const { data: propertyTypesData, loadOnce: loadPropertyTypes } = useDataLoader(
-    api.lookup.getPropertyTypes,
-  );
+  const { agencyOptions } = useGroupedAgenciesApi();
   const { data: usersAgenciesData, loadOnce: loadUsersAgencies } = useDataLoader(() =>
     api.users.getUsersAgencyIds(user.pimsUser.data?.Username),
   );
-  const { data: regionalDistrictsData, loadOnce: loadRegionalDistricts } = useDataLoader(
-    api.lookup.getRegionalDistricts,
-  );
-  loadAdminAreas({});
-  loadClassifications();
-  loadPropertyTypes();
+
   loadUsersAgencies();
-  loadRegionalDistricts();
 
   // Initial form values
   const formMethods = useForm({
@@ -106,19 +93,17 @@ const FilterControl = (props: FilterControlProps) => {
             name={'AdministrativeAreas'}
             label="Administrative Areas"
             options={
-              adminAreasData
-                ?.filter((aa) => !aa.IsDisabled)
-                .map((aa) => ({
-                  label: aa.Name,
-                  value: aa.Id,
-                })) ?? []
+              lookupData?.AdministrativeAreas.filter((aa) => !aa.IsDisabled).map((aa) => ({
+                label: aa.Name,
+                value: aa.Id,
+              })) ?? []
             }
           />
           <MultiselectFormField
             name={'RegionalDistricts'}
             label="Regional Districts"
             options={
-              regionalDistrictsData?.map((rd) => ({
+              lookupData?.RegionalDistricts.map((rd) => ({
                 label: rd.Name,
                 value: rd.Id,
               })) ?? []
@@ -128,7 +113,7 @@ const FilterControl = (props: FilterControlProps) => {
             name={'Classifications'}
             label="Classifications"
             options={
-              classificationsData?.map((c) => ({
+              lookupData?.Classifications.map((c) => ({
                 label: c.Name,
                 value: c.Id,
               })) ?? []
@@ -138,12 +123,10 @@ const FilterControl = (props: FilterControlProps) => {
             name={'PropertyTypes'}
             label="Property Types"
             options={
-              propertyTypesData
-                ?.filter((pt) => !pt.IsDisabled)
-                .map((pt) => ({
-                  label: pt.Name,
-                  value: pt.Id,
-                })) ?? []
+              lookupData?.PropertyTypes.map((pt) => ({
+                label: pt.Name,
+                value: pt.Id,
+              })) ?? []
             }
           />
           <Grid item xs={12} justifyContent={'space-between'} display={'inline-flex'} gap={1}>

--- a/react-app/src/components/map/sidebar/MapSidebar.tsx
+++ b/react-app/src/components/map/sidebar/MapSidebar.tsx
@@ -4,12 +4,18 @@ import { FilterList, ArrowCircleLeft, ArrowCircleRight } from '@mui/icons-materi
 import { Box, Paper, Grid, IconButton, Typography, Icon, useTheme } from '@mui/material';
 import sideBarIcon from '@/assets/icons/SidebarLeft-Linear.svg';
 import { Map } from 'leaflet';
-import React, { CSSProperties, Dispatch, SetStateAction, useLayoutEffect, useState } from 'react';
+import React, {
+  CSSProperties,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useLayoutEffect,
+  useState,
+} from 'react';
 import PropertyRow from '@/components/map/propertyRow/PropertyRow';
 import { PropertyTypes } from '@/constants/propertyTypes';
-import useDataLoader from '@/hooks/useDataLoader';
-import usePimsApi from '@/hooks/usePimsApi';
 import FilterControl from '@/components/map/controls/FilterControl';
+import { LookupContext } from '@/contexts/lookupContext';
 
 interface MapSidebarProps {
   properties: PropertyGeo[];
@@ -31,17 +37,11 @@ const MapSidebar = (props: MapSidebarProps) => {
   const [pageIndex, setPageIndex] = useState<number>(0);
   const [filterOpen, setFilterOpen] = useState<boolean>(false);
   const theme = useTheme();
-  const api = usePimsApi();
   const propertyPageSize = 20; // Affects paging size
   const sidebarWidth = 350;
 
   // Get related data for lookups
-  const { data: agencyData, loadOnce: loadAgencies } = useDataLoader(api.agencies.getAgencies);
-  const { data: adminAreaData, loadOnce: loadAdminAreas } = useDataLoader(
-    api.administrativeAreas.getAdministrativeAreas,
-  );
-  loadAgencies({});
-  loadAdminAreas({});
+  const { getLookupValueById } = useContext(LookupContext);
 
   // Sets the properties that are in the map's bounds at current view. Resets the page index.
   const definePropertiesInBounds = () => {
@@ -151,12 +151,13 @@ const MapSidebar = (props: MapSidebarProps) => {
                     : pidFormatter(property.properties.PID) ?? String(property.properties.PIN)
                 }
                 content1={
-                  adminAreaData?.find((aa) => aa.Id === property.properties.AdministrativeAreaId)
-                    ?.Name ?? 'No Administrative Area'
+                  getLookupValueById(
+                    'AdministrativeAreas',
+                    property.properties.AdministrativeAreaId,
+                  )?.Name ?? 'No Administrative Area'
                 }
                 content2={
-                  agencyData?.find((a) => a.Id === property.properties.AgencyId)?.Name ??
-                  'No Agency'
+                  getLookupValueById('Agencies', property.properties.AgencyId)?.Name ?? 'No Agency'
                 }
               />
             ))}

--- a/react-app/src/components/map/sidebar/MapSidebar.tsx
+++ b/react-app/src/components/map/sidebar/MapSidebar.tsx
@@ -152,10 +152,11 @@ const MapSidebar = (props: MapSidebarProps) => {
                 }
                 content={[
                   property.properties.Address1,
-                  adminAreaData?.find((aa) => aa.Id === property.properties.AdministrativeAreaId)
-                    ?.Name ?? 'No Administrative Area',
-                  agencyData?.find((a) => a.Id === property.properties.AgencyId)?.Name ??
-                    'No Agency',
+                  getLookupValueById(
+                    'AdministrativeAreas',
+                    property.properties.AdministrativeAreaId,
+                  )?.Name ?? 'No Administrative Area',
+                  getLookupValueById('Agencies', property.properties.AgencyId)?.Name ?? 'No Agency',
                 ]}
               />
             ))}

--- a/react-app/src/components/projects/ProjectForms.tsx
+++ b/react-app/src/components/projects/ProjectForms.tsx
@@ -1,20 +1,17 @@
 import { Grid, InputAdornment, Typography } from '@mui/material';
-import React from 'react';
+import React, { useContext } from 'react';
 import AutocompleteFormField from '../form/AutocompleteFormField';
 import TextFormField from '../form/TextFormField';
 import { ISelectMenuItem } from '../form/SelectFormField';
 import SingleSelectBoxFormField from '../form/SingleSelectBoxFormField';
-import usePimsApi from '@/hooks/usePimsApi';
-import useDataLoader from '@/hooks/useDataLoader';
+import { LookupContext } from '@/contexts/lookupContext';
 
 interface IProjectGeneralInfoForm {
   projectStatuses: ISelectMenuItem[];
 }
 
 export const ProjectGeneralInfoForm = (props: IProjectGeneralInfoForm) => {
-  const api = usePimsApi();
-  const { data: tiers, loadOnce } = useDataLoader(api.lookup.getTierLevels);
-  loadOnce();
+  const { data: lookupData } = useContext(LookupContext);
   return (
     <Grid mt={'1rem'} spacing={2} container>
       <Grid item xs={6}>
@@ -42,7 +39,7 @@ export const ProjectGeneralInfoForm = (props: IProjectGeneralInfoForm) => {
           name={'TierLevelId'}
           label={'Assign Tier'}
           required
-          options={tiers?.map((t) => ({ label: t.Name, value: t.Id })) ?? []}
+          options={lookupData?.ProjectTiers?.map((t) => ({ label: t.Name, value: t.Id })) ?? []}
         />
       </Grid>
       <Grid item xs={12}>

--- a/react-app/src/components/projects/ProjectForms.tsx
+++ b/react-app/src/components/projects/ProjectForms.tsx
@@ -22,7 +22,7 @@ export const ProjectGeneralInfoForm = (props: IProjectGeneralInfoForm) => {
           required
           options={props.projectStatuses}
           name={'StatusId'}
-          label={'Classification'}
+          label={'Status'}
         />
       </Grid>
       <Grid item xs={12}>

--- a/react-app/src/components/property/PropertyDetail.tsx
+++ b/react-app/src/components/property/PropertyDetail.tsx
@@ -29,6 +29,7 @@ import TitleOwnership from '../ltsa/TitleOwnership';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
 import { AuthContext } from '@/contexts/authContext';
 import { Roles } from '@/constants/roles';
+import { LookupContext } from '@/contexts/lookupContext';
 
 interface IPropertyDetail {
   onClose: () => void;
@@ -38,6 +39,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
   const navigate = useNavigate();
   const params = useParams();
   const { keycloak } = useContext(AuthContext);
+  const { getLookupValueById } = useContext(LookupContext);
   const parcelId = isNaN(Number(params.parcelId)) ? null : Number(params.parcelId);
   const buildingId = isNaN(Number(params.buildingId)) ? null : Number(params.buildingId);
   const api = usePimsApi();
@@ -156,6 +158,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
   }, [parcel, building]);
 
   const customFormatter = (key: any, val: any) => {
+    console.log(val);
     switch (key) {
       case 'PID':
         return <Typography>{pidFormatter(val)}</Typography>;
@@ -179,7 +182,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
             <MetresSquared />
           </>
         );
-      case 'LotSize':
+      case 'LandArea':
         return <Typography>{`${val} Hectares`}</Typography>;
       case 'Tenancy':
         return (
@@ -194,26 +197,33 @@ const PropertyDetail = (props: IPropertyDetail) => {
   const mainInformation = useMemo(() => {
     const data: Parcel | Building = buildingOrParcel === 'Building' ? building : parcel;
     const info: any = {
-      Classification: data?.Classification,
+      Classification: getLookupValueById('Classifications', data?.ClassificationId),
       PID: data?.PID ? zeroPadPID(data.PID) : undefined,
       PIN: data?.PIN,
       PostalCode: data?.Postal,
-      Agency: data?.Agency?.Name,
-      AdministrativeArea: data?.AdministrativeArea?.Name,
+      Agency: getLookupValueById('Agencies', data?.AgencyId)?.Name,
+      AdministrativeArea: getLookupValueById('AdministrativeAreas', data?.AdministrativeAreaId)
+        ?.Name,
       Address: data?.Address1,
       IsSensitive: data?.IsSensitive,
       Description: data?.Description,
     };
     if (buildingOrParcel === 'Building') {
       info.Name = (data as Building)?.Name;
-      info.MainUsage = (data as Building)?.BuildingPredominateUse?.Name || '';
-      info.ConstructionType = (data as Building)?.BuildingConstructionType?.Name || '';
+      info.MainUsage = getLookupValueById(
+        'PredominateUses',
+        (data as Building)?.BuildingPredominateUseId,
+      )?.Name;
+      info.ConstructionType = getLookupValueById(
+        'ConstructionTypes',
+        (data as Building)?.BuildingConstructionTypeId,
+      )?.Name;
       info.TotalArea = (data as Building)?.TotalArea;
       info.UsableArea = (data as Building)?.RentableArea;
       info.Tenancy = (data as Building)?.BuildingTenancy;
       info.TenancyDate = dateFormatter((data as Building)?.BuildingTenancyUpdatedOn);
     } else {
-      info.LotSize = (data as Parcel)?.LandArea;
+      info.LandArea = (data as Parcel)?.LandArea;
     }
     return info;
   }, [parcel, building]);

--- a/react-app/src/components/property/PropertyDetail.tsx
+++ b/react-app/src/components/property/PropertyDetail.tsx
@@ -158,7 +158,6 @@ const PropertyDetail = (props: IPropertyDetail) => {
   }, [parcel, building]);
 
   const customFormatter = (key: any, val: any) => {
-    console.log(val);
     switch (key) {
       case 'PID':
         return <Typography>{pidFormatter(val)}</Typography>;

--- a/react-app/src/components/property/PropertyForms.tsx
+++ b/react-app/src/components/property/PropertyForms.tsx
@@ -294,7 +294,7 @@ export const ParcelInformationForm = (props: IParcelInformationForm) => {
         <Grid item xs={6}>
           <TextFormField
             fullWidth
-            label={'Lot size'}
+            label={'Land Area'}
             name={'LandArea'}
             InputProps={{
               endAdornment: <InputAdornment position="end">Hectares</InputAdornment>,

--- a/react-app/src/components/table/DataTable.tsx
+++ b/react-app/src/components/table/DataTable.tsx
@@ -466,7 +466,7 @@ export const FilterSearchDataGrid = (props: FilterSearchDataGridProps) => {
   // Sets quickfilter value of DataGrid. newValue is a string input.
   const updateSearchValue = useMemo(() => {
     return debounce((newValue) => {
-      //tableApiRef.current.setQuickFilterValues(newValue.split(' ').filter((word) => word !== ''));
+      tableApiRef.current.setQuickFilterValues(newValue.split(' ').filter((word) => word !== ''));
       const defaultpagesize = { page: 0, pageSize: tableModel.pagination.pageSize };
       tableApiRef.current.setPaginationModel(defaultpagesize);
       setQuery(defaultpagesize);

--- a/react-app/src/contexts/lookupContext.tsx
+++ b/react-app/src/contexts/lookupContext.tsx
@@ -43,7 +43,7 @@ export const LookupContextProvider: React.FC<React.PropsWithChildren> = (props) 
   // Retrieves record from lookupTables based on table name and record Id.
   const getLookupValueById = (tableName: keyof LookupAll, id: number) => {
     if (lookupTables === undefined) {
-      return {};
+      return undefined;
     } else {
       return lookupTables[tableName][id];
     }

--- a/react-app/src/hooks/api/useGroupedAgenciesApi.ts
+++ b/react-app/src/hooks/api/useGroupedAgenciesApi.ts
@@ -1,25 +1,24 @@
-import { useMemo } from 'react';
-import useDataLoader from '@/hooks/useDataLoader';
-import usePimsApi from '@/hooks/usePimsApi';
+import { useContext, useMemo } from 'react';
 import { Agency } from '@/hooks/api/useAgencyApi';
 import { ISelectMenuItem } from '@/components/form/SelectFormField';
+import { LookupContext } from '@/contexts/lookupContext';
 
 export const useGroupedAgenciesApi = () => {
-  const api = usePimsApi();
-  const { loadOnce: agencyLoad, data: agencyData } = useDataLoader(api.agencies.getAgencies);
-  agencyLoad({});
+  const { data: lookupData } = useContext(LookupContext);
 
   const groupedAgencies = useMemo(() => {
     const groups: { [parentName: string]: Agency[] } = {};
     const parentAgencies: Agency[] = [];
 
     // Populate groups
-    agencyData?.forEach((agency) => {
+    lookupData?.Agencies?.forEach((agency: Agency) => {
       if (!agency.IsDisabled) {
         if (agency.ParentId === null) {
           parentAgencies.push(agency);
         } else {
-          const parentAgency = agencyData.find((parent) => parent.Id === agency.ParentId);
+          const parentAgency = lookupData?.Agencies?.find(
+            (parent) => parent.Id === agency.ParentId,
+          );
           if (parentAgency) {
             if (!groups[parentAgency.Name]) {
               groups[parentAgency.Name] = [];
@@ -39,7 +38,7 @@ export const useGroupedAgenciesApi = () => {
     }));
 
     return groupedAgencies;
-  }, [agencyData]);
+  }, [lookupData]);
 
   const agencyOptions: ISelectMenuItem[] = useMemo(() => {
     const options: ISelectMenuItem[] = [];
@@ -67,7 +66,7 @@ export const useGroupedAgenciesApi = () => {
     return options;
   }, [groupedAgencies]);
 
-  return { groupedAgencies, ungroupedAgencies: agencyData, agencyOptions };
+  return { groupedAgencies, ungroupedAgencies: lookupData?.Agencies, agencyOptions };
 };
 
 export default useGroupedAgenciesApi;


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1801](https://citz-imb.atlassian.net/browse/PIMS-1801)

<!-- PROVIDE BELOW an explanation of your changes -->
Reducing the need for database joins by using the lookup context instead.
## Changes
- Removed a number of dataloader uses where context usage would work instead.
- Removed joins from services where it would no longer affect frontend behaviour
- Uncommented a line to restore quicksearch functionality on client-filtered tables
- MultiselectFormField now accepts nested indent formatting

## Issues
Didn't remove the joins on get______ services. This mostly just applies to tables. Replacing the joins on these tables with just the Id value affects the server-side pagination addition in a negative way. Can continue to look for a solution, but would like to see how the pagination is applied to the Disposal Inventory table first.

## Testing
Just use the app as normal. Note if any values appear missing or if any errors are thrown.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
