### PR TITLE
PIMS-2002 Properties Export

### DIFF
--- a/express-api/src/services/properties/propertiesServices.ts
+++ b/express-api/src/services/properties/propertiesServices.ts
@@ -817,6 +817,7 @@ const getPropertiesForExport = async (filter: PropertyUnionFilter) => {
     where: { Id: In(buildingIds) },
   };
 
+  const startTime = new Date()
   let properties: (Parcel | Building)[] = [];
   const ongoingFinds = [];
   ongoingFinds.push(AppDataSource.getRepository(Parcel).find(parcelQueryOptions));
@@ -826,8 +827,51 @@ const getPropertiesForExport = async (filter: PropertyUnionFilter) => {
   resolvedFinds.forEach((propertyList) => {
     properties = properties.concat(...propertyList);
   });
-
+  const endTime = new Date()
+  console.log('time', Math.abs(endTime.getTime() - startTime.getTime()))
   return properties;
+
+  // Getting evals, fiscals, and filtering separately: 850-1050ms
+  // Getting as as part of joins, where clause: 1587-1672ms
+
+  // const ongoingFinds = [];
+  // ongoingFinds.push(AppDataSource.getRepository(Parcel).find(parcelQueryOptions));
+  // ongoingFinds.push(AppDataSource.getRepository(Building).find(buildingQueryOptions));
+  // ongoingFinds.push(AppDataSource.getRepository(ParcelEvaluation).find({order: {Year: 'DESC'}}));
+  // ongoingFinds.push(AppDataSource.getRepository(ParcelFiscal).find({order: {FiscalYear: 'DESC'}}));
+  // ongoingFinds.push(AppDataSource.getRepository(BuildingEvaluation).find({order: {Year: 'DESC'}}));
+  // ongoingFinds.push(AppDataSource.getRepository(BuildingFiscal).find({order: {FiscalYear: 'DESC'}}));
+
+
+  // const resolvedFinds = await Promise.all(ongoingFinds);
+  // const parcelEvaluations = resolvedFinds.at(2) as ParcelEvaluation[];
+  // const parcelFiscals = resolvedFinds.at(3) as ParcelFiscal[];
+  // const buildingEvaluations = resolvedFinds.at(4) as BuildingEvaluation[];
+  // const buildingFiscals = resolvedFinds.at(5) as BuildingFiscal[];
+  // const parcels: Parcel[] = (resolvedFinds.at(0) as Parcel[]).filter((p: Parcel) => parcelIds.includes(p.Id))
+  // .map((p: Parcel) => {
+  //   const evaluation = parcelEvaluations.find(pe => pe.ParcelId === p.Id);
+  //   const fiscal = parcelFiscals.find(pf => pf.ParcelId === p.Id);
+  //   return ({
+  //   ...p,
+  //   Evaluations: evaluation ? [evaluation] : undefined,
+  //   Fiscals: fiscal ? [fiscal] : undefined,
+  // })});
+  // const buildings: Building[] = (resolvedFinds.at(1) as Building[]).filter((b: Building) => buildingIds.includes(b.Id))
+  // .map((b: Building) => {
+  //   const evaluation = buildingEvaluations.find(be => be.BuildingId === b.Id);
+  //   const fiscal = buildingFiscals.find(bf => bf.BuildingId === b.Id);
+  //   return ({
+  //   ...b,
+  //   Evaluations: evaluation ? [evaluation] : undefined,
+  //   Fiscals: fiscal ? [fiscal] : undefined,
+  // })});;
+
+  // const endTime = new Date()
+  // console.log('time', Math.abs(endTime.getTime() - startTime.getTime()))
+
+
+  // return [...parcels, ...buildings];
 };
 
 /**

--- a/express-api/src/services/properties/propertiesServices.ts
+++ b/express-api/src/services/properties/propertiesServices.ts
@@ -30,7 +30,7 @@ import {
   constructFindOptionFromQuerySingleSelect,
 } from '@/utilities/helperFunctions';
 import userServices from '../users/usersServices';
-import { Brackets, FindManyOptions, FindOptionsWhere, ILike, In, QueryRunner } from 'typeorm';
+import { Brackets, FindOptionsWhere, ILike, In, QueryRunner } from 'typeorm';
 import { SSOUser } from '@bcgov/citz-imb-sso-express';
 import { PropertyType } from '@/constants/propertyType';
 import { ProjectStatus } from '@/constants/projectStatus';
@@ -799,79 +799,62 @@ const getPropertiesForExport = async (filter: PropertyUnionFilter) => {
   const buildingIds = filteredProperties
     .filter((p) => p.PropertyTypeId === PropertyType.BUILDING)
     .map((b) => b.Id);
-  // Use IDs from filtered properties to get those properites with joins
-  const parcelQueryOptions: FindManyOptions<Parcel> = {
-    relations: {
-      Evaluations: true,
-      Fiscals: true,
-    },
-    where: {
-      Id: In(parcelIds),
-    },
-  };
-  const buildingQueryOptions: FindManyOptions<Building> = {
-    relations: {
-      Evaluations: true,
-      Fiscals: true,
-    },
-    where: { Id: In(buildingIds) },
-  };
 
-  const startTime = new Date()
-  let properties: (Parcel | Building)[] = [];
+  /**
+   * For some reason, getting the data in multiple calls and filtering here is faster than letting TypeORM do it.
+   *
+   * Getting evals, fiscals, and filtering separately: 850-1050ms
+   * Getting as as part of joins, WHERE clause with TypeORM: 1587-1672ms
+   */
+
   const ongoingFinds = [];
