### PR TITLE
PIMS-1929: Unknown status for project notifications

### DIFF
--- a/express-api/src/controllers/notifications/notificationsController.ts
+++ b/express-api/src/controllers/notifications/notificationsController.ts
@@ -46,7 +46,8 @@ export const getNotificationsByProjectId = async (req: Request, res: Response) =
 
     return res.status(200).send(notificationsResult);
   } catch (error) {
-    // not sure if the error codes can be handled better here?
+    // not sure if the 401 and 500 error codes can be handled better here?
+    // if the ches credentials are incorrect, we don't seem to catch the 401 error in the notificationService
     return res.status(500).send({ message: 'Error fetching notifications' });
   }
 };

--- a/express-api/src/controllers/notifications/notificationsController.ts
+++ b/express-api/src/controllers/notifications/notificationsController.ts
@@ -46,8 +46,6 @@ export const getNotificationsByProjectId = async (req: Request, res: Response) =
 
     return res.status(200).send(notificationsResult);
   } catch (error) {
-    // not sure if the 401 and 500 error codes can be handled better here?
-    // if the ches credentials are incorrect, we don't seem to catch the 401 error in the notificationService
     return res.status(500).send({ message: 'Error fetching notifications' });
   }
 };

--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -34,8 +34,6 @@ export enum NotificationStatus {
   Failed = 3,
   Completed = 4,
   NotFound = 5,
-  Invalid = 6,
-  Unauthorized = 7,
 }
 
 export enum NotificationAudience {
@@ -447,10 +445,6 @@ const convertChesStatusToNotificationStatus = (chesStatus: string): Notification
       return NotificationStatus.Completed;
     case '404':
       return NotificationStatus.NotFound;
-    case '422':
-      return NotificationStatus.Invalid;
-    case '401':
-      return NotificationStatus.Unauthorized;
     default:
       return null;
   }

--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -500,28 +500,19 @@ const updateNotificationStatus = async (notificationId: number, user: User) => {
         query.release();
         return updatedNotification;
       }
