### PR TITLE
Pims-1773 Only Admins to See Agency Interest

### DIFF
--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -222,13 +222,13 @@ const ProjectDetail = (props: IProjectDetail) => {
   const documentationHistory = 'Documentation History';
 
   const sideBarList = [
-    { title: 'Project Information' },
-    { title: 'Disposal Properties' },
-    { title: 'Financial Information' },
-    { title: 'Documentation History' },
+    { title: projectInformation },
+    { title: disposalProperties },
+    { title: financialInformation },
+    { title: documentationHistory },
   ];
   // only show Agency Interest for admin or auditor
-  isAdmin || isAuditor ? sideBarList.splice(3, 0, { title: 'Agency Interest' }) : null;
+  isAdmin || isAuditor ? sideBarList.splice(3, 0, { title: agencyInterest }) : null;
 
   return (
     <CollapsibleSidebar items={sideBarList}>

--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -215,7 +215,6 @@ const ProjectDetail = (props: IProjectDetail) => {
     refreshData();
   }, [id]);
 
-  // use splice or something to have agency interest onlu show up for admins
   const projectInformation = 'Project Information';
   const disposalProperties = 'Disposal Properties';
   const financialInformation = 'Financial Information';
@@ -228,6 +227,7 @@ const ProjectDetail = (props: IProjectDetail) => {
     { title: 'Financial Information' },
     { title: 'Documentation History' },
   ];
+  // only show Agency Interest for admin or auditor
   isAdmin || isAuditor ? sideBarList.splice(3, 0, { title: 'Agency Interest' }) : null;
 
   return (

--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -228,7 +228,7 @@ const ProjectDetail = (props: IProjectDetail) => {
     { title: 'Financial Information' },
     { title: 'Documentation History' },
   ];
-  isAdmin ? sideBarList.splice(3, 0, { title: 'Agency Interest' }) : null;
+  isAdmin || isAuditor ? sideBarList.splice(3, 0, { title: 'Agency Interest' }) : null;
 
   return (
     <CollapsibleSidebar items={sideBarList}>
@@ -291,7 +291,7 @@ const ProjectDetail = (props: IProjectDetail) => {
           onEdit={() => setOpenFinancialInfoDialog(true)}
           disableEdit={isAuditor}
         />
-        {isAdmin && (
+        {(isAdmin || isAuditor) && (
           <DataCard
             loading={isLoading}
             title={agencyInterest}

--- a/react-app/src/components/projects/ProjectForms.tsx
+++ b/react-app/src/components/projects/ProjectForms.tsx
@@ -1,10 +1,12 @@
 import { Grid, InputAdornment, Typography } from '@mui/material';
 import React, { useContext } from 'react';
 import AutocompleteFormField from '../form/AutocompleteFormField';
+import { AuthContext } from '@/contexts/authContext';
 import TextFormField from '../form/TextFormField';
 import { ISelectMenuItem } from '../form/SelectFormField';
 import SingleSelectBoxFormField from '../form/SingleSelectBoxFormField';
 import { LookupContext } from '@/contexts/lookupContext';
+import { Roles } from '@/constants/roles';
 
 interface IProjectGeneralInfoForm {
   projectStatuses: ISelectMenuItem[];
@@ -12,11 +14,15 @@ interface IProjectGeneralInfoForm {
 
 export const ProjectGeneralInfoForm = (props: IProjectGeneralInfoForm) => {
   const { data: lookupData } = useContext(LookupContext);
+  const { keycloak } = useContext(AuthContext);
+  const canEdit = keycloak.hasRoles([Roles.ADMIN]);
+
   return (
     <Grid mt={'1rem'} spacing={2} container>
       <Grid item xs={6}>
         <AutocompleteFormField
           required
+          disabled={!canEdit}
           options={props.projectStatuses}
           name={'StatusId'}
           label={'Status'}


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1773: ](https://citz-imb.atlassian.net/browse/PIMS-1773)

<!-- PROVIDE BELOW an explanation of your changes -->
as noted in the ticket above here are the changes requested by Josh:

- ~~User list should be limited to Admin – I’m not sure how old PIMS is but I think only admin can see this~~
  - This was cleared up after a conversation - users list should stay as is
- General user should be able to submit Disposal Project, but not change status once submitted under the Project Information heading. Changing status should be limited to Admin after project has been submitted by client.
  - handled in this ticket
- Agency Interest field should only be accessible/viewable to Admin
  - handled in this ticket
- Error when trying to submit application for exemption to ERP – after trying this I now get the error when trying to submit regular project
  - resolved in https://github.com/bcgov/PIMS/pull/2554

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
