### PR TITLE
PIMS-1830 Sidebar Count Issue & Other Map Fixes

### DIFF
--- a/react-app/src/components/map/InventoryLayer.tsx
+++ b/react-app/src/components/map/InventoryLayer.tsx
@@ -94,13 +94,14 @@ export const InventoryLayer = (props: InventoryLayerProps) => {
   const icons = {};
   const makeClusterIcon = (count: number) => {
     // Only make one icon per identical count
-    const size = 10 + (count / properties.length) * 40;
+    const size = 10 + (count / properties.length) * 20;
     if (!icons[count]) {
       const displayCount = count < 1000 ? count : `${(count / 1000).toFixed(1)}K`;
       return (icons[count] = L.divIcon({
         html: `<div class="cluster-marker" style="width: ${size}px; height: ${size}px; background-color: rgb(120,120,120); color: white;">
         ${displayCount}
       </div>`,
+        iconAnchor: [size, size], // This helps to centre the icon on the location. Otherwise anchored top-left.
       }));
     }
     return icons[count];

--- a/react-app/src/components/map/ParcelMap.tsx
+++ b/react-app/src/components/map/ParcelMap.tsx
@@ -57,7 +57,11 @@ export const SelectedMarkerContext = createContext(null);
  */
 const ParcelMap = (props: ParcelMapProps) => {
   const MapEvents = () => {
-    useMapEvents({});
+    useMapEvents({
+      resize: () => {
+        setPopupState({ ...popupState, open: false });
+      },
+    });
     return null;
   };
   const api = usePimsApi();

--- a/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
+++ b/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
@@ -43,7 +43,7 @@ const ClusterPopup = (props: ClusterPopupProps) => {
    */
   const screenCentre = { x: window.innerWidth / 2 - 100, y: window.innerHeight / 2 }; // -100 to account for the side menu being open
   let offset: { x: number; y: number } = { x: 0, y: 0 };
-  // Depending on how many properties are available, y displacement changes. 1 = -30, 2 = -120, else -210
+  // Depending on how many properties are available, y displacement changes. 1 = -60, 2 = -180, else -220
   const bottomYOffset =
     popupState.properties.length < 3 ? (popupState.properties.length === 2 ? -180 : -60) : -220;
   // Determine quadrant and set offset

--- a/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
+++ b/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
@@ -45,10 +45,10 @@ const ClusterPopup = (props: ClusterPopupProps) => {
   let offset: { x: number; y: number } = { x: 0, y: 0 };
   // Depending on how many properties are available, y displacement changes. 1 = -30, 2 = -120, else -210
   const bottomYOffset =
-    popupState.properties.length < 3 ? (popupState.properties.length === 2 ? -120 : -30) : -210;
+    popupState.properties.length < 3 ? (popupState.properties.length === 2 ? -180 : -60) : -220;
   // Determine quadrant and set offset
-  const leftXOffset = 25;
-  const rightXOffset = -405;
+  const leftXOffset = 5;
+  const rightXOffset = -415;
   const topYOffset = 80;
   switch (true) {
     // Top-left quadant

--- a/react-app/src/components/map/sidebar/MapSidebar.tsx
+++ b/react-app/src/components/map/sidebar/MapSidebar.tsx
@@ -111,7 +111,7 @@ const MapSidebar = (props: MapSidebarProps) => {
             <Typography
               margin={'0 0.5em'}
               fontSize={'0.8em'}
-            >{`${pageIndex + 1} of ${formatNumber(Math.ceil(propertiesInBounds.length / propertyPageSize))} (${formatNumber(propertiesInBounds.length)} items)`}</Typography>
+            >{`${pageIndex + 1} of ${formatNumber(Math.max(Math.ceil(propertiesInBounds.length / propertyPageSize), 1))} (${formatNumber(propertiesInBounds.length)} items)`}</Typography>
             <IconButton
               size="small"
               onClick={() => {


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1830](https://citz-imb.atlassian.net/browse/PIMS-1830?atlOrigin=eyJpIjoiMDMwZjRkZWI4YjNjNDhhZDg0ZmMxMDE1OTVmYWQ1ODAiLCJwIjoiaiJ9)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Sidebar `x of y` count now has a minimum of 1 for the second number
- Things noticed and fixed while doing this:
  - Clusters' centres are now anchored properly to the location. This is really only obvious for properties of 1, but before the cluster marker anchored from the top-left.
  - Cluster popup closes on resizing the map. Noticed it would just stay up, then be out of position when the map resized before.
  - Shrunk scaling of cluster icons. When there were only a few on the screen, it got much bigger than needed.
  - Updated offset of cluster popup. This was probably affected when the address was added to the property rows.

## Testing
- Use the map page to view the items mentioned above.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
