### PR TITLE
PIMS-2302 Idle Connection Pool Fixes

### DIFF
--- a/express-api/src/appDataSource.ts
+++ b/express-api/src/appDataSource.ts
@@ -31,4 +31,6 @@ export const AppDataSource = new DataSource({
   migrations: [`src/typeorm/Migrations/*.{ts,js}`],
   subscribers: [],
   namingStrategy: new SnakeNamingStrategy(),
+  connectTimeoutMS: 30 * 1000, // 30 seconds
+  maxQueryExecutionTime: 30 * 1000, // 30 seconds
 });

--- a/express-api/src/server.ts
+++ b/express-api/src/server.ts
@@ -28,8 +28,8 @@ const startApp = (app: Application) => {
       logger.info('Failed email check: Completed');
     });
 
-    // 0 1 * * *  == Triggers every 1:00AM
-    cron.schedule('0 1 * * *', async () => {
+    // 0 1 * * 6  == Triggers 1:00AM on Saturday
+    cron.schedule('0 1 * * 6', async () => {
       logger.info('Clear idle database connections: start');
       await clearIdleConnections();
       logger.info('Clear idle database connections: complete');

--- a/express-api/src/server.ts
+++ b/express-api/src/server.ts
@@ -6,6 +6,7 @@ import { Application } from 'express';
 import { IncomingMessage, Server, ServerResponse } from 'http';
 import cron from 'node-cron';
 import failedEmailCheck from '@/utilities/failedEmailCheck';
+import clearIdleConnections from '@/utilities/clearIdleConnections';
 
 const { API_PORT } = constants;
 
@@ -27,9 +28,16 @@ const startApp = (app: Application) => {
       logger.info('Failed email check: Completed');
     });
 
+    // 0 1 * * *  == Triggers every 1:00AM
+    cron.schedule('0 1 * * *', async () => {
+      logger.info('Clear idle database connections: start');
+      await clearIdleConnections();
+      logger.info('Clear idle database connections: complete');
+    });
+
     // creating connection to database
     await AppDataSource.initialize()
-      .then(() => {
+      .then(async () => {
         logger.info('Database connection has been initialized');
       })
       .catch((err?: Error) => {

--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -190,7 +190,7 @@ const insertProjectNotificationQueue = async (
     ToAgencyId: agency?.Id,
   };
   const insertedNotif = await query.manager.save(NotificationQueue, queueObject);
-  if (queryRunner === undefined) {
+  if (queryRunner == null) {
     //If no arg passed we spawned a new query runner and we must release that!
     await query.release();
   }
@@ -377,7 +377,7 @@ const generateProjectNotifications = async (
       );
     }
   }
-  if (queryRunner === undefined) {
+  if (queryRunner == null) {
     await query.release();
   }
   return await Promise.all(returnNotifications);
@@ -431,7 +431,7 @@ const sendNotification = async (
       Status: NotificationStatus.Failed,
     });
   } finally {
-    if (queryRunner === undefined) {
+    if (queryRunner == null) {
       await query.release();
     }
   }
@@ -476,6 +476,7 @@ const updateNotificationStatus = async (notificationId: number, user: User) => {
   });
 
   if (!notification || Object.keys(notification).length === 0) {
+    await query.release();
     throw new Error(`Notification with id ${notificationId} not found.`);
   }
 
@@ -484,7 +485,7 @@ const updateNotificationStatus = async (notificationId: number, user: User) => {
     const notificationStatus = convertChesStatusToNotificationStatus(statusResponse.status);
     // If the CHES status is non-standard, don't update the notification.
     if (notificationStatus === null) {
-      query.release();
+      await query.release();
       return notification;
     }
     notification.Status = notificationStatus;
@@ -492,7 +493,7 @@ const updateNotificationStatus = async (notificationId: number, user: User) => {
     notification.UpdatedById = user.Id;
     const updatedNotification = await query.manager.save(NotificationQueue, notification);
 
-    query.release();
+    await query.release();
     return updatedNotification;
   } else if (typeof statusResponse?.status === 'number') {
     // handle 404, 422 code here....
@@ -503,7 +504,7 @@ const updateNotificationStatus = async (notificationId: number, user: User) => {
         notification.UpdatedById = user.Id;
         const updatedNotification = await query.manager.save(NotificationQueue, notification);
         logger.error(`Notification with id ${notificationId} not found on CHES.`);
-        query.release();
+        await query.release();
         return updatedNotification;
       }
 
@@ -528,10 +529,10 @@ const updateNotificationStatus = async (notificationId: number, user: User) => {
         logger.error(`Received unexpected status code ${statusResponse.status}.`);
         break;
     }
-    query.release();
+    await query.release();
     return notification;
   } else {
-    query.release();
+    await query.release();
     throw new Error(`Failed to retrieve status for notification with id ${notificationId}.`);
   }
 };
@@ -623,8 +624,8 @@ const cancelProjectNotifications = async (
       failed: 0,
     };
   } finally {
-    if (queryRunner === undefined) {
-      query.release();
+    if (queryRunner == null) {
+      await query.release();
     }
   }
 };
@@ -731,8 +732,8 @@ const generateProjectWatchNotifications = async (
     );
     logger.error(e.stack);
   } finally {
-    if (queryRunner === undefined) {
-      query.release();
+    if (queryRunner == null) {
+      await query.release();
     }
   }
   return notificationsInserted;

--- a/express-api/src/services/projects/projectsServices.ts
+++ b/express-api/src/services/projects/projectsServices.ts
@@ -840,7 +840,7 @@ const updateProject = async (
       });
     }
 
-    queryRunner.commitTransaction();
+    await queryRunner.commitTransaction();
     const changedResponses = [];
     if (project.AgencyResponses) {
       changedResponses.push(...(await getAgencyResponseChanges(originalProject, project)));

--- a/express-api/src/utilities/clearIdleConnections.ts
+++ b/express-api/src/utilities/clearIdleConnections.ts
@@ -1,0 +1,57 @@
+import { AppDataSource } from '@/appDataSource';
+
+/**
+ * Clears idle database connections by identifying and terminating inactive connections
+ * to the current database that match specific criteria.
+ *
+ * The function uses a PostgreSQL query to:
+ * - Exclude the current backend process.
+ * - Exclude connections from known applications (e.g., psql, pgAdmin).
+ * - Include only connections to the same database and user as the current process.
+ * - Include only inactive connections.
+ *
+ * This helps free up resources by terminating unnecessary idle connections.
+ *
+ * @async
+ * @function clearIdleConnections
+ * @returns {Promise<void>} Resolves when idle connections are cleared.
+ * @throws {Error} If the query execution fails.
+ */
+const clearIdleConnections = async () => {
+  const db = AppDataSource.createQueryRunner();
+  await db.query(`
+  WITH inactive_connections AS (
+    SELECT
+        pid,
+        rank() over (partition by client_addr order by backend_start ASC) as rank
+    FROM 
+        pg_stat_activity
+    WHERE
+        -- Exclude the thread owned connection (ie no auto-kill)
+        pid <> pg_backend_pid( )
+    AND
+        -- Exclude known applications connections
+        application_name !~ '(?:psql)|(?:pgAdmin.+)'
+    AND
+        -- Include connections to the same database the thread is connected to
+        datname = current_database() 
+    AND
+        -- Include connections using the same thread username connection
+        usename = current_user 
+    AND
+        -- Include inactive connections only
+        state in ('idle', 'idle in transaction', 'idle in transaction (aborted)', 'disabled') 
+    AND
+        -- Include old connections (found with the state_change field)
+        current_timestamp - state_change > interval '5 minutes' 
+  )
+  SELECT
+      pg_terminate_backend(pid)
+  FROM
+      inactive_connections 
+  WHERE
+      rank > 1 -- Leave one connection for each application connected to the database
+    `);
+  await db.release();
+};
+export default clearIdleConnections;


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2302](https://citz-imb.atlassian.net/browse/PIMS-2302)
## Changes
- Remedy some database calls in the backend services that may be opening connections and never closing them.
- Add a cron job that removes idle connections that match appropriate conditions

## Testing
I tested it by creating intentionally open idle connections
```ts
const db = AppDataSource.createQueryRunner();
db.startTransaction();
```
Trigger this a couple of times to make the connections, then check your connections in the database with this SQL
```sql
SELECT * FROM pg_stat_activity;
```
Manually trigger the `clearIdleConnections` function and check the table again to see that the ones in the `idle in transaction` state should be cleared. They must also be older than 5 minutes to clear, so give yourself some delay or adjust the SQL to be a shorter time.
<!-- PROVIDE BELOW an explanation of your changes -->

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