-  ongoingFinds.push(AppDataSource.getRepository(Parcel).find(parcelQueryOptions));
-  ongoingFinds.push(AppDataSource.getRepository(Building).find(buildingQueryOptions));
+  ongoingFinds.push(AppDataSource.getRepository(Parcel).find());
+  ongoingFinds.push(AppDataSource.getRepository(Building).find());
+  // Order these to guarantee the find operation later gets the most recent one.
+  ongoingFinds.push(
+    AppDataSource.getRepository(ParcelEvaluation).find({ order: { Year: 'DESC' } }),
+  );
+  ongoingFinds.push(
+    AppDataSource.getRepository(ParcelFiscal).find({ order: { FiscalYear: 'DESC' } }),
+  );
+  ongoingFinds.push(
+    AppDataSource.getRepository(BuildingEvaluation).find({ order: { Year: 'DESC' } }),
+  );
+  ongoingFinds.push(
+    AppDataSource.getRepository(BuildingFiscal).find({ order: { FiscalYear: 'DESC' } }),
+  );
 
+  // Wait for all database requests to resolve, then build the parcels and buildings lists
+  // Use IDs from filtered properties above to filter lists
   const resolvedFinds = await Promise.all(ongoingFinds);
-  resolvedFinds.forEach((propertyList) => {
-    properties = properties.concat(...propertyList);
-  });
-  const endTime = new Date()
-  console.log('time', Math.abs(endTime.getTime() - startTime.getTime()))
-  return properties;
+  const parcelEvaluations = resolvedFinds.at(2) as ParcelEvaluation[];
+  const parcelFiscals = resolvedFinds.at(3) as ParcelFiscal[];
+  const buildingEvaluations = resolvedFinds.at(4) as BuildingEvaluation[];
+  const buildingFiscals = resolvedFinds.at(5) as BuildingFiscal[];
+  const parcels: Parcel[] = (resolvedFinds.at(0) as Parcel[])
+    .filter((p: Parcel) => parcelIds.includes(p.Id))
+    .map((p: Parcel) => {
+      const evaluation = parcelEvaluations.find((pe) => pe.ParcelId === p.Id);
+      const fiscal = parcelFiscals.find((pf) => pf.ParcelId === p.Id);
+      return {
+        ...p,
+        Evaluations: evaluation ? [evaluation] : undefined,
+        Fiscals: fiscal ? [fiscal] : undefined,
+      };
+    });
+  const buildings: Building[] = (resolvedFinds.at(1) as Building[])
+    .filter((b: Building) => buildingIds.includes(b.Id))
+    .map((b: Building) => {
+      const evaluation = buildingEvaluations.find((be) => be.BuildingId === b.Id);
+      const fiscal = buildingFiscals.find((bf) => bf.BuildingId === b.Id);
+      return {
+        ...b,
+        Evaluations: evaluation ? [evaluation] : undefined,
+        Fiscals: fiscal ? [fiscal] : undefined,
+      };
+    });
 
