### PR TITLE
PIMS-2136 Filter Scroll

### DIFF
--- a/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
+++ b/react-app/src/components/map/clusterPopup/ClusterPopup.tsx
@@ -148,7 +148,7 @@ const ClusterPopup = (props: ClusterPopupProps) => {
           </IconButton>
         </Grid>
       </Grid>
-      <Box overflow={'scroll'}>
+      <Box sx={{ overflowY: 'scroll' }}>
         {popupState.properties.map((property) => (
           <PropertyRow
             key={`${property.properties.PropertyTypeId === PropertyTypes.BUILDING ? 'Building' : 'Land'}-${property.properties.Id}`}

--- a/react-app/src/components/map/controls/FilterControl.tsx
+++ b/react-app/src/components/map/controls/FilterControl.tsx
@@ -58,6 +58,8 @@ const FilterControl = (props: FilterControlProps) => {
     <Box
       sx={{
         padding: '1em',
+        overflowY: 'scroll',
+        scrollbarWidth: 'none',
       }}
     >
       <FormProvider {...formMethods}>

--- a/react-app/src/components/map/sidebar/MapSidebar.tsx
+++ b/react-app/src/components/map/sidebar/MapSidebar.tsx
@@ -134,7 +134,7 @@ const MapSidebar = (props: MapSidebarProps) => {
         </Grid>
 
         {/* List of Properties */}
-        <Box overflow={'scroll'} height={'100%'} display={'flex'} flexDirection={'column'}>
+        <Box height={'100%'} display={'flex'} flexDirection={'column'} sx={{ overflowY: 'scroll' }}>
           {propertiesInBounds
             .slice(pageIndex * propertyPageSize, pageIndex * propertyPageSize + propertyPageSize)
             .map((property) => (


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2136](https://citz-imb.atlassian.net/browse/PIMS-2136)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Made the map filter area scrollable. Kept this scroll bar visually hidden.
- Made the property lists in the sidebar and cluster popup only have the scroll on the Y axis. Didn't notice this before on Mac, but on Windows it shows a horizontal scrollbar otherwise.

## Testing
- Visually inspect the filter and property lists on the map for scroll function.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
