### PR TITLE
PIMS-1928: Cancel and resend notifications

### DIFF
--- a/express-api/src/controllers/notifications/notificationsController.ts
+++ b/express-api/src/controllers/notifications/notificationsController.ts
@@ -67,7 +67,12 @@ export const resendNotificationById = async (req: Request, res: Response) => {
     }
   }
   const resultantNotification = await notificationServices.sendNotification(notification, kcUser);
-  return res.status(200).send(resultantNotification);
+  const user = await userServices.getUser(kcUser.preferred_username);
+  const updatedNotification = await notificationServices.updateNotificationStatus(
+    resultantNotification.Id,
+    user,
+  );
+  return res.status(200).send(updatedNotification);
 };
 
 export const cancelNotificationById = async (req: Request, res: Response) => {

--- a/express-api/src/controllers/notifications/notificationsController.ts
+++ b/express-api/src/controllers/notifications/notificationsController.ts
@@ -58,13 +58,8 @@ export const resendNotificationById = async (req: Request, res: Response) => {
     return res.status(404).send('Notification not found.');
   }
   const kcUser = req.user;
-  if (!(isAdmin(kcUser) || isAuditor(kcUser))) {
-    // get array of user's agencies
-    const usersAgencies = await userServices.getAgencies(kcUser.preferred_username);
-    const project = await projectServices.getProjectById(notification.ProjectId);
-    if (!usersAgencies.includes(project.AgencyId)) {
-      return res.status(403).send({ message: 'User is not authorized to access this endpoint.' });
-    }
+  if (!isAdmin(kcUser)) {
+    return res.status(403).send({ message: 'User is not authorized to access this endpoint.' });
   }
   const resultantNotification = await notificationServices.sendNotification(notification, kcUser);
   const user = await userServices.getUser(kcUser.preferred_username);
@@ -82,13 +77,8 @@ export const cancelNotificationById = async (req: Request, res: Response) => {
     return res.status(404).send('Notification not found.');
   }
   const kcUser = req.user;
-  if (!(isAdmin(kcUser) || isAuditor(kcUser))) {
-    // get array of user's agencies
-    const usersAgencies = await userServices.getAgencies(kcUser.preferred_username);
-    const project = await projectServices.getProjectById(notification.ProjectId);
-    if (!usersAgencies.includes(project.AgencyId)) {
-      return res.status(403).send({ message: 'User is not authorized to access this endpoint.' });
-    }
+  if (!isAdmin(kcUser)) {
+    return res.status(403).send({ message: 'User is not authorized to access this endpoint.' });
   }
   const resultantNotification = await notificationServices.cancelNotificationById(notification.Id);
   if (resultantNotification.Status !== NotificationStatus.Cancelled) {

--- a/express-api/src/controllers/notifications/notificationsController.ts
+++ b/express-api/src/controllers/notifications/notificationsController.ts
@@ -1,4 +1,6 @@
-import notificationServices from '@/services/notifications/notificationServices';
+import notificationServices, {
+  NotificationStatus,
+} from '@/services/notifications/notificationServices';
 import userServices from '@/services/users/usersServices';
 import { SSOUser } from '@bcgov/citz-imb-sso-express';
 import { Request, Response } from 'express';
@@ -47,4 +49,45 @@ export const getNotificationsByProjectId = async (req: Request, res: Response) =
     // not sure if the error codes can be handled better here?
     return res.status(500).send({ message: 'Error fetching notifications' });
   }
+};
+
+export const resendNotificationById = async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const notification = await notificationServices.getNotificationById(id);
+  if (!notification) {
+    return res.status(404).send('Notification not found.');
+  }
+  const kcUser = req.user;
+  if (!(isAdmin(kcUser) || isAuditor(kcUser))) {
+    // get array of user's agencies
+    const usersAgencies = await userServices.getAgencies(kcUser.preferred_username);
+    const project = await projectServices.getProjectById(notification.ProjectId);
+    if (!usersAgencies.includes(project.AgencyId)) {
+      return res.status(403).send({ message: 'User is not authorized to access this endpoint.' });
+    }
+  }
+  const resultantNotification = await notificationServices.sendNotification(notification, kcUser);
+  return res.status(200).send(resultantNotification);
+};
+
+export const cancelNotificationById = async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const notification = await notificationServices.getNotificationById(id);
+  if (!notification) {
+    return res.status(404).send('Notification not found.');
+  }
+  const kcUser = req.user;
+  if (!(isAdmin(kcUser) || isAuditor(kcUser))) {
+    // get array of user's agencies
+    const usersAgencies = await userServices.getAgencies(kcUser.preferred_username);
+    const project = await projectServices.getProjectById(notification.ProjectId);
+    if (!usersAgencies.includes(project.AgencyId)) {
+      return res.status(403).send({ message: 'User is not authorized to access this endpoint.' });
+    }
+  }
+  const resultantNotification = await notificationServices.cancelNotificationById(notification.Id);
+  if (resultantNotification.Status !== NotificationStatus.Cancelled) {
+    return res.status(400).send(resultantNotification);
+  }
+  return res.status(200).send(resultantNotification);
 };

