### PR TITLE
PIMS-2307 Remove Watch Agency Response Type

### DIFF
--- a/express-api/src/typeorm/Migrations/1745434734346-RemoveWatchResponseType.ts
+++ b/express-api/src/typeorm/Migrations/1745434734346-RemoveWatchResponseType.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveWatchResponseType1745434734346 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Move all Watch responses to Subscribe
+    // This is a one-way migration. The Watch response type is removed from the database and the code.
+    await queryRunner.query(`
+        UPDATE project_agency_response
+        SET response = 1
+        WHERE response = 2;
+        `);
+  }
+
+  public async down(): Promise<void> {
+    // There is no going back from this.
+    // The enum value is removed from the database and the code.
+  }
+}

--- a/react-app/src/constants/agencyResponseTypes.ts
+++ b/react-app/src/constants/agencyResponseTypes.ts
@@ -1,5 +1,4 @@
 export enum AgencyResponseType {
   Unsubscribe = 0,
   Subscribe = 1,
-  Watch = 2,
 }


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2307](https://citz-imb.atlassian.net/browse/PIMS-2307)
Recommend this is reviewed after PIMS-2275 is merged. Will keep in draft until then.

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Remove Watch value from enums in frontend and backend
- Adjust notification generation area to look for Subscribe instead of NOT (watch or unsubscribe)
- Create migration that moves all Watch responses to Subscribe responses. After looking at PROD to see how Watch is being used, it seems like admins occasionally attempt to use it when an agency is interested in a project. Unfortunately, Watch status acts more like Unsubscribe status at the moment. This should bring the attempted use closer to the intended behaviour.

## Testing
- Make sure you have parent agencies and child agencies with emails and Send Notifications checked in your local database.
- Start a new project and move it to ERP. There should be agencies in the Agency Response table when the project is created. 
- See that Watch is no longer an option when trying to manually change the response.
- See that emails are queued for expected agencies.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
