### PR TITLE
Wrap getLookupValueById in useCallback

### DIFF
--- a/react-app/src/components/property/PropertyDetail.tsx
+++ b/react-app/src/components/property/PropertyDetail.tsx
@@ -255,7 +255,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
       info.LandArea = (data as Parcel)?.LandArea;
     }
     return info;
-  }, [parcel, building]);
+  }, [parcel, building, getLookupValueById]);
 
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
   const [openInformationDialog, setOpenInformationDialog] = useState(false);

--- a/react-app/src/contexts/lookupContext.tsx
+++ b/react-app/src/contexts/lookupContext.tsx
@@ -2,7 +2,7 @@ import { AuthContext } from '@/contexts/authContext';
 import { LookupAll } from '@/hooks/api/useLookupApi';
 import useDataLoader from '@/hooks/useDataLoader';
 import usePimsApi from '@/hooks/usePimsApi';
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useCallback, useContext, useMemo } from 'react';
 
 type LookupContextValue = {
   data: LookupAll | undefined;
@@ -41,13 +41,16 @@ export const LookupContextProvider: React.FC<React.PropsWithChildren> = (props) 
   }, [data]);
 
   // Retrieves record from lookupTables based on table name and record Id.
-  const getLookupValueById = (tableName: keyof LookupAll, id: number) => {
-    if (lookupTables === undefined) {
-      return undefined;
-    } else {
-      return lookupTables[tableName][id];
-    }
-  };
+  const getLookupValueById = useCallback(
+    (tableName: keyof LookupAll, id: number) => {
+      if (lookupTables === undefined) {
+        return undefined;
+      } else {
+        return lookupTables[tableName][id];
+      }
+    },
+    [data],
+  );
 
   const contextValue = { data, getLookupValueById };
   return <LookupContext.Provider value={contextValue}>{props.children}</LookupContext.Provider>;


### PR DESCRIPTION
Wrapped the function for looking up values by id in a useCallback so that dependent components know to re-render when data is loaded. Most evident on the property page as the object used to display property data was memoized and did not have anything lookupContext related as a dependency. 

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
