### PR TITLE
PIMS-2258 Adjust when property agency changes are restricted

### DIFF
--- a/express-api/src/services/buildings/buildingServices.ts
+++ b/express-api/src/services/buildings/buildingServices.ts
@@ -69,12 +69,14 @@ export const updateBuildingById = async (
   user: PimsRequestUser,
 ) => {
   const existingBuilding = await getBuildingById(building.Id);
+  // Does this building exist?
   if (!existingBuilding) {
     throw new ErrorWithCode('Building does not exists.', 404);
   }
+  // Does the user have permissions to change its agency?
   const validUserAgencies = await userServices.getAgencies(user.Username);
   const isAdmin = user.hasOneOfRoles([Roles.ADMIN]);
-  if (!isAdmin && !validUserAgencies.includes(building.AgencyId)) {
+  if (!isAdmin && building.AgencyId && !validUserAgencies.includes(building.AgencyId)) {
     throw new ErrorWithCode('This agency change is not permitted.', 403);
   }
   if (building.Fiscals && building.Fiscals.length) {

--- a/express-api/src/services/parcels/parcelServices.ts
+++ b/express-api/src/services/parcels/parcelServices.ts
@@ -159,13 +159,15 @@ const updateParcel = async (incomingParcel: DeepPartial<Parcel>, user: PimsReque
   if (incomingParcel.PID == null && incomingParcel.PIN == null) {
     throw new ErrorWithCode('Must include PID or PIN in parcel data.', 400);
   }
+  // Does this parcel exist?
   const findParcel = await getParcelById(incomingParcel.Id);
   if (findParcel == null || findParcel.Id !== incomingParcel.Id) {
     throw new ErrorWithCode('Parcel not found', 404);
   }
+  // Does the user have permissions to change its agency?
   const validUserAgencies = await userServices.getAgencies(user.Username);
   const isAdmin = user.hasOneOfRoles([Roles.ADMIN]);
-  if (!isAdmin && !validUserAgencies.includes(incomingParcel.AgencyId)) {
+  if (!isAdmin && incomingParcel.AgencyId && !validUserAgencies.includes(incomingParcel.AgencyId)) {
     throw new ErrorWithCode('This agency change is not permitted.', 403);
   }
   if (incomingParcel.Fiscals && incomingParcel.Fiscals.length) {

--- a/express-api/tests/unit/services/buildings/buildingService.test.ts
+++ b/express-api/tests/unit/services/buildings/buildingService.test.ts
@@ -147,7 +147,7 @@ describe('updateBuildingById', () => {
       RoleId: Roles.GENERAL_USER,
       hasOneOfRoles: () => false,
     });
-    const updateBuilding = produceBuilding();
+    const updateBuilding = produceBuilding({ AgencyId: 1 });
     expect(
       async () => await buildingService.updateBuildingById(updateBuilding, generalUser),
     ).rejects.toThrow();


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2258](https://citz-imb.atlassian.net/browse/PIMS-2258)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Added some comments
- Added a condition to the if statement that controls if an agency change is denied for properties
  - It will now check that an agency was included in the request before checking if a user has permissions for that agency

## Testing
- As a General User, try to add/update assessment values for a property in your agencies.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