--- a/express-api/src/routes/notificationsRouter.ts
+++ b/express-api/src/routes/notificationsRouter.ts
@@ -9,12 +9,20 @@ export const DISPOSAL_API_ROUTE = '/projects/disposal';
 export const NOTIFICATION_QUEUE_ROUTE = '/queue';
 export const NOTIFICATION_TEMPLATE_ROUTE = '/templates';
 
-const { getNotificationsByProjectId } = controllers;
+const { getNotificationsByProjectId, resendNotificationById, cancelNotificationById } = controllers;
 
 //I believe that the IDs used in these routes are actually the project ID, even though the structure here sort of implies
 //that it might be an individual "notification id".
 router
-  .route(`${NOTIFICATION_QUEUE_ROUTE}`)
+  .route(NOTIFICATION_QUEUE_ROUTE)
   .get(activeUserCheck, catchErrors(getNotificationsByProjectId));
+
+router
+  .route(`${NOTIFICATION_QUEUE_ROUTE}/:id`)
+  .put(activeUserCheck, catchErrors(resendNotificationById));
+
+router
+  .route(`${NOTIFICATION_QUEUE_ROUTE}/:id`)
+  .delete(activeUserCheck, catchErrors(cancelNotificationById));
 
 export default router;

--- a/express-api/src/services/ches/chesServices.ts
+++ b/express-api/src/services/ches/chesServices.ts
@@ -231,7 +231,7 @@ const getStatusByIdAsync = async (messageId: string): Promise<IChesStatusRespons
     if (!response) {
       throw new Error(`Failed to fetch status for messageId ${messageId}`);
     }
-    return await response;
+    return response;
   } catch (error) {
     logger.error(`Error fetching status for messageId ${messageId}:`, error);
     return null;

--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -550,6 +550,25 @@ const cancelAllProjectNotifications = async (projectId: number) => {
   };
 };
 
