### PR TITLE
Map popup scrollbar fix

### DIFF
--- a/react-app/src/components/map/parcelPopup/LtsaDetails.tsx
+++ b/react-app/src/components/map/parcelPopup/LtsaDetails.tsx
@@ -22,7 +22,7 @@ const LtsaDetails = (props: LtsaDetailsProps) => {
   }
 
   return (
-    <Box minWidth={width} height={'300px'} overflow={'scroll'}>
+    <Box minWidth={width} height={'300px'}>
       <Grid container gap={1}>
         {ltsaData && ltsaData.order ? (
           <>

--- a/react-app/src/components/map/parcelPopup/ParcelPopup.tsx
+++ b/react-app/src/components/map/parcelPopup/ParcelPopup.tsx
@@ -108,7 +108,7 @@ export const ParcelPopup = (props: ParcelPopupProps) => {
   const tabPanelStyle: SxProps = {
     padding: '1em 0 0 0',
     height: '100%',
-    overflow: 'scroll',
+    overflowY: 'scroll',
   };
 
   if (size === 'large')


### PR DESCRIPTION
Removing double overflow properties so that we don't get scrollbars stacked all over the place in Chromium browsers

<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
Removing double overflow properties so that we don't get scrollbars stacked all over the place in Chromium browsers.
Let me know if this breaks anything somehow but it looks better to me.
## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