-  // Getting evals, fiscals, and filtering separately: 850-1050ms
-  // Getting as as part of joins, where clause: 1587-1672ms
-
-  // const ongoingFinds = [];
-  // ongoingFinds.push(AppDataSource.getRepository(Parcel).find(parcelQueryOptions));
-  // ongoingFinds.push(AppDataSource.getRepository(Building).find(buildingQueryOptions));
-  // ongoingFinds.push(AppDataSource.getRepository(ParcelEvaluation).find({order: {Year: 'DESC'}}));
-  // ongoingFinds.push(AppDataSource.getRepository(ParcelFiscal).find({order: {FiscalYear: 'DESC'}}));
-  // ongoingFinds.push(AppDataSource.getRepository(BuildingEvaluation).find({order: {Year: 'DESC'}}));
-  // ongoingFinds.push(AppDataSource.getRepository(BuildingFiscal).find({order: {FiscalYear: 'DESC'}}));
-
-
-  // const resolvedFinds = await Promise.all(ongoingFinds);
-  // const parcelEvaluations = resolvedFinds.at(2) as ParcelEvaluation[];
-  // const parcelFiscals = resolvedFinds.at(3) as ParcelFiscal[];
-  // const buildingEvaluations = resolvedFinds.at(4) as BuildingEvaluation[];
-  // const buildingFiscals = resolvedFinds.at(5) as BuildingFiscal[];
-  // const parcels: Parcel[] = (resolvedFinds.at(0) as Parcel[]).filter((p: Parcel) => parcelIds.includes(p.Id))
-  // .map((p: Parcel) => {
-  //   const evaluation = parcelEvaluations.find(pe => pe.ParcelId === p.Id);
-  //   const fiscal = parcelFiscals.find(pf => pf.ParcelId === p.Id);
-  //   return ({
-  //   ...p,
-  //   Evaluations: evaluation ? [evaluation] : undefined,
-  //   Fiscals: fiscal ? [fiscal] : undefined,
-  // })});
-  // const buildings: Building[] = (resolvedFinds.at(1) as Building[]).filter((b: Building) => buildingIds.includes(b.Id))
-  // .map((b: Building) => {
-  //   const evaluation = buildingEvaluations.find(be => be.BuildingId === b.Id);
-  //   const fiscal = buildingFiscals.find(bf => bf.BuildingId === b.Id);
-  //   return ({
-  //   ...b,
-  //   Evaluations: evaluation ? [evaluation] : undefined,
-  //   Fiscals: fiscal ? [fiscal] : undefined,
-  // })});;
-
-  // const endTime = new Date()
-  // console.log('time', Math.abs(endTime.getTime() - startTime.getTime()))
-
-
-  // return [...parcels, ...buildings];
+  return [...parcels, ...buildings];
 };
 
 /**

--- a/express-api/tests/testUtils/factories.ts
+++ b/express-api/tests/testUtils/factories.ts
@@ -217,7 +217,7 @@ export const produceSSO = (props?: Partial<SSOUser>): SSOUser => {
   };
 };
 
-export const produceParcel = (): Parcel => {
+export const produceParcel = (props?: Partial<Parcel>): Parcel => {
   const id = faker.number.int({ max: 10 });
   return {
     Id: faker.number.int({ max: 10 }),
@@ -252,11 +252,12 @@ export const produceParcel = (): Parcel => {
     CreatedBy: undefined,
     UpdatedById: undefined,
     UpdatedBy: undefined,
-    Fiscals: produceParcelFiscal(id),
-    Evaluations: produceParcelEvaluation(id),
+    Fiscals: produceParcelFiscals(id),
+    Evaluations: produceParcelEvaluations(id),
     DeletedById: null,
     DeletedOn: null,
     DeletedBy: undefined,
+    ...props,
   };
 };
 
@@ -284,7 +285,7 @@ export const produceEmail = (props: Partial<IEmail>): IEmail => {
   return email;
 };
 
-export const produceBuilding = (): Building => {
+export const produceBuilding = (props?: Partial<Building>): Building => {
   const agencyId = faker.number.int();
   const id = faker.number.int({ max: 10 });
   return {
@@ -328,17 +329,18 @@ export const produceBuilding = (): Building => {
     CreatedBy: undefined,
     UpdatedById: undefined,
     UpdatedBy: undefined,
-    Fiscals: produceBuildingFiscal(id),
-    Evaluations: produceBuildingEvaluation(id),
+    Fiscals: produceBuildingFiscals(id),
+    Evaluations: produceBuildingEvaluations(id),
     PID: undefined,
     PIN: undefined,
     DeletedById: null,
     DeletedOn: null,
     DeletedBy: undefined,
+    ...props,
   };
 };
 
-export const produceBuildingEvaluation = (
+export const produceBuildingEvaluations = (
   buildingId: number,
   props?: Partial<BuildingEvaluation>,
 ): BuildingEvaluation[] => {
@@ -355,7 +357,7 @@ export const produceBuildingEvaluation = (
   return [evaluation];
 };
 
-export const produceBuildingFiscal = (
+export const produceBuildingFiscals = (
   buildingId: number,
   props?: Partial<BuildingFiscal>,
 ): BuildingFiscal[] => {
@@ -370,7 +372,7 @@ export const produceBuildingFiscal = (
   return [fiscal];
 };
 
-export const produceParcelEvaluation = (
+export const produceParcelEvaluations = (
   parcelId: number,
   props?: Partial<ParcelEvaluation>,
 ): ParcelEvaluation[] => {
@@ -388,7 +390,7 @@ export const produceParcelEvaluation = (
   return [evaluation];
 };
 
-export const produceParcelFiscal = (
+export const produceParcelFiscals = (
   parcelId: number,
   props?: Partial<ParcelFiscal>,
 ): ParcelFiscal[] => {

--- a/express-api/tests/unit/services/buildings/buildingService.test.ts
+++ b/express-api/tests/unit/services/buildings/buildingService.test.ts
@@ -2,8 +2,8 @@ import { AppDataSource } from '@/appDataSource';
 import { Building } from '@/typeorm/Entities/Building';
 import {
   produceBuilding,
-  produceBuildingEvaluation,
-  produceBuildingFiscal,
+  produceBuildingEvaluations,
+  produceBuildingFiscals,
   produceSSO,
   produceUser,
 } from 'tests/testUtils/factories';
@@ -26,11 +26,11 @@ const _buildingSave = jest
 
 const _buildingFiscalFindOne = jest
   .spyOn(AppDataSource.getRepository(BuildingFiscal), 'findOne')
-  .mockImplementation(async () => produceBuildingFiscal(1)[0]);
+  .mockImplementation(async () => produceBuildingFiscals(1)[0]);
 
 const _buildingEvaluationFindOne = jest
   .spyOn(AppDataSource.getRepository(BuildingEvaluation), 'findOne')
-  .mockImplementation(async () => produceBuildingEvaluation(1)[0]);
+  .mockImplementation(async () => produceBuildingEvaluations(1)[0]);
 
 const _buildingFindOne = jest
   .spyOn(buildingRepo, 'findOne')
@@ -38,11 +38,11 @@ const _buildingFindOne = jest
 
 jest
   .spyOn(AppDataSource.getRepository(BuildingFiscal), 'find')
-  .mockImplementation(async () => produceBuildingFiscal(1));
+  .mockImplementation(async () => produceBuildingFiscals(1));
 
 jest
   .spyOn(AppDataSource.getRepository(BuildingEvaluation), 'find')
-  .mockImplementation(async () => produceBuildingEvaluation(1));
+  .mockImplementation(async () => produceBuildingEvaluations(1));
 
 const _mockStartTransaction = jest.fn(async () => {});
 const _mockRollbackTransaction = jest.fn(async () => {});

--- a/express-api/tests/unit/services/parcels/parcelsService.test.ts
+++ b/express-api/tests/unit/services/parcels/parcelsService.test.ts
@@ -2,8 +2,8 @@ import { AppDataSource } from '@/appDataSource';
 import { Parcel } from '@/typeorm/Entities/Parcel';
 import {
   produceParcel,
-  produceParcelEvaluation,
-  produceParcelFiscal,
+  produceParcelEvaluations,
+  produceParcelFiscals,
   produceSSO,
   produceUser,
 } from 'tests/testUtils/factories';
@@ -28,7 +28,7 @@ const _parcelSave = jest
 const _parcelFindOne = jest.spyOn(parcelRepo, 'findOne').mockImplementation(async () => {
   const parcel = produceParcel();
   const { Id } = parcel;
-  produceParcelFiscal(Id);
+  produceParcelFiscals(Id);
   return parcel;
 });
 
@@ -42,10 +42,10 @@ const _parcelFindOne = jest.spyOn(parcelRepo, 'findOne').mockImplementation(asyn
 
 const _parcelEvaluationFindOne = jest
   .spyOn(AppDataSource.getRepository(ParcelEvaluation), 'findOne')
-  .mockImplementation(async () => produceParcelEvaluation(1)[0]);
+  .mockImplementation(async () => produceParcelEvaluations(1)[0]);
 const _parcelFiscalFindOne = jest
   .spyOn(AppDataSource.getRepository(ParcelFiscal), 'findOne')
-  .mockImplementation(async () => produceParcelFiscal(1)[0]);
+  .mockImplementation(async () => produceParcelFiscals(1)[0]);
 
 // const _parcelFindOne = jest
 //   .spyOn(parcelRepo, 'findOne')
@@ -60,10 +60,10 @@ jest.spyOn(userServices, 'getAgencies').mockImplementation(async () => []);
 
 jest
   .spyOn(AppDataSource.getRepository(ParcelEvaluation), 'find')
-  .mockImplementation(async () => produceParcelEvaluation(1));
+  .mockImplementation(async () => produceParcelEvaluations(1));
 jest
   .spyOn(AppDataSource.getRepository(ParcelFiscal), 'find')
-  .mockImplementation(async () => produceParcelFiscal(1));
+  .mockImplementation(async () => produceParcelFiscals(1));
 
 const _mockStartTransaction = jest.fn(async () => {});
 const _mockRollbackTransaction = jest.fn(async () => {});

--- a/express-api/tests/unit/services/properties/propertyServices.test.ts
+++ b/express-api/tests/unit/services/properties/propertyServices.test.ts
@@ -81,8 +81,17 @@ const _propertyUnionCreateQueryBuilder: any = {
   take: () => _propertyUnionCreateQueryBuilder,
   skip: () => _propertyUnionCreateQueryBuilder,
   orderBy: () => _propertyUnionCreateQueryBuilder,
-  getMany: () => [producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.LAND }), producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.BUILDING })],
-  getManyAndCount: () => [[producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.LAND }), producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.BUILDING })], 1],
+  getMany: () => [
+    producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.LAND }),
+    producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.BUILDING }),
+  ],
+  getManyAndCount: () => [
+    [
+      producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.LAND }),
+      producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.BUILDING }),
+    ],
+    1,
+  ],
 };
 
 const _projectStatusCreateQueryBuilder: any = {
@@ -152,7 +161,7 @@ jest
 const parcelRepoSpy = jest
   .spyOn(AppDataSource.getRepository(Parcel), 'find')
   .mockImplementation(async () => [produceParcel()]);
-  const buildingRepoSpy = jest
+const buildingRepoSpy = jest
   .spyOn(AppDataSource.getRepository(Building), 'find')
   .mockImplementation(async () => [produceBuilding()]);
 jest
@@ -308,8 +317,8 @@ describe('UNIT - Property Services', () => {
 
   describe('getPropertiesforExport', () => {
     it('should get a list of properties based on the filter', async () => {
-      parcelRepoSpy.mockImplementationOnce(async () => [produceParcel({Id: 1})])
-      buildingRepoSpy.mockImplementationOnce(async () => [produceBuilding({Id: 1})])
+      parcelRepoSpy.mockImplementationOnce(async () => [produceParcel({ Id: 1 })]);
+      buildingRepoSpy.mockImplementationOnce(async () => [produceBuilding({ Id: 1 })]);
       const result = await propertyServices.getPropertiesForExport({
         pid: 'contains,123',
         pin: 'contains,456',

--- a/express-api/tests/unit/services/properties/propertyServices.test.ts
+++ b/express-api/tests/unit/services/properties/propertyServices.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AppDataSource } from '@/appDataSource';
+import { PropertyType } from '@/constants/propertyType';
 import { Roles } from '@/constants/roles';
 import propertyServices, {
   getAgencyOrThrowIfMismatched,
@@ -36,10 +37,10 @@ import {
   produceAdminArea,
   produceUser,
   produceImportResult,
-  produceParcelEvaluation,
-  produceParcelFiscal,
-  produceBuildingEvaluation,
-  produceBuildingFiscal,
+  produceParcelEvaluations,
+  produceParcelFiscals,
+  produceBuildingEvaluations,
+  produceBuildingFiscals,
   produceSSO,
   produceProjectStatus,
   produceProjectProperty,
@@ -80,8 +81,8 @@ const _propertyUnionCreateQueryBuilder: any = {
   take: () => _propertyUnionCreateQueryBuilder,
   skip: () => _propertyUnionCreateQueryBuilder,
   orderBy: () => _propertyUnionCreateQueryBuilder,
-  getMany: () => [producePropertyUnion()],
-  getManyAndCount: () => [[producePropertyUnion()], 1],
+  getMany: () => [producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.LAND }), producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.BUILDING })],
+  getManyAndCount: () => [[producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.LAND }), producePropertyUnion({ Id: 1, PropertyTypeId: PropertyType.BUILDING })], 1],
 };
 
 const _projectStatusCreateQueryBuilder: any = {
@@ -148,12 +149,24 @@ jest
   .spyOn(AppDataSource.getRepository(PropertyUnion), 'createQueryBuilder')
   .mockImplementation(() => _propertyUnionCreateQueryBuilder);
 
-jest
+const parcelRepoSpy = jest
   .spyOn(AppDataSource.getRepository(Parcel), 'find')
   .mockImplementation(async () => [produceParcel()]);
-jest
+  const buildingRepoSpy = jest
   .spyOn(AppDataSource.getRepository(Building), 'find')
   .mockImplementation(async () => [produceBuilding()]);
+jest
+  .spyOn(AppDataSource.getRepository(ParcelEvaluation), 'find')
+  .mockImplementation(async () => produceParcelEvaluations(1));
+jest
+  .spyOn(AppDataSource.getRepository(ParcelFiscal), 'find')
+  .mockImplementation(async () => produceParcelFiscals(1));
+jest
+  .spyOn(AppDataSource.getRepository(BuildingEvaluation), 'find')
+  .mockImplementation(async () => produceBuildingEvaluations(1));
+jest
+  .spyOn(AppDataSource.getRepository(BuildingFiscal), 'find')
+  .mockImplementation(async () => produceBuildingFiscals(1));
 jest
   .spyOn(AppDataSource.getRepository(Parcel), 'save')
   .mockImplementation(async () => produceParcel());
@@ -198,13 +211,13 @@ const _mockEntityManager = {
     } else if (entityClass === Building) {
       return produceBuilding();
     } else if (entityClass === ParcelEvaluation) {
-      return produceParcelEvaluation(1, { Year: 2023 });
+      return produceParcelEvaluations(1, { Year: 2023 });
     } else if (entityClass === ParcelFiscal) {
-      return produceParcelFiscal(1, { FiscalYear: 2023 });
+      return produceParcelFiscals(1, { FiscalYear: 2023 });
     } else if (entityClass === BuildingEvaluation) {
-      return produceBuildingEvaluation(1, { Year: 2023 });
+      return produceBuildingEvaluations(1, { Year: 2023 });
     } else if (entityClass === BuildingFiscal) {
-      return produceBuildingFiscal(1, { FiscalYear: 2023 });
+      return produceBuildingFiscals(1, { FiscalYear: 2023 });
     } else {
       return [];
     }
@@ -295,6 +308,8 @@ describe('UNIT - Property Services', () => {
 
   describe('getPropertiesforExport', () => {
     it('should get a list of properties based on the filter', async () => {
+      parcelRepoSpy.mockImplementationOnce(async () => [produceParcel({Id: 1})])
+      buildingRepoSpy.mockImplementationOnce(async () => [produceBuilding({Id: 1})])
       const result = await propertyServices.getPropertiesForExport({
         pid: 'contains,123',
         pin: 'contains,456',

--- a/react-app/src/components/property/PropertyTable.tsx
+++ b/react-app/src/components/property/PropertyTable.tsx
@@ -251,8 +251,9 @@ const PropertyTable = (props: IPropertyTable) => {
           property.AdministrativeAreaId,
         )?.Name,
         Postal: property.Postal,
-        PID: property.PID,
+        PID: pidFormatter(property.PID),
         PIN: property.PIN,
+        'Is Sensitive': property.IsSensitive,
         'Assessed Value': property.Evaluations?.length
           ? property.Evaluations.sort(
               (

--- a/react-app/src/components/table/DataTable.tsx
+++ b/react-app/src/components/table/DataTable.tsx
@@ -48,6 +48,7 @@ import { CommonFiltering } from '@/interfaces/ICommonFiltering';
 import { useSearchParams } from 'react-router-dom';
 import { Roles } from '@/constants/roles';
 import { AuthContext } from '@/contexts/authContext';
+import { SnackBarContext } from '@/contexts/snackbarContext';
 
 type RenderCellParams = GridRenderCellParams<any, any, any, GridTreeNodeWithRender>;
 
@@ -207,6 +208,8 @@ export const FilterSearchDataGrid = (props: FilterSearchDataGridProps) => {
   const [dataSourceLoading, setDataSourceLoading] = useState<boolean>(false);
   const tableApiRef = useGridApiRef(); // Ref to MUI DataGrid
   const previousController = useRef<AbortController>();
+  const snackbar = useContext(SnackBarContext);
+
   interface ITableModelCollection {
     pagination?: GridPaginationModel;
     sort?: GridSortModel;
@@ -535,23 +538,30 @@ export const FilterSearchDataGrid = (props: FilterSearchDataGridProps) => {
                   rows = props.excelDataSource
                     ? await props.excelDataSource(sortFilterObj, signal)
                     : await props.dataSource(sortFilterObj, signal);
-                  if (props.customExcelMap) rows = props.customExcelMap(rows);
                 } else {
                   // Client-side tables
                   rows = gridFilteredSortedRowEntriesSelector(tableApiRef).map((row) => row.model);
-                  if (props.customExcelMap) rows = props.customExcelMap(rows);
                 }
-                // Convert back to MUI table model
-                rows = rows.map((r, i) => ({
-                  model: r,
-                  id: i,
-                }));
-                downloadExcelFile({
-                  data: rows,
-                  tableName: props.excelTitle,
-                  filterName: selectValue,
-                  includeDate: true,
-                });
+                if (rows) {
+                  if (props.customExcelMap) rows = props.customExcelMap(rows);
+                  // Convert back to MUI table model
+                  rows = rows.map((r, i) => ({
+                    model: r,
+                    id: i,
+                  }));
+                  downloadExcelFile({
+                    data: rows,
+                    tableName: props.excelTitle,
+                    filterName: selectValue,
+                    includeDate: true,
+                  });
+                } else {
+                  snackbar.setMessageState({
+                    style: snackbar.styles.warning,
+                    text: 'Table failed to export.',
+                    open: true,
+                  });
+                }
                 setIsExporting(false);
               }}
             >

--- a/react-app/src/hooks/api/usePropertiesApi.ts
+++ b/react-app/src/hooks/api/usePropertiesApi.ts
@@ -127,8 +127,8 @@ const usePropertiesApi = (absoluteFetch: IFetch) => {
       },
       { signal },
     );
-    if ((parsedBody as Record<string, any>).error) {
-      return [];
+    if ((parsedBody as Record<string, any>)?.error) {
+      return;
     }
     return parsedBody as (Parcel | Building)[];
   };


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2002](https://citz-imb.atlassian.net/browse/PIMS-2002?atlOrigin=eyJpIjoiMmIxMTMxNDFlZWU0NGU5ZjhiZTM1MDRlMDE0YTAyOWEiLCJwIjoiaiJ9)
This is in response to the timeout issue sometimes happening when exporting the properties in a live environment.
Pretty sure the clause that slows things down is this:
`where: { Id: In(buildingIds) }`
When it is called getting parcels and buildings.
Suspect this is an issue with how TypeORM handles its queries. Almost looks like it's going a circular query at one point.
<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Broke up the relations and where properties in the TypeORM call into operations in code instead. For some reason this runs faster than letting TypeORM do the joins and filtering. These are the timings I got in local testing:
```
  // Getting evals, fiscals, and filtering separately: 850-1050ms
  // Getting as as part of joins, where clause: 1587-1672ms
```
- If the request for export data fails, it shows a snackbar message and resets the download icon.
- PID in export is now formatted with padded zeroes and hyphens
- IsSensitive column added to export

## Testing
It's hard to know if this will save time in OpenShift, where the issue seems to be.
Locally, you can test that the download works by exporting the properties table.
Test it doesn't work by stopping the API and hitting the download button again.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
