### PR TITLE
PIMS-2309 Initial ERP Notification for Watching Agencies

### DIFF
--- a/express-api/src/typeorm/Migrations/1745424172379-AddWatchingAgencyErpTemplate.ts
+++ b/express-api/src/typeorm/Migrations/1745424172379-AddWatchingAgencyErpTemplate.ts
@@ -4,36 +4,60 @@ export class AddWatchingAgencyErpTemplate1745424172379 implements MigrationInter
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Adjust name of Parent Agency intial ERP template
     await queryRunner.query(`
-        UPDATE notification_template
-        SET name = 'New Properties on ERP - Parent Agencies'
-        WHERE name = 'New Properties on ERP';
+      UPDATE notification_template
+      SET name = 'New Properties on ERP - Parent Agencies'
+      WHERE name = 'New Properties on ERP';
     `);
 
     // Add Watching Agency ERP template
     const systemId = await queryRunner.query(`
-        SELECT id FROM "user" WHERE username = 'system';
+      SELECT id FROM "user" WHERE username = 'system';
     `);
     await queryRunner.query(`
-        INSERT INTO notification_template (name, description, bcc, audience, priority, body_type, encoding, subject, body, tag, created_by_id, "to", cc)
-        SELECT 'New Properties on ERP - Purchasing Agencies', description, bcc, 'WatchingAgencies', priority, body_type, encoding, subject, body, tag, '${systemId.at(0).id}', "to", cc
-        FROM notification_template
-        WHERE audience = 'ParentAgencies'
-            AND name = 'New Properties on ERP - Parent Agencies';
+      INSERT INTO notification_template (name, description, bcc, audience, priority, body_type, encoding, subject, body, tag, created_by_id, "to", cc)
+      SELECT 'New Properties on ERP - Purchasing Agencies', description, bcc, 'WatchingAgencies', priority, body_type, encoding, subject, body, tag, '${systemId.at(0).id}', "to", cc
+      FROM notification_template
+      WHERE audience = 'ParentAgencies'
+          AND name = 'New Properties on ERP - Parent Agencies';
+    `);
+    // Insert record into project_status_notification so template will be triggered on status change
+    const newTemplate = await queryRunner.query(`
+      SELECT * FROM notification_template
+      WHERE name = 'New Properties on ERP - Purchasing Agencies';
+    `);
+    const templateId = newTemplate.at(0).id;
+    const erpStatus = await queryRunner.query(`
+      SELECT id FROM project_status WHERE name = 'Approved for ERP';
+      `);
+    const statusId = erpStatus.at(0).id;
+    await queryRunner.query(`
+      INSERT INTO project_status_notification (template_id, from_status_id, to_status_id, priority, delay, delay_days, created_by_id)
+      VALUES (${templateId}, NULL, ${statusId}, 2, 0, 0, '${systemId.at(0).id}');
     `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // Identify template id
+    const newTemplate = await queryRunner.query(`
+      SELECT * FROM notification_template
+      WHERE name = 'New Properties on ERP - Purchasing Agencies';
+  `);
+    const templateId = newTemplate.at(0).id;
+    // Remove record from project_status_notification
+    await queryRunner.query(`
+      DELETE FROM project_status_notification
+      WHERE template_id = ${templateId};
+    `);
     // Remove Watching Agency ERP template
     await queryRunner.query(`
-        DELETE FROM notification_template
-        WHERE name = 'New Properties on ERP - Purchasing Agencies';
+      DELETE FROM notification_template
+      WHERE id = ${templateId};
     `);
-
     // Revert name of Parent Agency intial ERP template
     await queryRunner.query(`
-        UPDATE notification_template
-        SET name = 'New Properties on ERP'
-        WHERE name = 'New Properties on ERP - Parent Agencies';
+      UPDATE notification_template
+      SET name = 'New Properties on ERP'
+      WHERE name = 'New Properties on ERP - Parent Agencies';
     `);
   }
 }

--- a/express-api/src/typeorm/Migrations/1745424172379-AddWatchingAgencyErpTemplate.ts
+++ b/express-api/src/typeorm/Migrations/1745424172379-AddWatchingAgencyErpTemplate.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWatchingAgencyErpTemplate1745424172379 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Adjust name of Parent Agency intial ERP template
+    await queryRunner.query(`
+        UPDATE notification_template
+        SET name = 'New Properties on ERP - Parent Agencies'
+        WHERE name = 'New Properties on ERP';
+    `);
+
+    // Add Watching Agency ERP template
+    const systemId = await queryRunner.query(`
+        SELECT id FROM "user" WHERE username = 'system';
+    `);
+    await queryRunner.query(`
+        INSERT INTO notification_template (name, description, bcc, audience, priority, body_type, encoding, subject, body, tag, created_by_id, "to", cc)
+        SELECT 'New Properties on ERP - Purchasing Agencies', description, bcc, 'WatchingAgencies', priority, body_type, encoding, subject, body, tag, '${systemId.at(0).id}', "to", cc
+        FROM notification_template
+        WHERE audience = 'ParentAgencies'
+            AND name = 'New Properties on ERP - Parent Agencies';
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove Watching Agency ERP template
+    await queryRunner.query(`
+        DELETE FROM notification_template
+        WHERE name = 'New Properties on ERP - Purchasing Agencies';
+    `);
+
+    // Revert name of Parent Agency intial ERP template
+    await queryRunner.query(`
+        UPDATE notification_template
+        SET name = 'New Properties on ERP'
+        WHERE name = 'New Properties on ERP - Parent Agencies';
+    `);
+  }
+}


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2309](https://citz-imb.atlassian.net/browse/PIMS-2309)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Added migration that adds the missing template for Watching Agencies and relevant entry in the `project_status_notification` table

## Testing
This can only be properly tested once the other notification PR (PIMS-2275) is merged. Otherwise, the Watching Agency emails aren't even detected.
 
Once that is done:
- Pick an agency that is not a parent agency. Make sure it has a To email and Send Notifications checked.
- Create a project. Make sure the agency above is Subscribed.
- Move the project to Approved for ERP. There should be 4 emails for that agency queued. The initial email is the new one that was previously missing.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
