### PR TITLE
PIMS-2027 BCSC Provider Options

### DIFF
--- a/express-api/src/constants/config.ts
+++ b/express-api/src/constants/config.ts
@@ -34,7 +34,7 @@ const config = {
   },
   keycloak: {
     client_id: process.env.SSO_CLIENT_ID,
-  }
+  },
 };
 
 const getConfig = () => {

--- a/express-api/src/constants/config.ts
+++ b/express-api/src/constants/config.ts
@@ -32,6 +32,9 @@ const config = {
     title: 'PIMS',
     uri: process.env.FRONTEND_URL,
   },
+  keycloak: {
+    client_id: process.env.SSO_CLIENT_ID,
+  }
 };
 
 const getConfig = () => {

--- a/express-api/src/controllers/lookup/lookupController.ts
+++ b/express-api/src/controllers/lookup/lookupController.ts
@@ -380,6 +380,7 @@ export const lookupAll = async (req: Request, res: Response) => {
     ),
     Config: {
       contactEmail: cfg.contact.toEmail,
+      bcscIdentifier: cfg.keycloak.client_id,
     },
   };
   return res.status(200).send(returnObj);

--- a/express-api/src/routes/lookup.swagger.yaml
+++ b/express-api/src/routes/lookup.swagger.yaml
@@ -385,6 +385,8 @@ components:
             contactEmail:
               type: string
               example: email@gov.bc.ca
+            bcscIdentifier:
+              type: string
         ConstructionTypes: 
           type: array
           items: 

--- a/express-api/src/typeorm/Entities/User.ts
+++ b/express-api/src/typeorm/Entities/User.ts
@@ -66,7 +66,8 @@ export class User extends BaseEntity {
   @Column({ type: 'timestamp', nullable: true })
   ApprovedOn: Date;
 
-  @Column({ type: 'uuid', nullable: true })
+  // Using varchar instead of uuid because some providers use characters outside [0-9a-f]
+  @Column({ type: 'character varying', nullable: true, length: 36 })
   KeycloakUserId: string;
 
   // Agency Relations

--- a/express-api/src/typeorm/Migrations/1726615038425-KeycloakUserIdType.ts
+++ b/express-api/src/typeorm/Migrations/1726615038425-KeycloakUserIdType.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class KeycloakUserIdType1726615038425 implements MigrationInterface {
+  name = 'KeycloakUserIdType1726615038425';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN keycloak_user_id TYPE CHARACTER VARYING(36) USING keycloak_user_id::TEXT;`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN keycloak_user_id TYPE UUID USING keycloak_user_id::UUID;`,
+    );
+  }
+}

--- a/react-app/src/components/users/UserDetail.tsx
+++ b/react-app/src/components/users/UserDetail.tsx
@@ -17,6 +17,7 @@ import { useParams } from 'react-router-dom';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
 import { Role, Roles } from '@/constants/roles';
 import { LookupContext } from '@/contexts/lookupContext';
