### PR TITLE
PIMS-1823: Fix count for server-side pagination

### DIFF
--- a/express-api/src/services/projects/projectsServices.ts
+++ b/express-api/src/services/projects/projectsServices.ts
@@ -816,8 +816,6 @@ const getProjects = async (filter: ProjectFilter) => {
     });
   }
 
-  const totalCount = await query.getCount();
-
   if (filter.quantity) query.take(filter.quantity);
   if (filter.page && filter.quantity) query.skip((filter.page ?? 0) * (filter.quantity ?? 0));
   if (filter.sortKey && filter.sortOrder) {
@@ -830,7 +828,7 @@ const getProjects = async (filter: ProjectFilter) => {
       logger.error('PropertyUnion Service - Invalid Sort Key');
     }
   }
-  const projects = await query.getMany();
+  const [projects, totalCount] = await query.getManyAndCount();
   return { projects, totalCount };
 };
 

--- a/express-api/src/services/projects/projectsServices.ts
+++ b/express-api/src/services/projects/projectsServices.ts
@@ -816,6 +816,8 @@ const getProjects = async (filter: ProjectFilter) => {
     });
   }
 
+  const totalCount = await query.getCount();
+
   if (filter.quantity) query.take(filter.quantity);
   if (filter.page && filter.quantity) query.skip((filter.page ?? 0) * (filter.quantity ?? 0));
   if (filter.sortKey && filter.sortOrder) {
@@ -828,7 +830,8 @@ const getProjects = async (filter: ProjectFilter) => {
       logger.error('PropertyUnion Service - Invalid Sort Key');
     }
   }
-  return await query.getMany();
+  const projects = await query.getMany();
+  return { projects, totalCount };
 };
 
 const getProjectsForExport = async (filter: ProjectFilter, includeRelations: boolean = false) => {

--- a/express-api/src/services/properties/propertiesServices.ts
+++ b/express-api/src/services/properties/propertiesServices.ts
@@ -602,6 +602,8 @@ const getPropertiesUnion = async (filter: PropertyUnionFilter) => {
     );
   }
 
+  const totalCount = await query.getCount();
+
   if (filter.quantity) query.take(filter.quantity);
   if (filter.page && filter.quantity) query.skip((filter.page ?? 0) * (filter.quantity ?? 0));
   if (filter.sortKey && filter.sortOrder) {
@@ -614,7 +616,8 @@ const getPropertiesUnion = async (filter: PropertyUnionFilter) => {
       logger.error('PropertyUnion Service - Invalid Sort Key');
     }
   }
-  return await query.getMany();
+  const properties = await query.getMany();
+  return { properties, totalCount };
 };
 
 const propertyServices = {

--- a/express-api/src/services/properties/propertiesServices.ts
+++ b/express-api/src/services/properties/propertiesServices.ts
@@ -602,8 +602,6 @@ const getPropertiesUnion = async (filter: PropertyUnionFilter) => {
     );
   }
 
-  const totalCount = await query.getCount();
-
   if (filter.quantity) query.take(filter.quantity);
   if (filter.page && filter.quantity) query.skip((filter.page ?? 0) * (filter.quantity ?? 0));
   if (filter.sortKey && filter.sortOrder) {
@@ -616,7 +614,7 @@ const getPropertiesUnion = async (filter: PropertyUnionFilter) => {
       logger.error('PropertyUnion Service - Invalid Sort Key');
     }
   }
-  const properties = await query.getMany();
+  const [properties, totalCount] = await query.getManyAndCount();
   return { properties, totalCount };
 };
 

--- a/express-api/tests/unit/services/projects/projectsServices.test.ts
+++ b/express-api/tests/unit/services/projects/projectsServices.test.ts
@@ -237,6 +237,7 @@ const projectJoinQueryBuilder: any = {
   take: () => projectJoinQueryBuilder,
   skip: () => projectJoinQueryBuilder,
   getMany: () => [produceProjectJoin()],
+  getManyAndCount: () => [[produceProjectJoin()], 1],
 };
 jest
   .spyOn(AppDataSource.getRepository(ProjectJoin), 'createQueryBuilder')
@@ -634,6 +635,7 @@ describe('UNIT - Project Services', () => {
         // Call the service function
         const projectsResponse = await projectServices.getProjects(filter); // Pass the mocked projectRepo
         // Returned project should be the one based on the agency and status id in the filter
+        expect(projectsResponse.totalCount).toEqual(1);
         expect(projectsResponse.projects.length).toEqual(1);
       });
     });

--- a/express-api/tests/unit/services/projects/projectsServices.test.ts
+++ b/express-api/tests/unit/services/projects/projectsServices.test.ts
@@ -632,9 +632,9 @@ describe('UNIT - Project Services', () => {
         };
 
         // Call the service function
-        const projects = await projectServices.getProjects(filter); // Pass the mocked projectRepo
+        const projectsResponse = await projectServices.getProjects(filter); // Pass the mocked projectRepo
         // Returned project should be the one based on the agency and status id in the filter
-        expect(projects.length).toEqual(1);
+        expect(projectsResponse.projects.length).toEqual(1);
       });
     });
 

