### PR TITLE
PIMS-2085: Add the required option to DatePicker

### DIFF
--- a/react-app/src/components/form/DateFormField.tsx
+++ b/react-app/src/components/form/DateFormField.tsx
@@ -41,6 +41,7 @@ const DateFormField = (props: DateFieldFormProps) => {
                   InputLabelProps: {
                     style: { fontSize: '14px' }, // Font size for label
                   },
+                  required: required ? true : undefined,
                 },
               }}
             />

--- a/react-app/src/components/form/DateFormField.tsx
+++ b/react-app/src/components/form/DateFormField.tsx
@@ -41,7 +41,7 @@ const DateFormField = (props: DateFieldFormProps) => {
                   InputLabelProps: {
                     style: { fontSize: '14px' }, // Font size for label
                   },
-                  required: required ? true : undefined,
+                  required,
                 },
               }}
             />


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2085](https://citz-imb.atlassian.net/browse/PIMS-2085)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Added a required property to slotProps in the DateFormField.tsx component

## Testing
- Please see testing instructions here: https://citz-imb.atlassian.net/browse/PIMS-2085
- This will automatically show the date as required on the page displaying the asterisk symbol beside the name, and right now there is only one date in the database being required.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