+import { getProvider } from '@/utilities/helperFunctions';
 
 interface IUserDetail {
   onClose: () => void;
@@ -50,8 +51,13 @@ const UserDetail = ({ onClose }: IUserDetail) => {
     Role: lookupData?.Roles?.find((role) => role.Id === data?.RoleId),
   };
 
+  const provider = useMemo(
+    () => getProvider(data?.Username, lookupData?.Config.bcscIdentifier),
+    [data],
+  );
+
   const userProfileData = {
-    Provider: data?.Username.includes('idir') ? 'IDIR' : 'BCeID',
+    Provider: provider,
     Email: data?.Email,
     FirstName: data?.FirstName,
     LastName: data?.LastName,
@@ -102,7 +108,7 @@ const UserDetail = ({ onClose }: IUserDetail) => {
 
   useEffect(() => {
     profileFormMethods.reset({
-      Provider: data?.Username.includes('idir') ? 'IDIR' : 'BCeID',
+      Provider: provider,
       Email: userProfileData.Email,
       FirstName: userProfileData.FirstName,
       LastName: userProfileData.LastName,

--- a/react-app/src/components/users/UsersTable.tsx
+++ b/react-app/src/components/users/UsersTable.tsx
@@ -11,6 +11,7 @@ import { Agency } from '@/hooks/api/useAgencyApi';
 import { User } from '@/hooks/api/useUsersApi';
 import { LookupContext } from '@/contexts/lookupContext';
 import { Role } from '@/constants/roles';
+import { getProvider } from '@/utilities/helperFunctions';
 
 const CustomMenuItem = (props: PropsWithChildren & { value: string }) => {
   const theme = useTheme();
@@ -175,17 +176,7 @@ const UsersTable = (props: IUsersTable) => {
       field: 'Username',
       headerName: 'Provider',
       width: 125,
-      valueGetter: (value) => {
-        const username: string = value;
-        if (username && !username.includes('@')) return undefined;
-        const provider = username.split('@').at(1);
-        switch (provider) {
-          case 'idir':
-            return 'IDIR';
-          default:
-            return 'BCeID';
-        }
-      },
+      valueGetter: (value) => getProvider(value, lookup?.data?.Config.bcscIdentifier),
     },
     {
       field: 'Agency',

--- a/react-app/src/hooks/api/useLookupApi.ts
+++ b/react-app/src/hooks/api/useLookupApi.ts
@@ -60,6 +60,7 @@ export interface LookupAll {
   RegionalDistricts: Partial<RegionalDistrict>[];
   Config: {
     contactEmail: string;
+    bcscIdentifier?: string;
   };
 }
 

--- a/react-app/src/pages/AccessRequest.tsx
+++ b/react-app/src/pages/AccessRequest.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import pendingImage from '@/assets/images/pending.svg';
 import { Box, Button, Grid, Paper, Typography } from '@mui/material';
 import AutocompleteFormField from '@/components/form/AutocompleteFormField';
@@ -60,6 +60,18 @@ const RequestForm = ({ submitHandler }: { submitHandler: (d: any) => void }) => 
       Position: '',
     },
   });
+
+  useEffect(() => {
+    formMethods.reset({
+      Provider: provider,
+      FirstName: keycloak.user?.first_name || '',
+      LastName: keycloak.user?.last_name || '',
+      Email: keycloak.user?.email || '',
+      Notes: '',
+      Agency: '',
+      Position: '',
+    });
+  }, [provider, keycloak.user, formMethods]);
 
   return (
     <>

--- a/react-app/src/pages/AccessRequest.tsx
+++ b/react-app/src/pages/AccessRequest.tsx
@@ -46,7 +46,7 @@ const RequestForm = ({ submitHandler }: { submitHandler: (d: any) => void }) => 
 
   const provider = useMemo(
     () => getProvider(keycloak.user?.preferred_username, lookup?.data?.Config.bcscIdentifier),
-    [keycloak.user],
+    [keycloak.user, lookup],
   );
 
   const formMethods = useForm({

--- a/react-app/src/pages/AccessRequest.tsx
+++ b/react-app/src/pages/AccessRequest.tsx
@@ -71,7 +71,7 @@ const RequestForm = ({ submitHandler }: { submitHandler: (d: any) => void }) => 
       Agency: '',
       Position: '',
     });
-  }, [provider, keycloak.user, formMethods]);
+  }, [provider, keycloak.user]);
 
   return (
     <>

--- a/react-app/src/pages/AccessRequest.tsx
+++ b/react-app/src/pages/AccessRequest.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import pendingImage from '@/assets/images/pending.svg';
 import { Box, Button, Grid, Paper, Typography } from '@mui/material';
 import AutocompleteFormField from '@/components/form/AutocompleteFormField';
@@ -18,6 +18,7 @@ import TextFormField from '@/components/form/TextFormField';
 import { useGroupedAgenciesApi } from '@/hooks/api/useGroupedAgenciesApi';
 import { SnackBarContext } from '@/contexts/snackbarContext';
 import { LookupContext } from '@/contexts/lookupContext';
+import { getProvider } from '@/utilities/helperFunctions';
 
 interface StatusPageTemplateProps {
   blurb: JSX.Element;
@@ -41,10 +42,16 @@ const StatusPageTemplate = (props: StatusPageTemplateProps) => {
 const RequestForm = ({ submitHandler }: { submitHandler: (d: any) => void }) => {
   const keycloak = useSSO();
   const agencyOptions = useGroupedAgenciesApi().agencyOptions;
+  const lookup = useContext(LookupContext);
+
+  const provider = useMemo(
+    () => getProvider(keycloak.user?.preferred_username, lookup?.data?.Config.bcscIdentifier),
+    [keycloak.user],
+  );
 
   const formMethods = useForm({
     defaultValues: {
-      UserName: keycloak.user?.username,
+      Provider: provider,
       FirstName: keycloak.user?.first_name,
       LastName: keycloak.user?.last_name,
       Email: keycloak.user?.email,
@@ -59,7 +66,7 @@ const RequestForm = ({ submitHandler }: { submitHandler: (d: any) => void }) => 
       <FormProvider {...formMethods}>
         <Grid spacing={2} container>
           <Grid item xs={6}>
-            <TextFormField fullWidth name={'UserName'} label={'IDIR/BCeID'} disabled />
+            <TextFormField fullWidth name={'Provider'} label={'Provider'} disabled />
           </Grid>
           <Grid item xs={6}>
             <TextFormField fullWidth name={'Email'} label={'Email'} disabled />

--- a/react-app/src/utilities/helperFunctions.ts
+++ b/react-app/src/utilities/helperFunctions.ts
@@ -66,7 +66,7 @@ export const getProvider = (username: string, bcscIdentifier?: string) => {
     case username.includes('bceid'):
       return 'BCeID';
     case username.includes(bcscIdentifier):
-      return 'BCSC';
+      return 'BC Services Card';
     default:
       return '';
   }

--- a/react-app/src/utilities/helperFunctions.ts
+++ b/react-app/src/utilities/helperFunctions.ts
@@ -51,3 +51,23 @@ export const getValueByNestedKey = <T extends Record<string, any>>(obj: T, key: 
   }
   return result;
 };
+
+/**
+ * Returns the provider based on the username and optional BCSC identifier.
+ * @param username The username to check for provider information.
+ * @param bcscIdentifier The optional BCSC identifier to check for BCSC provider.
+ * @returns The provider name ('IDIR', 'BCeID', 'BCSC') based on the username or an empty string if no match.
+ */
+export const getProvider = (username: string, bcscIdentifier?: string) => {
+  if (!username) return '';
+  switch (true) {
+    case username.includes('idir'):
+      return 'IDIR';
+    case username.includes('bceid'):
+      return 'BCeID';
+    case username.includes(bcscIdentifier):
+      return 'BCSC';
+    default:
+      return '';
+  }
+};


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2027](https://citz-imb.atlassian.net/browse/PIMS-2027)

<!-- PROVIDE BELOW an explanation of your changes -->
This PR adds the BCSC option whenever a provider is presented in the frontend.
The BCSC provider in the token is just the Keycloak integration client ID unfortunately, so it looks for that.

## Changes
- Added helper function to return Provider string
- Replaced individual checks with this helper function for consistency
- Added sso client id to config so we have something to check BCSC for
- Changed KeycloakUserId column from uuid type to varchar type. The id from Keycloak for BCSC is not a true uuid because it contains values outside [0-9a-f]. This would cause the database to reject the BCSC value when it was entered. Note, the KeycloakUserId field will not populate correctly still, because the sso-express package does not recognize BCSC as an option yet.

## Testing
- Log in with user who doesn't have access, check that provider on access form is correct
- Check provider column on user table
- Check provider area on user details

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