+const cancelNotificationById = async (id: number) => {
+  const notification = await AppDataSource.getRepository(NotificationQueue).findOne({
+    where: { Id: id },
+  });
+  const chesResult = await chesServices.cancelEmailByIdAsync(notification.ChesMessageId);
+  if (chesResult.status === 'cancelled') {
+    return AppDataSource.getRepository(NotificationQueue).save({
+      Id: notification.Id,
+      Status: NotificationStatus.Cancelled,
+    });
+  } else {
+    return notification;
+  }
+};
+
+const getNotificationById = async (id: number) => {
+  return AppDataSource.getRepository(NotificationQueue).findOne({ where: { Id: id } });
+};
+
 const notificationServices = {
   generateProjectNotifications,
   generateAccessRequestNotification,
@@ -558,6 +577,8 @@ const notificationServices = {
   getProjectNotificationsInQueue,
   convertChesStatusToNotificationStatus,
   cancelAllProjectNotifications,
+  getNotificationById,
+  cancelNotificationById,
 };
 
 export default notificationServices;

--- a/express-api/tests/testUtils/factories.ts
+++ b/express-api/tests/testUtils/factories.ts
@@ -29,10 +29,7 @@ import { Task } from '@/typeorm/Entities/Task';
 import { ProjectTask } from '@/typeorm/Entities/ProjectTask';
 import { ProjectStatusNotification } from '@/typeorm/Entities/ProjectStatusNotification';
 import { NotificationQueue } from '@/typeorm/Entities/NotificationQueue';
-import {
-  NotificationAudience,
-  NotificationStatus,
-} from '@/services/notifications/notificationServices';
+import { NotificationAudience } from '@/services/notifications/notificationServices';
 import { NotificationTemplate } from '@/typeorm/Entities/NotificationTemplate';
 import { BuildingFiscal } from '@/typeorm/Entities/BuildingFiscal';
 import { BuildingEvaluation } from '@/typeorm/Entities/BuildingEvaluation';
@@ -916,13 +913,13 @@ export const produceNotificationQueue = (props?: Partial<NotificationQueue>) => 
   const queue: NotificationQueue = {
     Id: faker.number.int(),
     Key: randomUUID(),
-    Status: NotificationStatus.Pending,
-    Priority: EmailPriority.Normal,
-    Encoding: EmailEncoding.Utf8,
+    Status: 1,
+    Priority: 'normal',
+    Encoding: 'utf-8',
     SendOn: new Date(),
     To: faker.internet.email(),
     Subject: faker.lorem.word(),
-    BodyType: EmailBody.Html,
+    BodyType: 'html',
     Body: faker.lorem.sentences(),
     Bcc: '',
     Cc: '',

--- a/express-api/tests/unit/controllers/notifications/notificationsController.test.ts
+++ b/express-api/tests/unit/controllers/notifications/notificationsController.test.ts
@@ -30,6 +30,9 @@ const _getNotifById = jest
 const _cancelNotifById = jest
   .fn()
   .mockImplementation((id: number) => produceNotificationQueue({ Id: id, Status: 2 }));
+const _updateNotifStatus = jest
+  .fn()
+  .mockImplementation((id: number) => produceNotificationQueue({ Id: id }));
 
 jest.mock('@/services/users/usersServices', () => ({
   getAgencies: () => _getAgencies(),
@@ -47,6 +50,7 @@ jest.mock('@/services/notifications/notificationServices', () => ({
       ChesMessageId: randomUUID(),
       ChesTransactionId: randomUUID(),
     }),
+  updateNotificationStatus: (id: number) => _updateNotifStatus(id),
 }));
 
 jest.mock('@/services/projects/projectsServices', () => ({

--- a/express-api/tests/unit/controllers/notifications/notificationsController.test.ts
+++ b/express-api/tests/unit/controllers/notifications/notificationsController.test.ts
@@ -7,8 +7,13 @@ import {
   produceUser,
   produceSSO,
   produceProject,
+  produceNotificationQueue,
 } from 'tests/testUtils/factories';
 import projectServices from '@/services/projects/projectsServices';
+import { randomUUID } from 'crypto';
+import { NotificationQueue } from '@/typeorm/Entities/NotificationQueue';
+import { Roles } from '@/constants/roles';
+import { NotificationStatus } from '@/services/notifications/notificationServices';
 
 const _getUser = jest
   .fn()
@@ -19,6 +24,12 @@ const _getProjectById = jest.fn().mockImplementation(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async (_id: number) => ({ AgencyId: 1 }),
 );
+const _getNotifById = jest
+  .fn()
+  .mockImplementation((id: number) => produceNotificationQueue({ Id: id }));
+const _cancelNotifById = jest
+  .fn()
+  .mockImplementation((id: number) => produceNotificationQueue({ Id: id, Status: 2 }));
 
 jest.mock('@/services/users/usersServices', () => ({
   getAgencies: () => _getAgencies(),
@@ -26,7 +37,16 @@ jest.mock('@/services/users/usersServices', () => ({
 }));
 
 jest.mock('@/services/notifications/notificationServices', () => ({
+  ...jest.requireActual('@/services/notifications/notificationServices'),
   getProjectNotificationsInQueue: () => _getProjectNotificationsInQueue(),
+  getNotificationById: (id: number) => _getNotifById(id),
+  cancelNotificationById: (id: number) => _cancelNotifById(id),
+  sendNotification: (notification: NotificationQueue) =>
+    produceNotificationQueue({
+      ...notification,
+      ChesMessageId: randomUUID(),
+      ChesTransactionId: randomUUID(),
+    }),
 }));
 
 jest.mock('@/services/projects/projectsServices', () => ({
@@ -42,58 +62,116 @@ describe('UNIT - Testing controllers for notifications routes.', () => {
     mockResponse = mockRes;
   });
 
-  it('should return 400 if filter parsing fails', async () => {
-    mockRequest.query = { invalidField: 'invalidValue' };
+  describe('getNotificationsByProjectId', () => {
+    it('should return 400 if filter parsing fails', async () => {
+      mockRequest.query = { invalidField: 'invalidValue' };
 
-    await controllers.getNotificationsByProjectId(mockRequest, mockResponse);
+      await controllers.getNotificationsByProjectId(mockRequest, mockResponse);
 
-    expect(mockResponse.status).toHaveBeenCalledWith(400);
-    expect(mockResponse.send).toHaveBeenCalledWith({ message: 'Could not parse filter.' });
-  });
-
-  it('should return 400 if no valid filter provided', async () => {
-    await controllers.getNotificationsByProjectId(mockRequest, mockResponse);
-
-    expect(mockResponse.statusValue).toBe(400);
-    expect(mockResponse.status).toHaveBeenCalledWith(400);
-    expect(mockResponse.send).toHaveBeenCalledWith({
-      message: 'Could not parse filter.',
-    });
-  });
-
-  it('should return 403 if user is not authorized', async () => {
-    const kcUser = produceSSO();
-    mockRequest.user = kcUser;
-    mockRequest.query = { projectId: '1' };
-
-    await controllers.getNotificationsByProjectId(mockRequest, mockResponse);
-
-    expect(mockResponse.status).toHaveBeenCalledWith(403);
-  });
-
-  it('should return 200 and notifications if user is authorized', async () => {
-    const mockRequest = {
-      query: { projectId: '123' },
-      user: { agencies: [1] },
-    } as unknown as Request;
-
-    const mockProject = produceProject({
-      Id: 123,
-      AgencyId: 1,
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.send).toHaveBeenCalledWith({ message: 'Could not parse filter.' });
     });
 
-    const getProjectByIdSpy = jest
-      .spyOn(projectServices, 'getProjectById')
-      .mockResolvedValueOnce(mockProject);
+    it('should return 400 if no valid filter provided', async () => {
+      await controllers.getNotificationsByProjectId(mockRequest, mockResponse);
 
-    const mockResponse = {
-      status: jest.fn().mockReturnThis(),
-      send: jest.fn(),
-    } as unknown as Response;
+      expect(mockResponse.statusValue).toBe(400);
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.send).toHaveBeenCalledWith({
+        message: 'Could not parse filter.',
+      });
+    });
 
-    await controllers.getNotificationsByProjectId(mockRequest, mockResponse);
+    it('should return 403 if user is not authorized', async () => {
+      const kcUser = produceSSO();
+      mockRequest.user = kcUser;
+      mockRequest.query = { projectId: '1' };
 
-    expect(mockResponse.status).toHaveBeenCalledWith(200);
-    expect(getProjectByIdSpy).toHaveBeenCalledWith(123);
+      await controllers.getNotificationsByProjectId(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(403);
+    });
+
+    it('should return 200 and notifications if user is authorized', async () => {
+      const mockRequest = {
+        query: { projectId: '123' },
+        user: { agencies: [1] },
+      } as unknown as Request;
+
+      const mockProject = produceProject({
+        Id: 123,
+        AgencyId: 1,
+      });
+
+      const getProjectByIdSpy = jest
+        .spyOn(projectServices, 'getProjectById')
+        .mockResolvedValueOnce(mockProject);
+
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        send: jest.fn(),
+      } as unknown as Response;
+
+      await controllers.getNotificationsByProjectId(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(getProjectByIdSpy).toHaveBeenCalledWith(123);
+    });
+  });
+  describe('resendNotifcationById', () => {
+    it('should read a notification and try to send it through ches again, status 200', async () => {
+      mockRequest.params.id = '1';
+      mockRequest.user = produceSSO({ client_roles: [Roles.ADMIN] });
+      await controllers.resendNotificationById(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(mockResponse.sendValue.Id).toBe(1);
+    });
+    it('should 404 if notif not found', async () => {
+      mockRequest.params.id = '1';
+      mockRequest.user = produceSSO({ client_roles: [Roles.ADMIN] });
+      _getNotifById.mockImplementationOnce(() => null);
+      await controllers.resendNotificationById(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(404);
+    });
+    it('should 403 if user lacks permissions', async () => {
+      mockRequest.params.id = '1';
+      mockRequest.user = produceSSO({ client_roles: [] });
+      await controllers.resendNotificationById(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(403);
+    });
+  });
+  describe('cancelNotificationById', () => {
+    it('should try to cancel a notification, status 200', async () => {
+      mockRequest.params.id = '1';
+      mockRequest.user = produceSSO({ client_roles: [Roles.ADMIN] });
+      await controllers.cancelNotificationById(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(200);
+      expect(mockResponse.sendValue.Id).toBe(1);
+      expect(mockResponse.sendValue.Status).toBe(NotificationStatus.Cancelled);
+    });
+    it('should 404 if no notif found', async () => {
+      mockRequest.params.id = '1';
+      mockRequest.user = produceSSO({ client_roles: [Roles.ADMIN] });
+      _getNotifById.mockImplementationOnce(() => null);
+      await controllers.cancelNotificationById(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(404);
+    });
+    it('should 400 if the notification came back with non-cancelled status', async () => {
+      mockRequest.params.id = '1';
+      mockRequest.user = produceSSO({ client_roles: [Roles.ADMIN] });
+      _cancelNotifById.mockImplementationOnce((id: number) =>
+        produceNotificationQueue({ Id: id, Status: NotificationStatus.Completed }),
+      );
+      await controllers.cancelNotificationById(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(400);
+      expect(mockResponse.sendValue.Id).toBe(1);
+      expect(mockResponse.sendValue.Status).not.toBe(NotificationStatus.Cancelled);
+    });
+    it('should 403 if user lacks permissions', async () => {
+      mockRequest.params.id = '1';
+      mockRequest.user = produceSSO({ client_roles: [] });
+      await controllers.cancelNotificationById(mockRequest, mockResponse);
+      expect(mockResponse.statusValue).toBe(403);
+    });
   });
 });

--- a/express-api/tests/unit/services/notifications/notificationServices.test.ts
+++ b/express-api/tests/unit/services/notifications/notificationServices.test.ts
@@ -362,7 +362,6 @@ describe('generateProjectWatchNotifications', () => {
 });
 describe('cancelNotificationById', () => {
   it('should cancel a notificaion', async () => {
-    const result = await notificationServices.cancelNotificationById(1);
     _cancelEmailByIdAsync.mockImplementationOnce(() => ({
       status: 'cancelled',
       tag: 'sampleTag',
@@ -371,22 +370,23 @@ describe('cancelNotificationById', () => {
       createdTS: Date.now(),
       msgId: randomUUID(),
     }));
+    const result = await notificationServices.cancelNotificationById(1);
     expect(result.Status).toBe(NotificationStatus.Cancelled);
   });
   it('should return unmodified notification in the case of a non cancelled notification', async () => {
-    const result = await notificationServices.cancelNotificationById(1);
     _cancelEmailByIdAsync.mockImplementationOnce(() => ({
-      status: 'cancelled',
+      status: 'completed',
       tag: 'sampleTag',
       txId: randomUUID(),
       updatedTS: Date.now(),
       createdTS: Date.now(),
       msgId: randomUUID(),
     }));
-    const notif = produceNotificationQueue();
-    _notifQueueFind.mockImplementationOnce(() => notif);
-    expect(result.ChesMessageId).toBe(result.ChesMessageId);
-    expect(result.Status).toBe(result.Status);
+    const notif = produceNotificationQueue({ ChesMessageId: randomUUID() });
+    _notifQueueFindOne.mockImplementationOnce(() => notif);
+    const result = await notificationServices.cancelNotificationById(1);
+    expect(result.ChesMessageId).toBe(notif.ChesMessageId);
+    expect(result.Status).toBe(notif.Status);
   });
 });
 describe('getNotificationById', () => {

--- a/express-api/tests/unit/services/notifications/notificationServices.test.ts
+++ b/express-api/tests/unit/services/notifications/notificationServices.test.ts
@@ -360,3 +360,41 @@ describe('generateProjectWatchNotifications', () => {
     expect(result.length).toBe(1);
   });
 });
+describe('cancelNotificationById', () => {
+  it('should cancel a notificaion', async () => {
+    const result = await notificationServices.cancelNotificationById(1);
+    _cancelEmailByIdAsync.mockImplementationOnce(() => ({
+      status: 'cancelled',
+      tag: 'sampleTag',
+      txId: randomUUID(),
+      updatedTS: Date.now(),
+      createdTS: Date.now(),
+      msgId: randomUUID(),
+    }));
+    expect(result.Status).toBe(NotificationStatus.Cancelled);
+  });
+  it('should return unmodified notification in the case of a non cancelled notification', async () => {
+    const result = await notificationServices.cancelNotificationById(1);
+    _cancelEmailByIdAsync.mockImplementationOnce(() => ({
+      status: 'cancelled',
+      tag: 'sampleTag',
+      txId: randomUUID(),
+      updatedTS: Date.now(),
+      createdTS: Date.now(),
+      msgId: randomUUID(),
+    }));
+    const notif = produceNotificationQueue();
+    _notifQueueFind.mockImplementationOnce(() => notif);
+    expect(result.ChesMessageId).toBe(result.ChesMessageId);
+    expect(result.Status).toBe(result.Status);
+  });
+});
+describe('getNotificationById', () => {
+  it('should return a single notification', async () => {
+    const result = await notificationServices.getNotificationById(1);
+    expect(result).toBeDefined();
+    expect(result.Status).toBeDefined();
+    expect(result.TemplateId).toBeDefined();
+    expect(result.Id).toBeDefined();
+  });
+});

--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -526,10 +526,12 @@ const ProjectDetail = (props: IProjectDetail) => {
           ungroupedAgencies={ungroupedAgencies as Agency[]}
           initialValues={notifications?.items ?? []}
           open={openNotificationDialog}
-          postSubmit={() => {
-            setOpenNotificationDialog(false);
-            refreshData();
-          }}
+          onRowCancelClick={(id: number) =>
+            cancelNotification(id).then(() => refreshNotifications())
+          }
+          onRowResendClick={(id: number) =>
+            resendNotification(id).then(() => refreshNotifications())
+          }
           onCancel={() => {
             setOpenNotificationDialog(false);
           }}

--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -93,6 +93,8 @@ const ProjectDetail = (props: IProjectDetail) => {
   const { submit: deleteProject, submitting: deletingProject } = useDataSubmitter(
     api.projects.deleteProjectById,
   );
+  const { submit: resendNotification } = useDataSubmitter(api.notifications.resendNotification);
+  const { submit: cancelNotification } = useDataSubmitter(api.notifications.cancelNotification);
 
   const { ungroupedAgencies, agencyOptions } = useGroupedAgenciesApi();
   interface IStatusHistoryStruct {
@@ -456,6 +458,8 @@ const ProjectDetail = (props: IProjectDetail) => {
                       }))
                     : []
                 }
+                onResendClick={(id) => resendNotification(id).then(() => refreshNotifications())}
+                onCancelClick={(id) => cancelNotification(id).then(() => refreshNotifications())}
               />
             )}
           </DataCard>

--- a/react-app/src/components/projects/ProjectDialog.tsx
+++ b/react-app/src/components/projects/ProjectDialog.tsx
@@ -511,7 +511,8 @@ interface INotificationDialog {
   initialValues: NotificationQueue[];
   open: boolean;
   ungroupedAgencies: Partial<Agency>[];
-  postSubmit: () => void;
+  onRowResendClick: (id: number) => void;
+  onRowCancelClick: (id: number) => void;
   onCancel: () => void;
 }
 
@@ -543,7 +544,11 @@ export const ProjectNotificationDialog = (props: INotificationDialog) => {
       }
     >
       <Box paddingTop={'1rem'}>
-        <ProjectNotificationsTable rows={rows} />
+        <ProjectNotificationsTable
+          onCancelClick={props.onRowCancelClick}
+          onResendClick={props.onRowResendClick}
+          rows={rows}
+        />
       </Box>
     </BaseDialog>
   );

--- a/react-app/src/components/projects/ProjectNotificationsTable.tsx
+++ b/react-app/src/components/projects/ProjectNotificationsTable.tsx
@@ -12,8 +12,8 @@ import React, { useState } from 'react';
 interface ProjectNotificationsTableProps {
   rows: NotificationQueue[];
   noteText?: string;
-  onResendClick: (id: number) => void;
-  onCancelClick: (id: number) => void;
+  onResendClick?: (id: number) => void;
+  onCancelClick?: (id: number) => void;
 }
 
 const ProjectNotificationsTable = (props: ProjectNotificationsTableProps) => {

--- a/react-app/src/components/projects/ProjectNotificationsTable.tsx
+++ b/react-app/src/components/projects/ProjectNotificationsTable.tsx
@@ -2,7 +2,8 @@ import { NotificationStatus } from '@/constants/chesNotificationStatus';
 import { NotificationType } from '@/constants/notificationTypes';
 import { NotificationQueue } from '@/hooks/api/useProjectNotificationApi';
 import { dateFormatter } from '@/utilities/formatters';
-import { Box, Button, Typography } from '@mui/material';
+import { Refresh, Delete } from '@mui/icons-material';
+import { Box, IconButton, Tooltip, Typography } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { DateField, LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -63,19 +64,22 @@ const ProjectNotificationsTable = (props: ProjectNotificationsTableProps) => {
       headerName: '',
       sortable: false,
       filterable: false,
+      maxWidth: 20,
       renderCell: (params) => (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '100%',
-          }}
-        >
-          <Button onClick={() => props.onResendClick(params.row.Id)} color="primary">
-            Resend
-          </Button>
-        </div>
+        <Tooltip placement="left" title="Resend Notification">
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              height: '100%',
+            }}
+          >
+            <IconButton onClick={() => props.onResendClick(params.row.Id)} color="primary">
+              <Refresh />
+            </IconButton>
+          </div>
+        </Tooltip>
       ),
     },
     {
@@ -83,26 +87,29 @@ const ProjectNotificationsTable = (props: ProjectNotificationsTableProps) => {
       headerName: '',
       sortable: false,
       filterable: false,
+      maxWidth: 20,
       renderCell: (params) => (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '100%',
-          }}
-        >
-          <Button
-            disabled={
-              params.row.Status !== NotificationStatus.Pending &&
-              params.row.Status !== NotificationStatus.Accepted
-            }
-            onClick={() => props.onCancelClick(params.row.Id)}
-            color="primary"
+        <Tooltip placement="right" title={'Cancel Notification'}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              height: '100%',
+            }}
           >
-            Cancel
-          </Button>
-        </div>
+            <IconButton
+              disabled={
+                params.row.Status !== NotificationStatus.Pending &&
+                params.row.Status !== NotificationStatus.Accepted
+              }
+              onClick={() => props.onCancelClick(params.row.Id)}
+              color="primary"
+            >
+              <Delete />
+            </IconButton>
+          </div>
+        </Tooltip>
       ),
     },
   ];

--- a/react-app/src/components/projects/ProjectNotificationsTable.tsx
+++ b/react-app/src/components/projects/ProjectNotificationsTable.tsx
@@ -1,7 +1,8 @@
+import { NotificationStatus } from '@/constants/chesNotificationStatus';
 import { NotificationType } from '@/constants/notificationTypes';
 import { NotificationQueue } from '@/hooks/api/useProjectNotificationApi';
 import { dateFormatter } from '@/utilities/formatters';
-import { Box, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { DateField, LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -11,6 +12,8 @@ import React, { useState } from 'react';
 interface ProjectNotificationsTableProps {
   rows: NotificationQueue[];
   noteText?: string;
+  onResendClick: (id: number) => void;
+  onCancelClick: (id: number) => void;
 }
 
 const ProjectNotificationsTable = (props: ProjectNotificationsTableProps) => {
@@ -54,6 +57,53 @@ const ProjectNotificationsTable = (props: ProjectNotificationsTableProps) => {
       width: 125,
       valueGetter: (value) => (value == null ? null : new Date(value)),
       renderCell: (params) => (params.value ? dateFormatter(params.value) : ''),
+    },
+    {
+      field: 'Resend',
+      headerName: '',
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}
+        >
+          <Button onClick={() => props.onResendClick(params.row.Id)} color="primary">
+            Resend
+          </Button>
+        </div>
+      ),
+    },
+    {
+      field: 'Cancel',
+      headerName: '',
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}
+        >
+          <Button
+            disabled={
+              params.row.Status !== NotificationStatus.Pending &&
+              params.row.Status !== NotificationStatus.Accepted
+            }
+            onClick={() => props.onCancelClick(params.row.Id)}
+            color="primary"
+          >
+            Cancel
+          </Button>
+        </div>
+      ),
     },
   ];
 

--- a/react-app/src/hooks/api/useBuildingsApi.ts
+++ b/react-app/src/hooks/api/useBuildingsApi.ts
@@ -103,7 +103,7 @@ const useBuildingsApi = (absoluteFetch: IFetch) => {
         Object.fromEntries(Object.entries(params).filter(([_, v]) => v != null))
       : undefined;
     const { parsedBody } = await absoluteFetch.get('/buildings', noNullParam);
-    if (parsedBody.error) {
+    if ((parsedBody as Record<string, any>).error) {
       return [];
     }
     return parsedBody as Building[];

--- a/react-app/src/hooks/api/useParcelsApi.ts
+++ b/react-app/src/hooks/api/useParcelsApi.ts
@@ -74,14 +74,14 @@ const useParcelsApi = (absoluteFetch: IFetch) => {
         Object.fromEntries(Object.entries(params).filter(([_, v]) => v != null))
       : undefined;
     const { parsedBody } = await absoluteFetch.get('/parcels', noNullParam);
-    if (parsedBody.error) {
+    if ((parsedBody as Record<string, any>).error) {
       return [];
     }
     return parsedBody as Parcel[];
   };
   const getParcelsWithRelations = async () => {
     const { parsedBody } = await absoluteFetch.get('/parcels?includeRelations=true');
-    if (parsedBody.error) {
+    if ((parsedBody as Record<string, any>).error) {
       return [];
     }
     return parsedBody as Parcel[];

--- a/react-app/src/hooks/api/useProjectNotificationApi.ts
+++ b/react-app/src/hooks/api/useProjectNotificationApi.ts
@@ -42,7 +42,11 @@ const useProjectNotificationsApi = (absoluteFetch: IFetch) => {
     return absoluteFetch.put(`/notifications/queue/${notificationId}`);
   };
   const cancelNotification = async (notificationId: number) => {
-    return absoluteFetch.del(`/notifications/queue/${notificationId}`);
+    const response = await absoluteFetch.del(`/notifications/queue/${notificationId}`);
+    if (!response.ok) {
+      response.parsedBody = 'Unable to cancel notification.';
+    }
+    return response;
   };
   return {
     getNotificationsByProjectId,

--- a/react-app/src/hooks/api/useProjectNotificationApi.ts
+++ b/react-app/src/hooks/api/useProjectNotificationApi.ts
@@ -38,8 +38,16 @@ const useProjectNotificationsApi = (absoluteFetch: IFetch) => {
     });
     return parsedBody as NotificationResponse;
   };
+  const resendNotification = async (notificationId: number) => {
+    return absoluteFetch.put(`/notifications/queue/${notificationId}`);
+  };
+  const cancelNotification = async (notificationId: number) => {
+    return absoluteFetch.del(`/notifications/queue/${notificationId}`);
+  };
   return {
     getNotificationsByProjectId,
+    resendNotification,
+    cancelNotification,
   };
 };
 

--- a/react-app/src/hooks/api/useProjectsApi.ts
+++ b/react-app/src/hooks/api/useProjectsApi.ts
@@ -334,7 +334,7 @@ const useProjectsApi = (absoluteFetch: IFetch) => {
       },
       { signal },
     );
-    if (parsedBody.error) {
+    if ((parsedBody as Record<string, any>).error) {
       return [];
     }
     return parsedBody as Project[];

--- a/react-app/src/hooks/api/usePropertiesApi.ts
+++ b/react-app/src/hooks/api/usePropertiesApi.ts
@@ -122,7 +122,7 @@ const usePropertiesApi = (absoluteFetch: IFetch) => {
       },
       { signal },
     );
-    if (parsedBody.error) {
+    if ((parsedBody as Record<string, any>).error) {
       return [];
     }
     return parsedBody as (Parcel | Building)[];

--- a/react-app/src/hooks/api/useUsersApi.ts
+++ b/react-app/src/hooks/api/useUsersApi.ts
@@ -43,7 +43,7 @@ const useUsersApi = (absoluteFetch: IFetch) => {
   };
   const getAllUsers = async (sort: CommonFiltering, signal?: AbortSignal) => {
     const { parsedBody } = await absoluteFetch.get('/users', sort, { signal });
-    if (parsedBody.error) {
+    if ((parsedBody as Record<string, any>).error) {
       return [] as User[];
     }
     return parsedBody as User[];

--- a/react-app/src/hooks/useFetch.ts
+++ b/react-app/src/hooks/useFetch.ts
@@ -1,7 +1,7 @@
 import { useSSO } from '@bcgov/citz-imb-sso-react';
 import { useMemo } from 'react';
 
-export type FetchResponse = Response & { parsedBody?: Record<string, any> };
+export type FetchResponse = Response & { parsedBody?: Record<string, any> | string };
 export type FetchType = (url: string, params?: RequestInit) => Promise<Response>;
 export interface IFetch {
   get: (

--- a/react-app/src/pages/BulkUpload.tsx
+++ b/react-app/src/pages/BulkUpload.tsx
@@ -271,7 +271,9 @@ const BulkUpload = () => {
             submit(file).then((resp) => {
               if (resp && resp.ok) {
                 setFile(null);
-                setFileProgress(resp.parsedBody?.CompletionPercentage ?? 0);
+                setFileProgress(
+                  (resp.parsedBody as Record<string, any>)?.CompletionPercentage ?? 0,
+                );
               }
             })
           }


### PR DESCRIPTION
## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1928](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-1928)

* Adds new controllers and services for resending and cancelling notifications
* Adds new frontend hooks for resending and cancelling notifications
* Added buttons to the notification table on the project detail for resending or cancelling projects.

Note:
* The cancel button is greyed out for notifications that are already cancelled or completed, obviously cancelling them doesn't do anything.
* Resending a cancelled or completed notification does work, but the function to refresh notifications in getNotificationByProjectId is hardcoded to not update notifications in these statuses. Should we loosen that restriction? EDIT: This is still true, but I added a call to update just the single notification in the resend endpoint, so this change will be reflected in the frontend table.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
