### PR TITLE
PIMS-2303 Express API Dependency Updates

### DIFF
--- a/express-api/package.json
+++ b/express-api/package.json
@@ -32,7 +32,7 @@
     "node-cron": "3.0.3",
     "node-sql-reader": "0.1.3",
     "nunjucks": "3.2.4",
-    "pg": "8.13.0",
+    "pg": "8.14.1",
     "reflect-metadata": "0.2.1",
     "swagger-jsdoc": "6.2.8",
     "swagger-ui-express": "5.0.0",
@@ -45,7 +45,7 @@
     "zod": "3.24.0"
   },
   "devDependencies": {
-    "@eslint/js": "9.22.0",
+    "@eslint/js": "9.23.0",
     "@faker-js/faker": "9.6.0",
     "@types/compression": "1.7.4",
     "@types/cookie-parser": "1.4.5",
@@ -61,16 +61,16 @@
     "@types/swagger-jsdoc": "6.0.4",
     "@types/swagger-ui-express": "4.1.6",
     "cross-env": "7.0.3",
-    "eslint": "9.22.0",
+    "eslint": "9.23.0",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-prettier": "5.2.1",
     "jest": "29.7.0",
     "nodemon": "3.1.0",
     "prettier": "3.5.0",
-    "supertest": "7.0.0",
-    "ts-jest": "29.2.0",
+    "supertest": "7.1.0",
+    "ts-jest": "29.3.1",
     "tsc-alias": "1.8.8",
     "typescript": "5.8.2",
-    "typescript-eslint": "8.26.1"
+    "typescript-eslint": "8.29.0"
   }
 }


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2303](https://citz-imb.atlassian.net/browse/PIMS-2303)
## Changes
Minor dependency updates. See the package.json file for more information.

I tried to update Express to v5 again as well, but I didn't commit those changes. There's still an issue where it looks like the body of the request is consumed before it gets to the route that needs it. I suspect `protectedRoute` from our Keycloak package is the issue, as it uses Express v4 still.
<!-- PROVIDE BELOW an explanation of your changes -->

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
