### PR TITLE
PIMS-1984: Fiscal year only takes year values.

### DIFF
--- a/react-app/src/components/form/SelectFormField.tsx
+++ b/react-app/src/components/form/SelectFormField.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { FormControl, InputLabel, Select, MenuItem, ListItemText } from '@mui/material';
-import { Controller, useFormContext } from 'react-hook-form';
+import {
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  ListItemText,
+  FormHelperText,
+} from '@mui/material';
+import { Controller, FieldValues, RegisterOptions, useFormContext } from 'react-hook-form';
 
 export interface ISelectMenuItem {
   label: string;
@@ -14,20 +21,32 @@ interface ISelectInputProps {
   name: string;
   label: string | JSX.Element;
   required: boolean;
+  disabled?: boolean;
   options: ISelectMenuItem[];
+  rules?: Omit<
+    RegisterOptions<FieldValues, string>,
+    'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'
+  >;
 }
 
 const SelectFormField = (props: ISelectInputProps) => {
-  const { label, options, name } = props;
+  const { label, options, name, rules, disabled } = props;
   const { control } = useFormContext();
   return (
     <Controller
       name={name}
       control={control}
-      render={({ field }) => (
-        <FormControl fullWidth>
+      rules={rules}
+      render={({ field, fieldState: { error } }) => (
+        <FormControl error={!!error} fullWidth>
           <InputLabel id={`select-inputlabel-${label}`}>{label}</InputLabel>
-          <Select labelId={`select-label-${label}`} id={`select-${label}`} label={label} {...field}>
+          <Select
+            disabled={disabled}
+            labelId={`select-label-${label}`}
+            id={`select-${label}`}
+            label={label}
+            {...field}
+          >
             {options.map((option) => (
               <MenuItem key={`menu-item-${label}-${option.label}`} value={option.value}>
                 <ListItemText
@@ -36,10 +55,11 @@ const SelectFormField = (props: ISelectInputProps) => {
                   sx={{
                     margin: 0,
                   }}
-                />{' '}
+                />
               </MenuItem>
             ))}
           </Select>
+          {error && <FormHelperText>{error.message}</FormHelperText>}
         </FormControl>
       )}
     />

--- a/react-app/src/components/property/PropertyForms.tsx
+++ b/react-app/src/components/property/PropertyForms.tsx
@@ -518,6 +518,18 @@ export const NetBookValue = (props: INetBookValue) => {
       `You may only enter current net book values.`
     );
   };
+
+  const getUnusedYearOptions = (fields: Record<string, any>[]) => {
+    const unusedYears = [];
+    if (!fields.some((field) => field.FiscalYear == new Date().getFullYear())) {
+      unusedYears.push(new Date().getFullYear());
+    }
+    if (!fields.some((field) => field.FiscalYear == new Date().getFullYear() - 1)) {
+      unusedYears.push(new Date().getFullYear() - 1);
+    }
+    return unusedYears;
+  };
+
   return (
     <Box display={'flex'} flexDirection={'column'} gap={'2rem'}>
       <Grid container spacing={2}>
@@ -525,9 +537,18 @@ export const NetBookValue = (props: INetBookValue) => {
         {fields?.map((netbook, idx) => (
           <React.Fragment key={`netbook-item-${netbook.id}`}>
             <Grid item xs={4}>
-              <TextFormField
+              <SelectFormField
+                required
                 name={`${name}.${idx}.FiscalYear`}
                 label={'Fiscal year'}
+                options={
+                  netbook['isNew']
+                    ? getUnusedYearOptions(fields).map((a) => ({
+                        value: a,
+                        label: a,
+                      }))
+                    : [{ value: netbook['FiscalYear'], label: netbook['FiscalYear'] }]
+                }
                 disabled={!netbook['isNew']}
                 rules={
                   netbook['isNew']
@@ -561,7 +582,7 @@ export const NetBookValue = (props: INetBookValue) => {
       <Button
         sx={{ maxWidth: '14rem', alignSelf: 'center' }}
         variant="outlined"
-        disabled={fields.length >= maxRows}
+        disabled={fields.length >= maxRows || !getUnusedYearOptions(fields).length}
         onClick={() =>
           prepend({
             FiscalYear: '',


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1984](https://apps.itsm.gov.bc.ca/jira/browse/PIMS-1984)

Just adding a numeric prop to the text field could have solved this bug but it seemed like it may be better to just constrain this input a lot more in general. After all, there's really only two options that may be valid, max. So with that in mind I've tried to make this a single select style input instead. I also made it so that you can't add more rows once you've added current year and previous year, since past that point nothing else is valid.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