--- a/express-api/tests/unit/services/properties/propertyServices.test.ts
+++ b/express-api/tests/unit/services/properties/propertyServices.test.ts
@@ -53,28 +53,29 @@ const _parcelsCreateQueryBuilder: any = {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _buildingsCreateQueryBuilder: any = {
-  select: () => _parcelsCreateQueryBuilder,
-  leftJoinAndSelect: () => _parcelsCreateQueryBuilder,
-  where: () => _parcelsCreateQueryBuilder,
-  orWhere: () => _parcelsCreateQueryBuilder,
-  andWhere: () => _parcelsCreateQueryBuilder,
-  take: () => _parcelsCreateQueryBuilder,
-  skip: () => _parcelsCreateQueryBuilder,
-  orderBy: () => _parcelsCreateQueryBuilder,
+  select: () => _buildingsCreateQueryBuilder,
+  leftJoinAndSelect: () => _buildingsCreateQueryBuilder,
+  where: () => _buildingsCreateQueryBuilder,
+  orWhere: () => _buildingsCreateQueryBuilder,
+  andWhere: () => _buildingsCreateQueryBuilder,
+  take: () => _buildingsCreateQueryBuilder,
+  skip: () => _buildingsCreateQueryBuilder,
+  orderBy: () => _buildingsCreateQueryBuilder,
   getMany: () => [produceBuilding()],
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _propertyUnionCreateQueryBuilder: any = {
-  select: () => _parcelsCreateQueryBuilder,
-  leftJoinAndSelect: () => _parcelsCreateQueryBuilder,
-  where: () => _parcelsCreateQueryBuilder,
-  orWhere: () => _parcelsCreateQueryBuilder,
-  andWhere: () => _parcelsCreateQueryBuilder,
-  take: () => _parcelsCreateQueryBuilder,
-  skip: () => _parcelsCreateQueryBuilder,
-  orderBy: () => _parcelsCreateQueryBuilder,
+  select: () => _propertyUnionCreateQueryBuilder,
+  leftJoinAndSelect: () => _propertyUnionCreateQueryBuilder,
+  where: () => _propertyUnionCreateQueryBuilder,
+  orWhere: () => _propertyUnionCreateQueryBuilder,
+  andWhere: () => _propertyUnionCreateQueryBuilder,
+  take: () => _propertyUnionCreateQueryBuilder,
+  skip: () => _propertyUnionCreateQueryBuilder,
+  orderBy: () => _propertyUnionCreateQueryBuilder,
   getMany: () => [producePropertyUnion()],
+  getManyAndCount: () => [[producePropertyUnion()], 1],
 };
 
 jest

--- a/express-api/tests/unit/services/properties/propertyServices.test.ts
+++ b/express-api/tests/unit/services/properties/propertyServices.test.ts
@@ -223,14 +223,14 @@ describe('UNIT - Property Services', () => {
         page: 1,
         updatedOn: 'after,' + new Date(),
       });
-      expect(Array.isArray(result));
-      expect(result.at(0)).toHaveProperty('PropertyType');
-      expect(result.at(0)).toHaveProperty('Id');
-      expect(result.at(0)).toHaveProperty('PIN');
-      expect(result.at(0)).toHaveProperty('PID');
-      expect(result.at(0)).toHaveProperty('Agency');
-      expect(result.at(0)).toHaveProperty('Classification');
-      expect(result.at(0)).toHaveProperty('AdministrativeArea');
+      expect(Array.isArray(result.properties)).toBe(true);
+      expect(result.properties.at(0)).toHaveProperty('PropertyType');
+      expect(result.properties.at(0)).toHaveProperty('Id');
+      expect(result.properties.at(0)).toHaveProperty('PIN');
+      expect(result.properties.at(0)).toHaveProperty('PID');
+      expect(result.properties.at(0)).toHaveProperty('Agency');
+      expect(result.properties.at(0)).toHaveProperty('Classification');
+      expect(result.properties.at(0)).toHaveProperty('AdministrativeArea');
     });
   });
 

--- a/react-app/src/components/table/DataTable.tsx
+++ b/react-app/src/components/table/DataTable.tsx
@@ -174,6 +174,7 @@ type FilterSearchDataGridProps = {
   tableOperationMode: 'client' | 'server';
   onPresetFilterChange: (value: string, ref: MutableRefObject<GridApiCommunity>) => void;
   onAddButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
+  rowCountProp?: number;
   defaultFilter: string;
   presetFilterSelectOptions: JSX.Element[];
   tableHeader: string;
@@ -500,8 +501,10 @@ export const FilterSearchDataGrid = (props: FilterSearchDataGridProps) => {
   }, [tableApiRef]);
 
   const tableHeaderRowCount = useMemo(() => {
-    return props.tableOperationMode === 'client' ? `(${rowCount ?? 0} rows)` : '';
-  }, [props.tableOperationMode, rowCount]);
+    return props.tableOperationMode === 'client'
+      ? `(${rowCount ?? 0} rows)`
+      : `(${props.rowCountProp ?? 0} rows)`;
+  }, [props.tableOperationMode, rowCount, props.rowCountProp]);
 
   return (
     <>


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1823: ](https://citz-imb.atlassian.net/browse/PIMS-1823) - Fix count for server-side pagination

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Used a separate query for the "totalCount" in the project and property services because the TypeORM "findAndCount" function still returns the "filtered" number of rows and not the actual count.
- Modified the FilterSearchDataGridProps to take a rowCountProp number as a property that can be passed in.
- You should be able to see the total count reflected in the properties and projects list page as well as a snackbar notification at the bottom of the screen. This number should change when applying a filter on the list being displayed.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
