### PR TITLE
PIMS-2269 Fixing Sidebar Page Count

### DIFF
--- a/react-app/src/components/map/sidebar/MapSidebar.tsx
+++ b/react-app/src/components/map/sidebar/MapSidebar.tsx
@@ -162,11 +162,20 @@ const MapSidebar = (props: MapSidebarProps) => {
             >
               <ArrowCircleLeft fontSize="small" />
             </IconButton>
-            <Typography
-              id="sidebar-count"
-              margin={'0 0.5em'}
-              fontSize={'0.8em'}
-            >{`${pageIndex + 1} of ${formatNumber(Math.max(Math.ceil(propertiesInBounds.length / propertyPageSize), 1))} (${formatNumber(propertiesInBounds.length)} items)`}</Typography>
+            <Grid item container display={'flex'} justifyContent={'center'} id="sidebar-count">
+              <Grid item>
+                <Typography
+                  margin={'0 0.3em'}
+                  fontSize={'0.8em'}
+                >{`${pageIndex + 1} of ${formatNumber(Math.max(Math.ceil(propertiesInBounds.length / propertyPageSize), 1))}`}</Typography>
+              </Grid>
+              <Grid item>
+                <Typography
+                  margin={'0 0.3em'}
+                  fontSize={'0.8em'}
+                >{`(${formatNumber(propertiesInBounds.length)} items)`}</Typography>
+              </Grid>
+            </Grid>
             <IconButton
               id="sidebar-increment"
               size="small"


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2269](https://citz-imb.atlassian.net/browse/PIMS-2269)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
Wrapped the sidebar page counts in a grid to separate some of the elements. It should break evenly now when there's a large number of properties.

Examples:
Small number
<img width="343" alt="image" src="https://github.com/user-attachments/assets/e17c754c-e632-487b-89cb-c3872b2dbadc" />

Big number
<img width="360" alt="image" src="https://github.com/user-attachments/assets/c124c2a7-1e9b-4834-b070-b33fb4e52621" />

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