-      case 422: {
-        notification.Status = NotificationStatus.Invalid;
-        notification.UpdatedOn = new Date();
-        notification.UpdatedById = user.Id;
-        const updatedNotification = await query.manager.save(NotificationQueue, notification);
+
+      case 422:
         logger.error(
           `Notification with id ${notificationId} could not be processed, some of the data could be formatted incorrectly.`,
         );
-        query.release();
-        return updatedNotification;
-      }
-      case 401: {
-        notification.Status = NotificationStatus.Unauthorized;
-        notification.UpdatedOn = new Date();
-        notification.UpdatedById = user.Id;
-        const updatedNotification = await query.manager.save(NotificationQueue, notification);
+        break;
+
+      case 401:
         logger.error(
           `Cannot authorize the request to the CHES server, check your CHES credentials.`,
         );
-        query.release();
-        return updatedNotification;
-      }
+        break;
+
       case 500:
         logger.error(
           `Internal server error while retrieving status for notification with id ${notificationId}.`,

--- a/express-api/tests/unit/services/notifications/notificationServices.test.ts
+++ b/express-api/tests/unit/services/notifications/notificationServices.test.ts
@@ -24,6 +24,7 @@ import { ProjectStatusNotification } from '@/typeorm/Entities/ProjectStatusNotif
 import { User } from '@/typeorm/Entities/User';
 import { Agency } from '@/typeorm/Entities/Agency';
 import { ProjectStatusHistory } from '@/typeorm/Entities/ProjectStatusHistory';
+import logger from '@/utilities/winstonLogger';
 
 const _notifQueueSave = jest
   .fn()
@@ -271,6 +272,121 @@ describe('updateNotificationStatus', () => {
     // Expect that notification was not updated.
     expect(response.Status).toBe(notification.Status);
   });
+  it('should handle CHES status 404 and update notification status to NotFound', async () => {
+    const user = produceUser();
+    const notifQueue = produceNotificationQueue();
+    notifQueue.ChesMessageId = randomUUID();
+
+    _getStatusByIdAsync.mockResolvedValueOnce({
+      status: 404 as unknown as string,
+      tag: 'sampleTag',
+      txId: randomUUID(),
+      updatedTS: Date.now(),
+      createdTS: Date.now(),
+      msgId: randomUUID(),
+    });
+
+    const response = await notificationServices.updateNotificationStatus(notifQueue.Id, user);
+
+    expect(response.Status).toBe(NotificationStatus.NotFound);
+    expect(response.UpdatedById).toBe(user.Id);
+  });
+
+  it('should handle CHES status 422 and log an error', async () => {
+    const user = produceUser();
+    const notifQueue = produceNotificationQueue();
+    notifQueue.ChesMessageId = randomUUID();
+
+    _getStatusByIdAsync.mockResolvedValueOnce({
+      status: 422 as unknown as string,
+      tag: 'sampleTag',
+      txId: randomUUID(),
+      updatedTS: Date.now(),
+      createdTS: Date.now(),
+      msgId: randomUUID(),
+    });
+
+    const loggerErrorSpy = jest.spyOn(logger, 'error');
+
+    const response = await notificationServices.updateNotificationStatus(notifQueue.Id, user);
+
+    expect(response.Status).toBe(notifQueue.Status);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      `Notification with id ${notifQueue.Id} could not be processed, some of the data could be formatted incorrectly.`,
+    );
+  });
+
+  it('should handle CHES status 401 and log an error', async () => {
+    const user = produceUser();
+    const notifQueue = produceNotificationQueue();
+    notifQueue.ChesMessageId = randomUUID();
+
+    _getStatusByIdAsync.mockResolvedValueOnce({
+      status: 401 as unknown as string,
+      tag: 'sampleTag',
+      txId: randomUUID(),
+      updatedTS: Date.now(),
+      createdTS: Date.now(),
+      msgId: randomUUID(),
+    });
+
+    const loggerErrorSpy = jest.spyOn(logger, 'error');
+
+    const response = await notificationServices.updateNotificationStatus(notifQueue.Id, user);
+
+    expect(response.Status).toBe(notifQueue.Status);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      `Cannot authorize the request to the CHES server, check your CHES credentials.`,
+    );
+  });
+
+  it('should handle CHES status 500 and log an error', async () => {
+    const user = produceUser();
+    const notifQueue = produceNotificationQueue();
+    notifQueue.ChesMessageId = randomUUID();
+
+    _getStatusByIdAsync.mockResolvedValueOnce({
+      status: 500 as unknown as string,
+      tag: 'sampleTag',
+      txId: randomUUID(),
+      updatedTS: Date.now(),
+      createdTS: Date.now(),
+      msgId: randomUUID(),
+    });
+
+    const loggerErrorSpy = jest.spyOn(logger, 'error');
+
+    const response = await notificationServices.updateNotificationStatus(notifQueue.Id, user);
+
+    expect(response.Status).toBe(notifQueue.Status);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      `Internal server error while retrieving status for notification with id ${notifQueue.Id}.`,
+    );
+  });
+  it('should throw an error when getNotificationStatusById fails to retrieve the status', async () => {
+    const mockInvalidStatusResponse: IChesStatusResponse = {
+      status: null, // Simulating an invalid status
+      tag: '',
+      txId: '',
+      updatedTS: 1234,
+      createdTS: 1234,
+      msgId: '',
+    };
+    const user = produceUser();
+
+    // Mock the response of `getStatusByIdAsync` to return the invalid status response
+    jest.spyOn(chesServices, 'getStatusByIdAsync').mockResolvedValueOnce(mockInvalidStatusResponse);
+
+    // Mock the query manager findOne method to return a valid notification
+    const mockNotification = { Id: 1, ChesMessageId: 'some-message-id' };
+    const mockFindOne = jest.spyOn(AppDataSource.createQueryRunner().manager, 'findOne');
+    mockFindOne.mockResolvedValueOnce(mockNotification);
+
+    // Expect the updateNotificationStatus to throw an error
+    await expect(notificationServices.updateNotificationStatus(1, user)).rejects.toThrow(
+      'Failed to retrieve status for notification with id 1.',
+    );
+  });
 });
 describe('convertChesStatusToNotificationStatus', () => {
   it('should return NotificationStatus.Accepted for "accepted"', () => {
@@ -294,6 +410,12 @@ describe('convertChesStatusToNotificationStatus', () => {
   it('should return NotificationStatus.Failed for "failed"', () => {
     expect(notificationServices.convertChesStatusToNotificationStatus('failed')).toBe(
       NotificationStatus.Failed,
+    );
+  });
+
+  it('should return NotificationStatus.NotFound when chesStatus is "404"', () => {
+    expect(notificationServices.convertChesStatusToNotificationStatus('404')).toBe(
+      NotificationStatus.NotFound,
     );
   });
 

--- a/react-app/src/constants/chesNotificationStatus.ts
+++ b/react-app/src/constants/chesNotificationStatus.ts
@@ -5,7 +5,6 @@ export enum NotificationStatus {
   Failed = 3,
   Completed = 4,
   NotFound = 5,
-  Invalid = 6,
 }
 
 export const getStatusString = (status: number): string => {

--- a/react-app/src/constants/chesNotificationStatus.ts
+++ b/react-app/src/constants/chesNotificationStatus.ts
@@ -4,6 +4,8 @@ export enum NotificationStatus {
   Cancelled = 2,
   Failed = 3,
   Completed = 4,
+  NotFound = 5,
+  Invalid = 6,
 }
 
 export const getStatusString = (status: number): string => {
@@ -18,6 +20,10 @@ export const getStatusString = (status: number): string => {
       return 'Failed';
     case NotificationStatus.Completed:
       return 'Completed';
+    case NotificationStatus.NotFound:
+      return 'Not Found';
+    case NotificationStatus.Invalid:
+      return 'Invalid';
     default:
       return 'Unknown';
   }

--- a/react-app/src/constants/chesNotificationStatus.ts
+++ b/react-app/src/constants/chesNotificationStatus.ts
@@ -22,8 +22,6 @@ export const getStatusString = (status: number): string => {
       return 'Completed';
     case NotificationStatus.NotFound:
       return 'Not Found';
-    case NotificationStatus.Invalid:
-      return 'Invalid';
     default:
       return 'Unknown';
   }


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1929: ](https://citz-imb.atlassian.net/browse/PIMS-1929)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Added 2 new notification statuses to handle 404, and 422 responses from the CHES api: https://ches.api.gov.bc.ca/api/v1/docs#tag/Message/operation/GetStatusQuery

- I can't seem to catch the 401 unauthorized response from CHES, this may need handling in the controller.

## Testing
- Since most of the notifications you will have in your localhost are from production, you can use the CHES dev credentials in your .env, then create a new project. To trigger a 404 not found, you can change one of the characters in the ChesMessageId column for the record in the NotificationQueue table where the notifications are stored.

- With existing projects from production, you should still see all the "completed" notifications, but the ones that were in a pending state will most likely display as "Not Found" if you are using the CHES dev credentials.

- Triggering a 422 is kind of tricky and I haven't found a way of doing it other than hard coding the request using an incorrectly formatted CHES Message id which is missing one character for example.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
