### PR TITLE
PIMS-2135 Bulk Upload Worker Bug

### DIFF
--- a/express-api/src/typeorm/Entities/User.ts
+++ b/express-api/src/typeorm/Entities/User.ts
@@ -76,7 +76,7 @@ export class User extends BaseEntity {
 
   @ManyToOne(() => Agency, (agency) => agency.Users, { nullable: true })
   @JoinColumn({ name: 'agency_id' })
-  Agency: Relation<Agency>;
+  Agency?: Relation<Agency>;
 
   // Role Relations
   @Column({ name: 'role_id', type: 'uuid', nullable: true })
@@ -84,7 +84,7 @@ export class User extends BaseEntity {
 
   @ManyToOne(() => Role, (role) => role.Users, { nullable: true })
   @JoinColumn({ name: 'role_id' })
-  Role: Relation<Role>;
+  Role?: Relation<Role>;
 
   @Column({ type: 'enum', enum: UserStatus })
   Status: UserStatus;

--- a/react-app/src/pages/BulkUpload.tsx
+++ b/react-app/src/pages/BulkUpload.tsx
@@ -53,7 +53,7 @@ const ResultsPaper = (props: {
           <Box display={'flex'} flexDirection={'column'} gap={'1rem'} height={'38rem'}>
             <Typography variant="h4">Recent upload result</Typography>
             <Typography>{`Filename: ${results.at(0).FileName}`}</Typography>
-            <Typography>{`Uploaded at: ${results.at(0).CreatedOn}`}</Typography>
+            <Typography>{`Uploaded at: ${new Date(results.at(0).CreatedOn).toLocaleString()}`}</Typography>
             <Button
               onClick={onDownloadClick}
               sx={{ width: '10rem' }}


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2135](https://citz-imb.atlassian.net/browse/PIMS-2135)

<!-- PROVIDE BELOW an explanation of your changes -->
There was an issue with the bulk upload that was caused when moving the authentication checks out of Keycloak.
Two problems:
- The user passed into the worker now had the `hasOneOfRoles` function attached. Workers apparently cannot pass functions, promises, steams, etc.
- The role was initially sending the name, but later checks expected the Id.

## Changes
- Formatted a date on the Bulk Upload page to make it more human readable.
- Made sure that the Role and Agency properties of the User records are marked as potentially undefined (when you get the record without doing the JOIN)
- Updated the user object to remove the `hasOneOfRoles` function before it is passed into the worker. It's not used further in this process, and the type is marked only as User to reflect that.
- Corrected how the role is passed to the worker.

## Testing
- Upload a file to bulk upload an make sure it works.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
