### PR TITLE
PIMS-2001: Add ERP date for general user projects

### DIFF
--- a/react-app/src/components/projects/EnhancedReferralDates.tsx
+++ b/react-app/src/components/projects/EnhancedReferralDates.tsx
@@ -11,7 +11,7 @@ interface EnhancedReferralDatesProps {
   rows: NotificationQueue[];
 }
 
-const EnhancedReferralDates: React.FC<EnhancedReferralDatesProps> = ({ rows }) => {
+const EnhancedReferralDates: React.FC<EnhancedReferralDatesProps> = ({ rows = [] }) => {
   const initalERN = rows.find((row) => row.TemplateId === NotificationType.NEW_PROPERTIES_ON_ERP);
   const thirtyDayERN = rows.find(
     (row) => row.TemplateId === NotificationType.THIRTY_DAY_ERP_NOTIFICATION_OWNING_AGENCY,

--- a/react-app/src/components/projects/EnhancedReferralDates.tsx
+++ b/react-app/src/components/projects/EnhancedReferralDates.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { DateField } from '@mui/x-date-pickers/DateField';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from 'dayjs';
+import { NotificationQueue } from '@/hooks/api/useProjectNotificationApi';
+import { NotificationType } from '@/constants/notificationTypes';
+
+interface EnhancedReferralDatesProps {
+  rows: NotificationQueue[];
+}
+
+const EnhancedReferralDates: React.FC<EnhancedReferralDatesProps> = ({ rows }) => {
+  const initalERN = rows.find((row) => row.TemplateId === NotificationType.NEW_PROPERTIES_ON_ERP);
+  const thirtyDayERN = rows.find(
+    (row) => row.TemplateId === NotificationType.THIRTY_DAY_ERP_NOTIFICATION_OWNING_AGENCY,
+  );
+  const sixtyDayERN = rows.find(
+    (row) => row.TemplateId === NotificationType.SIXTY_DAY_ERP_NOTIFICATION_OWNING_AGENCY,
+  );
+  const nintyDayERN = rows.find(
+    (row) => row.TemplateId === NotificationType.NINTY_DAY_ERP_NOTIFICATION_OWNING_AGENCY,
+  );
+
+  const allErnNotificatonsFound = [initalERN, thirtyDayERN, sixtyDayERN, nintyDayERN].every(
+    (notification) => notification != undefined,
+  );
+
+  if (!allErnNotificatonsFound) return null;
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Box
+        gap={1}
+        display={'inline-flex'}
+        mb={3}
+        mt={2}
+        sx={{
+          '& .MuiInputBase-root.Mui-disabled': {
+            '& > fieldset': {
+              borderColor: 'rgba(0,0,0)',
+            },
+          },
+          '& .MuiFormLabel-root.MuiInputLabel-root': {
+            color: 'rgba(0, 0, 0)',
+          },
+          '& .MuiInputBase-input.MuiOutlinedInput-input.Mui-disabled': {
+            color: 'rgba(0,0,0)',
+            WebkitTextFillColor: 'rgba(0,0,0)',
+          },
+        }}
+      >
+        <DateField
+          disabled={true}
+          value={initalERN ? dayjs(initalERN.SendOn) : undefined}
+          label={'Initial Send Date'}
+          format={'LL'}
+        />
+        <DateField
+          disabled={true}
+          value={thirtyDayERN ? dayjs(thirtyDayERN.SendOn) : undefined}
+          label={'30-day Send Date'}
+          format={'LL'}
+        />
+        <DateField
+          disabled={true}
+          value={sixtyDayERN ? dayjs(sixtyDayERN.SendOn) : undefined}
+          label={'60-day Send Date'}
+          format={'LL'}
+        />
+        <DateField
+          disabled={true}
+          value={nintyDayERN ? dayjs(nintyDayERN.SendOn) : undefined}
+          label={'90-day Send Date'}
+          format={'LL'}
+        />
+      </Box>
+    </LocalizationProvider>
+  );
+};
+
+export default EnhancedReferralDates;

--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -99,11 +99,11 @@ const ProjectDetail = (props: IProjectDetail) => {
   const { submit: cancelNotification } = useDataSubmitter(api.notifications.cancelNotification);
 
   const hasERPNotifications = useMemo(() => {
-    const notificationItems = notifications.items;
     // Check if notifications is an object and has an items array
     if (!notifications || !Array.isArray(notifications.items)) {
       return false;
     }
+    const notificationItems = notifications.items;
     if (notificationItems.length === 0) {
       return false;
     }

--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -329,17 +329,7 @@ const ProjectDetail = (props: IProjectDetail) => {
             onEdit={() => {}}
             disableEdit={true}
           >
-            <EnhancedReferralDates
-              rows={
-                notifications?.items
-                  ? notifications.items.map((resp) => ({
-                      AgencyName: lookup.getLookupValueById('Agencies', resp.ToAgencyId)?.Name,
-                      ChesStatusName: getStatusString(resp.Status),
-                      ...resp,
-                    }))
-                  : []
-              }
-            />{' '}
+            <EnhancedReferralDates rows={notifications?.items} />
           </DataCard>
         )}
         <DataCard

--- a/react-app/src/components/projects/ProjectNotificationsTable.tsx
+++ b/react-app/src/components/projects/ProjectNotificationsTable.tsx
@@ -1,13 +1,9 @@
 import { NotificationStatus } from '@/constants/chesNotificationStatus';
-import { NotificationType } from '@/constants/notificationTypes';
 import { NotificationQueue } from '@/hooks/api/useProjectNotificationApi';
 import { dateFormatter } from '@/utilities/formatters';
 import { Refresh, Delete } from '@mui/icons-material';
 import { Box, IconButton, Tooltip, Typography } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { DateField, LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import dayjs from 'dayjs';
 import React, { useState } from 'react';
 
 interface ProjectNotificationsTableProps {
@@ -116,83 +112,12 @@ const ProjectNotificationsTable = (props: ProjectNotificationsTableProps) => {
 
   if (!props.rows) return <></>;
 
-  // Prepare values for Enhanced Referral Notification fields
-  const initalERN = props.rows.find(
-    (row) => row.TemplateId === NotificationType.NEW_PROPERTIES_ON_ERP,
-  );
-  const thirtyDayERN = props.rows.find(
-    (row) => row.TemplateId === NotificationType.THIRTY_DAY_ERP_NOTIFICATION_OWNING_AGENCY,
-  );
-  const sixtyDayERN = props.rows.find(
-    (row) => row.TemplateId === NotificationType.SIXTY_DAY_ERP_NOTIFICATION_OWNING_AGENCY,
-  );
-  const nintyDayERN = props.rows.find(
-    (row) => row.TemplateId === NotificationType.NINTY_DAY_ERP_NOTIFICATION_OWNING_AGENCY,
-  );
-
-  const allErnNotificatonsFound = [initalERN, thirtyDayERN, sixtyDayERN, nintyDayERN].every(
-    (notification) => notification != undefined,
-  );
-
   return !props.rows ? (
     <Box display={'flex'} justifyContent={'center'}>
       <Typography>No notifications were sent.</Typography>
     </Box>
   ) : (
     <>
-      {allErnNotificatonsFound ? (
-        <LocalizationProvider dateAdapter={AdapterDayjs}>
-          <Typography variant="h6">Enhanced Referral Notification Dates</Typography>
-          <Box
-            gap={1}
-            display={'inline-flex'}
-            mb={3}
-            mt={2}
-            sx={{
-              '& .MuiInputBase-root.Mui-disabled': {
-                '& > fieldset': {
-                  borderColor: 'rgba(0,0,0)',
-                },
-              },
-              '& .MuiFormLabel-root.MuiInputLabel-root': {
-                color: 'rgba(0, 0, 0)',
-              },
-              '& .MuiInputBase-input.MuiOutlinedInput-input.Mui-disabled': {
-                color: 'rgba(0,0,0)',
-                WebkitTextFillColor: 'rgba(0,0,0)',
-              },
-            }}
-          >
-            <DateField
-              disabled={true}
-              value={initalERN ? dayjs(initalERN.SendOn) : undefined}
-              label={'Initial Send Date'}
-              format={'LL'}
-            />
-            <DateField
-              disabled={true}
-              value={thirtyDayERN ? dayjs(thirtyDayERN.SendOn) : undefined}
-              label={'30-day Send Date'}
-              format={'LL'}
-            />
-            <DateField
-              disabled={true}
-              value={sixtyDayERN ? dayjs(sixtyDayERN.SendOn) : undefined}
-              label={'60-day Send Date'}
-              format={'LL'}
-            />
-            <DateField
-              disabled={true}
-              value={nintyDayERN ? dayjs(nintyDayERN.SendOn) : undefined}
-              label={'90-day Send Date'}
-              format={'LL'}
-            />
-          </Box>
-        </LocalizationProvider>
-      ) : (
-        <></>
-      )}
-
       <Typography variant="h6">Total Notifications: {props.rows.length}</Typography>
       <DataGrid
         sx={{


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2001: ](https://citz-imb.atlassian.net/browse/PIMS-2001)

<!-- PROVIDE BELOW an explanation of your changes -->
- Created a separate component for the ERP dates section
- This will display when an ERP project has been approved and the 30, 60, 90 day notifications have been sent to CHES.
![image](https://github.com/user-attachments/assets/b0a68762-ff88-4254-b444-5d30594a8f0d)

<!-- PROVIDE ABOVE an explanation of your changes -->
## Testing
- You can either create a new and approved ERP project to see this new section, or just go to an existing project that has already sent the 30, 60, & 90 day notfications.
- Please test to see that all user types can see this section.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
