### PR TITLE
PIMS-1927 Keycloak Roles Update 

### DIFF
--- a/express-api/tests/testUtils/factories.ts
+++ b/express-api/tests/testUtils/factories.ts
@@ -4,7 +4,7 @@ import { User, UserStatus } from '@/typeorm/Entities/User';
 import { faker } from '@faker-js/faker';
 import { UUID, randomUUID } from 'crypto';
 import { Request, Response } from 'express';
-import { Role as RolesEntity } from '@/typeorm/Entities/Role';
+import { Role, Role as RolesEntity } from '@/typeorm/Entities/Role';
 import { SSOUser } from '@bcgov/citz-imb-sso-express';
 import { Parcel } from '@/typeorm/Entities/Parcel';
 import { Building } from '@/typeorm/Entities/Building';
@@ -184,7 +184,7 @@ export const produceAgency = (props?: Partial<Agency>): Agency => {
   return agency;
 };
 
-export const produceRole = (): RolesEntity => {
+export const produceRole = (props?: Partial<Role>): RolesEntity => {
   return {
     CreatedOn: faker.date.anytime(),
     UpdatedOn: faker.date.anytime(),
@@ -200,6 +200,7 @@ export const produceRole = (): RolesEntity => {
     KeycloakGroupId: faker.string.uuid() as UUID,
     IsPublic: false,
     Users: [],
+    ...props,
   };
 };
 


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1927](https://citz-imb.atlassian.net/browse/PIMS-1927)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
Altered the syncKeycloakUserRoles service so it does the following:
- If the user has keycloak roles, apply them to the database
- If they don't have keycloak roles, but have database roles, apply them to Keycloak
- Otherwise, don't do anything.

## Testing
Try changing your role in both keycloak and the database manually. 
Log in again to see if the sync took affect. This only triggers on login, not a refresh.

## Concern
Because this only triggers on login, there's a situation where a user with no keycloak role may log in and receive the no-access page, even if they have a database role. If they refresh the page, it should resolve itself, but it would be nice to handle this somehow. Open to ideas.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
