### PR TITLE
PIMS-1869 BCA XREF

### DIFF
--- a/express-api/src/controllers/tools/toolsController.ts
+++ b/express-api/src/controllers/tools/toolsController.ts
@@ -94,7 +94,7 @@ export const searchGeocoderAddresses = async (req: Request, res: Response) => {
 };
 
 export const getJurisdictionRollNumberByPid = async (req: Request, res: Response) => {
-  const pidQuery = String(req.query.pid);
+  const pidQuery = req.query.pid as string;
   if (parseInt(pidQuery)) {
     const result = await AppDataSource.getRepository(JurRollPidXref).findOne({
       where: { PID: parseInt(pidQuery) },
@@ -104,5 +104,5 @@ export const getJurisdictionRollNumberByPid = async (req: Request, res: Response
     }
     return res.status(200).send(result);
   }
-  return res.status(400).send('Invalid PID value');
+  return res.status(400).send('Invalid PID value.');
 };

--- a/express-api/src/controllers/tools/toolsController.ts
+++ b/express-api/src/controllers/tools/toolsController.ts
@@ -93,6 +93,13 @@ export const searchGeocoderAddresses = async (req: Request, res: Response) => {
   return res.status(200).send(geoReturn);
 };
 
+/**
+ * Retrieves jurisdiction & roll number based on PID.
+ * Used to cross reference BC Assessment records with Parcels.
+ * @param req - The request object.
+ * @param res - The response object.
+ * @returns A response with the jurisdiction, roll number, and PID if found.
+ */
 export const getJurisdictionRollNumberByPid = async (req: Request, res: Response) => {
   const pidQuery = req.query.pid as string;
   if (parseInt(pidQuery)) {

--- a/express-api/src/controllers/tools/toolsController.ts
+++ b/express-api/src/controllers/tools/toolsController.ts
@@ -3,6 +3,8 @@ import { Request, Response } from 'express';
 import chesServices from '@/services/ches/chesServices';
 import { ChesFilterSchema } from './toolsSchema';
 import geocoderService from '@/services/geocoder/geocoderService';
+import { AppDataSource } from '@/appDataSource';
+import { JurRollPidXref } from '@/typeorm/Entities/JurRollPidXref';
 
 /**
  * NOTE
@@ -89,4 +91,18 @@ export const searchGeocoderAddresses = async (req: Request, res: Response) => {
   const maxResults = isNaN(Number(req.query.maxResults)) ? undefined : String(req.query.maxResults);
   const geoReturn = await geocoderService.getSiteAddresses(address, minScore, maxResults);
   return res.status(200).send(geoReturn);
+};
+
+export const getJurisdictionRollNumberByPid = async (req: Request, res: Response) => {
+  const pidQuery = String(req.query.pid);
+  if (parseInt(pidQuery)) {
+    const result = await AppDataSource.getRepository(JurRollPidXref).findOne({
+      where: { PID: parseInt(pidQuery) },
+    });
+    if (!result) {
+      return res.status(404).send('PID not found.');
+    }
+    return res.status(200).send(result);
+  }
+  return res.status(400).send('Invalid PID value');
 };

--- a/express-api/src/express.ts
+++ b/express-api/src/express.ts
@@ -107,7 +107,7 @@ app.use(`/v2/buildings`, protectedRoute(), userAuthCheck(), router.buildingsRout
 app.use(`/v2/notifications`, protectedRoute(), router.notificationsRouter);
 app.use(`/v2/projects`, protectedRoute(), router.projectsRouter);
 app.use(`/v2/reports`, protectedRoute(), userAuthCheck(), router.reportsRouter);
-app.use(`/v2/tools`, protectedRoute(), userAuthCheck(), router.toolsRouter);
+app.use(`/v2/tools`, protectedRoute(), router.toolsRouter);
 
 // If a non-existent route is called. Must go after other routes.
 app.use('*', (_req, _res, next) => next(EndpointNotFound404));

--- a/express-api/src/routes/tools.swagger.yaml
+++ b/express-api/src/routes/tools.swagger.yaml
@@ -11,17 +11,17 @@ paths:
         This response comes from the BC Geocoder Service.
         Capable of any error code from BC Geocoder.
       parameters:
-        - in: path
+        - in: query
           name: address
           schema:
             type: string
             example: 742 Evergreen Terr
-        - in: path
+        - in: query
           name: minScore
           schema:
             type: integer
             example: 30
-        - in: path
+        - in: query
           name: maxResults
           schema:
             type: integer
@@ -40,9 +40,56 @@ paths:
               schema: 
                 type: string
                 example: Failed to fetch data
+  /tools/jur-roll-xref:
+    get:
+      security:
+        - bearerAuth: []
+      tags:
+        - Tools
+      summary: Returns a record matching the provided PID.
+      description: >
+        Used to cross reference the PID and Jurisdiction Code + Roll Number from BC Assessment.
+      parameters:
+        - in: query
+          name: pid
+          schema:
+            type: integer
+            example: 111222333
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/JurRollXref'
+        '400': 
+          content: 
+            text/plain:
+              schema: 
+                type: string
+                example: Invalid PID value.
+        '404':
+           content: 
+            text/plain:
+              schema: 
+                type: string
+                example: PID not found.
 ### SCHEMAS ### 
 components:
   schemas:
+    JurRollXref:
+      type: object
+      properties:
+        PID:
+          type: integer
+          example: 123456789
+        JurisdictionCode:
+          type: string
+          example: '123'
+        RollNumber:
+          type: string 
+          example: '1342341'
     GeocoderAddress:
       type: object
       properties: 

--- a/express-api/src/routes/toolsRouter.ts
+++ b/express-api/src/routes/toolsRouter.ts
@@ -1,4 +1,7 @@
+import { Roles } from '@/constants/roles';
 import controllers from '@/controllers';
+import { getJurisdictionRollNumberByPid } from '@/controllers/tools/toolsController';
+import userAuthCheck from '@/middleware/userAuthCheck';
 import catchErrors from '@/utilities/controllerErrorWrapper';
 import express from 'express';
 
@@ -6,6 +9,12 @@ const router = express.Router();
 
 const { searchGeocoderAddresses } = controllers;
 
-router.route(`/geocoder/addresses`).get(catchErrors(searchGeocoderAddresses));
+router.route(`/geocoder/addresses`).get(userAuthCheck(), catchErrors(searchGeocoderAddresses));
+router
+  .route(`/jur-roll-xref`)
+  .get(
+    userAuthCheck({ requiredRoles: [Roles.ADMIN] }),
+    catchErrors(getJurisdictionRollNumberByPid),
+  );
 
 export default router;

--- a/express-api/src/typeorm/Entities/JurRollPidXref.ts
+++ b/express-api/src/typeorm/Entities/JurRollPidXref.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryColumn } from 'typeorm';
+
+@Entity()
+export class JurRollPidXref {
+  @PrimaryColumn({ type: 'int', name: 'pid' })
+  PID: number;
+
+  @PrimaryColumn({ type: 'character varying', length: 3, name: 'jurisdiction_code' })
+  JurisdictionCode: string;
+
+  @PrimaryColumn({ type: 'character varying', length: 15, name: 'roll_number' })
+  RollNumber: string;
+}

--- a/express-api/src/typeorm/Entities/JurRollPidXref.ts
+++ b/express-api/src/typeorm/Entities/JurRollPidXref.ts
@@ -1,5 +1,8 @@
 import { Entity, PrimaryColumn } from 'typeorm';
 
+/**
+ * Used to cross reference the records from BC Assessment and find one that matches a PID.
+ */
 @Entity()
 export class JurRollPidXref {
   @PrimaryColumn({ type: 'int', name: 'pid' })

--- a/express-api/src/typeorm/Migrations/1729627184522-CreateXrefTable.ts
+++ b/express-api/src/typeorm/Migrations/1729627184522-CreateXrefTable.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateXrefTable1729627184522 implements MigrationInterface {
+  name = 'CreateXrefTable1729627184522';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "jur_roll_pid_xref" ("pid" integer NOT NULL, "jurisdiction_code" character varying(3) NOT NULL, "roll_number" character varying(15) NOT NULL, CONSTRAINT "PK_68f4d54ea088bb438e6100af993" PRIMARY KEY ("pid", "jurisdiction_code", "roll_number"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "jur_roll_pid_xref"`);
+  }
+}

--- a/express-api/src/typeorm/entitiesIndex.ts
+++ b/express-api/src/typeorm/entitiesIndex.ts
@@ -45,6 +45,7 @@ import { ImportResult } from './Entities/ImportResult';
 import { ProjectJoin } from './Entities/views/ProjectJoinView';
 import { AdministrativeAreaJoinView } from '@/typeorm/Entities/views/AdministrativeAreaJoinView';
 import { AgencyJoinView } from '@/typeorm/Entities/views/AgencyJoinView';
+import { JurRollPidXref } from '@/typeorm/Entities/JurRollPidXref';
 
 const views = [
   BuildingRelations,
@@ -97,5 +98,6 @@ export default [
   User,
   NoteType,
   ImportResult,
+  JurRollPidXref,
   ...views,
 ];

--- a/react-app/src/components/map/parcelPopup/ParcelPopup.tsx
+++ b/react-app/src/components/map/parcelPopup/ParcelPopup.tsx
@@ -116,6 +116,10 @@ export const ParcelPopup = (props: ParcelPopupProps) => {
     }
   }, [clickPosition]);
 
+  /**
+   * Gets a matching record from BC Assessment data by using the XREF table in the database to
+   * match the PID with a corresponding Jurisdiction Code and Roll Number.
+   */
   const getMatchingBcaRecord = useMemo(() => {
     if (!xrefData || !bcAssessmentData) {
       return undefined;

--- a/react-app/src/components/map/parcelPopup/ParcelPopup.tsx
+++ b/react-app/src/components/map/parcelPopup/ParcelPopup.tsx
@@ -192,11 +192,7 @@ export const ParcelPopup = (props: ParcelPopupProps) => {
                   </TabPanel>
                   <TabPanel value="2" sx={tabPanelStyle}>
                     <BCAssessmentDetails
-                      data={
-                        bcAssessmentData && bcAssessmentData.features.length
-                          ? getMatchingBcaRecord.properties
-                          : undefined
-                      }
+                      data={getMatchingBcaRecord ? getMatchingBcaRecord?.properties : undefined}
                       isLoading={bcaLoading || xrefLoading}
                       width={POPUP_WIDTH}
                     />

--- a/react-app/src/hooks/api/useBCAssessmentApi.ts
+++ b/react-app/src/hooks/api/useBCAssessmentApi.ts
@@ -1,3 +1,4 @@
+import { IFetch } from '@/hooks/useFetch';
 import { BBox, FeatureCollection, Geometry } from 'geojson';
 
 export interface BCAssessmentProperties {
@@ -29,7 +30,13 @@ export interface BCAssessmentProperties {
   bbox: BBox;
 }
 
-const useBCAssessmentApi = () => {
+export interface JurRollPidXref {
+  PID: number;
+  JurisdictionCode: string;
+  RollNumber: string;
+}
+
+const useBCAssessmentApi = (absoluteFetch: IFetch) => {
   const url = window.location.href.includes('pims.gov.bc.ca')
     ? 'https://apps.gov.bc.ca/ext/sgw/geo.bca?REQUEST=GetFeature&SERVICE=WFS&VERSION=2.0.0&typeName=geo.bca:WHSE_HUMAN_CULTURAL_ECONOMIC.BCA_FOLIO_GNRL_PROP_VALUES_SV&outputFormat=application/json'
     : 'https://test.apps.gov.bc.ca/ext/sgw/geo.bca?REQUEST=GetFeature&SERVICE=WFS&VERSION=2.0.0&typeName=geo.bca:WHSE_HUMAN_CULTURAL_ECONOMIC.BCA_FOLIO_GNRL_PROP_VALUES_SV&outputFormat=application/json';
@@ -44,8 +51,14 @@ const useBCAssessmentApi = () => {
     return body as FeatureCollection<Geometry, BCAssessmentProperties>;
   };
 
+  const getJurisdictionRoleByPid = async (pid: number) => {
+    const response = await absoluteFetch.get(`/tools/jur-roll-xref?pid=${pid}`);
+    return response;
+  };
+
   return {
     getBCAssessmentByLocation,
+    getJurisdictionRoleByPid,
   };
 };
 

--- a/react-app/src/hooks/usePimsApi.ts
+++ b/react-app/src/hooks/usePimsApi.ts
@@ -35,7 +35,7 @@ const usePimsApi = () => {
   const tools = useToolsApi(fetch);
   const parcelLayer = useParcelLayerApi(fetch);
   const projects = useProjectsApi(fetch);
-  const bcAssessment = useBCAssessmentApi();
+  const bcAssessment = useBCAssessmentApi(fetch);
   const ltsa = useLtsaApi(fetch);
   const notifications = useProjectNotificationsApi(fetch);
 


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-1869](https://citz-imb.atlassian.net/browse/PIMS-1869)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Created table to host XREF data
- Added controller and route to API to access this table
- Updated the ParcelPopup component to select the BCA data depending on the return value from this table.
- Tests and Documentation

## Testing
This is tough to test without the BC Assessment data in local, but it's possible to test individual parts with some substitutions.

First you have to run the migration then load the XREF data.
Get the data from here:
https://catalogue.data.gov.bc.ca/dataset/parcelmap-bc-jurisdiction-roll-number-pid-cross-reference-table
You will have to log in to see it.
I loaded the data with dbeaver. There's an option by right-clicking a table to import data > from CSV
Make sure you only import the three columns that are needed. You'll need to map them to the correct columns or additional columns with the CSV names will be created.

API
- Can test with Thunderclient or Postman. Use a GET request like this: `localhost:5000/v2/tools/jur-roll-xref?pid=206814`

Frontend
- You can test this by substituting the BC Assessment data with some static dummy data. Just make sure that the location you click has a PID that will correspond to an existing jurisdiction and roll number in the dummy data. 
- I just copied the returned object from PROD for a strata, then made sure that the useBCAssessment hook in the frontend returned that data instead of making the BCA call. 
- After that, click on the same strata as you took the data from in PROD
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
