### PR TITLE
PIMS-1752: Allow editing of previous netbook and asssessment values

### DIFF
--- a/react-app/src/components/property/PropertyDialog.tsx
+++ b/react-app/src/components/property/PropertyDialog.tsx
@@ -245,14 +245,6 @@ export const PropertyAssessedValueEditDialog = (props: IPropertyAssessedValueEdi
   const evaluationMapToRequest = (
     evaluations: Partial<ParcelEvaluation>[] | Partial<BuildingEvaluation>[],
   ) => {
-    for (const newEntry of evaluations.filter((f) => f['isNew'])) {
-      const oldEntry = evaluations.findIndex(
-        (f) => Number(f.Year) === Number(newEntry.Year) && !f['isNew'],
-      );
-      if (oldEntry > -1) {
-        evaluations = [...evaluations.slice(0, oldEntry), ...evaluations.slice(oldEntry + 1)];
-      }
-    }
     return evaluations
       .filter((evaluation) => evaluation.Value != null && evaluation.Year)
       .map((evaluation) => ({
@@ -386,14 +378,6 @@ export const PropertyNetBookValueEditDialog = (props: IPropertyNetBookValueEditD
   }, [initialValues]);
 
   const fiscalMapToRequest = (fiscals: Partial<ParcelFiscal>[] | Partial<BuildingFiscal>[]) => {
-    for (const newEntry of fiscals.filter((f) => f['isNew'])) {
-      const oldEntry = fiscals.findIndex(
-        (f) => Number(f.FiscalYear) === Number(newEntry.FiscalYear) && !f['isNew'],
-      );
-      if (oldEntry > -1) {
-        fiscals = [...fiscals.slice(0, oldEntry), ...fiscals.slice(oldEntry + 1)];
-      }
-    }
     return fiscals
       .filter((fiscal) => fiscal.Value != null && fiscal.FiscalYear)
       .map((fiscal) => ({

--- a/react-app/src/components/property/PropertyForms.tsx
+++ b/react-app/src/components/property/PropertyForms.tsx
@@ -486,7 +486,7 @@ export const NetBookValue = (props: INetBookValue) => {
     name: name,
   });
 
-  const handleFiscalYearChange = (inputValue: string) => {
+  const handleFiscalYearChange = (inputValue: string, otherYears: number[]) => {
     if (String(inputValue) == '' || inputValue == null) {
       return true;
     }
@@ -494,11 +494,11 @@ export const NetBookValue = (props: INetBookValue) => {
     if (isNaN(inputYear)) {
       return 'Invalid input.';
     }
-    // const yearValues: number[] = getValueByNestedKey(formValues, name).map(
-    //   (evaluation: ParcelFiscal | BuildingFiscal): number =>
-    //     parseInt(String(evaluation.FiscalYear)),
-    // );
+
     const currentYear = new Date().getFullYear();
+    if (otherYears.includes(Number(inputValue))) {
+      return `An entry already exists for this fiscal year.`;
+    }
     return (
       inputYear === currentYear ||
       inputYear === currentYear - 1 ||
@@ -519,24 +519,23 @@ export const NetBookValue = (props: INetBookValue) => {
                 rules={
                   netbook['isNew']
                     ? {
-                        validate: handleFiscalYearChange,
+                        validate: (value) =>
+                          handleFiscalYearChange(
+                            value,
+                            fields.filter((a) => !a['isNew']).map((a) => a['FiscalYear']),
+                          ),
                       }
                     : undefined
                 }
               />
             </Grid>
             <Grid item xs={4}>
-              <DateFormField
-                disabled={!netbook['isNew']}
-                name={`${name}.${idx}.EffectiveDate`}
-                label={'Effective date'}
-              />
+              <DateFormField name={`${name}.${idx}.EffectiveDate`} label={'Effective date'} />
             </Grid>
             <Grid item xs={4}>
               <TextFormField
                 name={`${name}.${idx}.Value`}
                 label={'Net Book Value'}
-                disabled={!netbook['isNew']}
                 numeric
                 InputProps={{
                   startAdornment: <InputAdornment position="start">$</InputAdornment>,
@@ -574,7 +573,7 @@ interface IAssessedValue {
 
 export const AssessedValue = (props: IAssessedValue) => {
   const { title, name, maxRows } = props;
-  const handleAssessmentYearChange = (inputValue: string) => {
+  const handleAssessmentYearChange = (inputValue: string, otherYears: number[]) => {
     if (String(inputValue) == '' || inputValue == null) {
       return true;
     }
@@ -582,9 +581,9 @@ export const AssessedValue = (props: IAssessedValue) => {
     if (isNaN(inputYear)) {
       return 'Invalid input.';
     }
-    // const yearValues: number[] = getValueByNestedKey(formValues, name).map((evaluation): number =>
-    //   parseInt(evaluation.Year),
-    // );
+    if (otherYears.includes(Number(inputValue))) {
+      return `An entry already exists for this assessment year.`;
+    }
     const currentYear = new Date().getFullYear();
     return (
       inputYear === currentYear ||
@@ -623,7 +622,11 @@ export const AssessedValue = (props: IAssessedValue) => {
               rules={
                 evaluation['isNew']
                   ? {
-                      validate: handleAssessmentYearChange,
+                      validate: (value) =>
+                        handleAssessmentYearChange(
+                          value,
+                          fields.filter((a) => !a['isNew']).map((a) => a['Year']),
+                        ),
                     }
                   : undefined
               }
@@ -634,7 +637,6 @@ export const AssessedValue = (props: IAssessedValue) => {
               }}
               sx={{ minWidth: 'calc(33.3% - 1rem)' }}
               name={`${name}.${idx}.Value`}
-              disabled={!evaluation['isNew']}
               numeric
               label={'Value'}
             />


### PR DESCRIPTION


<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1752: ](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-1752)

* The disabled prop has been removed on the non-year fields of the netbook and assessment forms for properties.
* An additional restriction has been added on adding a new row to these sections: you cannot re-use an existing year. Instead, just edit the relevant row and submit.
* You still must enter a year of current year or previous year for a new value.
* I removed some logic in the transform function for handling the submission, as it should no longer be relevant to do that filtering with the above changes.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
