### PR TITLE
PIMS-1805: Disposal project property search constraints 

### DIFF
--- a/express-api/src/controllers/properties/propertiesController.ts
+++ b/express-api/src/controllers/properties/propertiesController.ts
@@ -42,7 +42,12 @@ export const getPropertiesFuzzySearch = async (req: Request, res: Response) => {
    */
   const keyword = String(req.query.keyword);
   const take = req.query.take ? Number(req.query.take) : undefined;
-  const result = await propertyServices.propertiesFuzzySearch(keyword, take);
+  const kcUser = req.user;
+  let userAgencies;
+  if (!isAdmin(kcUser)) {
+    userAgencies = await userServices.getAgencies(kcUser.preferred_username);
+  }
+  const result = await propertyServices.propertiesFuzzySearch(keyword, take, userAgencies);
   return res.status(200).send(result);
 };
 

--- a/express-api/src/services/properties/propertiesServices.ts
+++ b/express-api/src/services/properties/propertiesServices.ts
@@ -8,35 +8,61 @@ import {
   constructFindOptionFromQuery,
   constructFindOptionFromQueryPid,
 } from '@/utilities/helperFunctions';
-import { FindOptionsOrder, FindOptionsOrderValue, ILike, In } from 'typeorm';
+import { Brackets, FindOptionsOrder, FindOptionsOrderValue, ILike, In } from 'typeorm';
 
-const propertiesFuzzySearch = async (keyword: string, limit?: number) => {
-  const parcels = await AppDataSource.getRepository(Parcel)
+const propertiesFuzzySearch = async (keyword: string, limit?: number, agencyIds?: number[]) => {
+  const parcelsQuery = await AppDataSource.getRepository(Parcel)
     .createQueryBuilder('parcel')
     .leftJoinAndSelect('parcel.Agency', 'agency')
     .leftJoinAndSelect('parcel.AdministrativeArea', 'adminArea')
     .leftJoinAndSelect('parcel.Evaluations', 'evaluations')
     .leftJoinAndSelect('parcel.Fiscals', 'fiscals')
-    .where(`parcel.pid::text like '%${keyword}%'`)
-    .orWhere(`parcel.pin::text like '%${keyword}%'`)
-    .orWhere(`agency.name like '%${keyword}%'`)
-    .orWhere(`adminArea.name like '%${keyword}%'`)
-    .orWhere(`parcel.address1 like '%${keyword}%'`)
-    .take(limit)
-    .getMany();
-  const buildings = await AppDataSource.getRepository(Building)
+    .leftJoinAndSelect('parcel.Classification', 'classification')
+    .where(
+      new Brackets((qb) => {
+        qb.where(`parcel.pid::text like '%${keyword}%'`)
+          .orWhere(`parcel.pin::text like '%${keyword}%'`)
+          .orWhere(`agency.name like '%${keyword}%'`)
+          .orWhere(`adminArea.name like '%${keyword}%'`)
+          .orWhere(`parcel.address1 like '%${keyword}%'`);
+      }),
+    )
+    .andWhere(`classification.Name in ('Surplus Encumbered', 'Surplus Active')`);
+
+  // Add the optional agencyIds filter if provided
+  if (agencyIds && agencyIds.length > 0) {
+    parcelsQuery.andWhere(`parcel.agency_id IN (:...agencyIds)`, { agencyIds });
+  }
+  if (limit) {
+    parcelsQuery.take(limit);
+  }
+  const parcels = await parcelsQuery.getMany();
+
+  const buildingsQuery = await AppDataSource.getRepository(Building)
     .createQueryBuilder('building')
     .leftJoinAndSelect('building.Agency', 'agency')
     .leftJoinAndSelect('building.AdministrativeArea', 'adminArea')
     .leftJoinAndSelect('building.Evaluations', 'evaluations')
     .leftJoinAndSelect('building.Fiscals', 'fiscals')
-    .where(`building.pid::text like '%${keyword}%'`)
-    .orWhere(`building.pin::text like '%${keyword}%'`)
-    .orWhere(`agency.name like '%${keyword}%'`)
-    .orWhere(`adminArea.name like '%${keyword}%'`)
-    .orWhere(`building.address1 like '%${keyword}%'`)
-    .take(limit)
-    .getMany();
+    .leftJoinAndSelect('building.Classification', 'classification')
+    .where(
+      new Brackets((qb) => {
+        qb.where(`building.pid::text like :keyword`, { keyword: `%${keyword}%` })
+          .orWhere(`building.pin::text like :keyword`, { keyword: `%${keyword}%` })
+          .orWhere(`agency.name like :keyword`, { keyword: `%${keyword}%` })
+          .orWhere(`adminArea.name like :keyword`, { keyword: `%${keyword}%` })
+          .orWhere(`building.address1 like :keyword`, { keyword: `%${keyword}%` });
+      }),
+    )
+    .andWhere(`classification.Name in ('Surplus Encumbered', 'Surplus Active')`);
+
+  if (agencyIds && agencyIds.length > 0) {
+    buildingsQuery.andWhere(`building.agency_id IN (:...agencyIds)`, { agencyIds });
+  }
+  if (limit) {
+    buildingsQuery.take(limit);
+  }
+  const buildings = await buildingsQuery.getMany();
   return {
     Parcels: parcels,
     Buildings: buildings,

--- a/express-api/tests/unit/controllers/properties/propertiesController.test.ts
+++ b/express-api/tests/unit/controllers/properties/propertiesController.test.ts
@@ -49,6 +49,12 @@ jest.mock('@/services/properties/propertiesServices', () => ({
   getPropertiesUnion: () => _getPropertyUnion(),
 }));
 
+const _getAgencies = jest.fn().mockImplementation(async () => [1, 2, 3]);
+
+jest.mock('@/services/users/usersServices', () => ({
+  getAgencies: () => _getAgencies(),
+}));
+
 describe('UNIT - Properties', () => {
   let mockRequest: Request & MockReq, mockResponse: Response & MockRes;
 

--- a/express-api/tests/unit/services/properties/propertyServices.test.ts
+++ b/express-api/tests/unit/services/properties/propertyServices.test.ts
@@ -12,6 +12,7 @@ const _parcelsCreateQueryBuilder: any = {
   leftJoinAndSelect: () => _parcelsCreateQueryBuilder,
   where: () => _parcelsCreateQueryBuilder,
   orWhere: () => _parcelsCreateQueryBuilder,
+  andWhere: () => _parcelsCreateQueryBuilder,
   take: () => _parcelsCreateQueryBuilder,
   getMany: () => [produceParcel()],
 };
@@ -22,6 +23,7 @@ const _buildingsCreateQueryBuilder: any = {
   leftJoinAndSelect: () => _parcelsCreateQueryBuilder,
   where: () => _parcelsCreateQueryBuilder,
   orWhere: () => _parcelsCreateQueryBuilder,
+  andWhere: () => _parcelsCreateQueryBuilder,
   take: () => _parcelsCreateQueryBuilder,
   getMany: () => [produceBuilding()],
 };

--- a/react-app/src/components/property/PropertyTable.tsx
+++ b/react-app/src/components/property/PropertyTable.tsx
@@ -166,7 +166,7 @@ const PropertyTable = (props: IPropertyTable) => {
         ref.current.setFilterModel({ items: [] });
         break;
       case 'Building':
-      case 'Land':
+      case 'Parcel':
         ref.current.setFilterModel({
           items: [{ value, operator: 'contains', field: 'PropertyType' }],
         });
@@ -311,8 +311,8 @@ const PropertyTable = (props: IPropertyTable) => {
             <CustomMenuItem key={'Building'} value={'Building'}>
               Building
             </CustomMenuItem>,
-            <CustomMenuItem key={'Land'} value={'Land'}>
-              Land
+            <CustomMenuItem key={'Parcel'} value={'Parcel'}>
+              Parcel
             </CustomMenuItem>,
           ]}
           tableHeader={'Properties Overview'}


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1805: ](https://citz-imb.atlassian.net/browse/PIMS-1805)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Adding restrictions on property search in projects so that "General Users" should only be able to add their own agency's properties, while administrators can add a property from any agency to a project.

- Only properties that are in "Surplus Active" or "Surplus Encumbered" classification can be added.
<!-- PROVIDE ABOVE an explanation of your changes -->
I needed to change the propertiesFuzzySearch, so hoping this doesn't break anything.

## Testing
- To test, you'll need to change your user's role to a "General User", then search for a property and confirm that you can only see properties belonging to your agency and if you belong to a parent agency, that properties belonging to the sub agency also can be added.
- These properties should all have a classification of either "Surplus Active" or "Surplus Encumbered".
## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
