### PR TITLE
PIMS-2310 Issue with Disabled Records

### DIFF
--- a/express-api/src/controllers/lookup/lookupController.ts
+++ b/express-api/src/controllers/lookup/lookupController.ts
@@ -355,7 +355,6 @@ export const lookupAll = async (req: Request, res: Response) => {
       RegionalDistrictId: true,
     },
     order: { SortOrder: 'asc', Name: 'asc' },
-    where: { IsDisabled: false },
   });
 
   const returnObj = {

--- a/express-api/src/controllers/lookup/lookupController.ts
+++ b/express-api/src/controllers/lookup/lookupController.ts
@@ -344,9 +344,9 @@ export const lookupAll = async (req: Request, res: Response) => {
       Name: true,
       Code: true,
       ParentId: true,
+      IsDisabled: true,
     },
     order: { SortOrder: 'asc', Name: 'asc' },
-    where: { IsDisabled: false },
   });
   const AdministrativeAreas = await AppDataSource.getRepository(AdministrativeArea).find({
     select: {

--- a/express-api/src/controllers/lookup/lookupController.ts
+++ b/express-api/src/controllers/lookup/lookupController.ts
@@ -353,6 +353,7 @@ export const lookupAll = async (req: Request, res: Response) => {
       Id: true,
       Name: true,
       RegionalDistrictId: true,
+      IsDisabled: true,
     },
     order: { SortOrder: 'asc', Name: 'asc' },
   });

--- a/react-app/src/components/adminAreas/AddAdministrativeArea.tsx
+++ b/react-app/src/components/adminAreas/AddAdministrativeArea.tsx
@@ -12,7 +12,7 @@ import useHistoryAwareNavigate from '@/hooks/useHistoryAwareNavigate';
 
 const AddAdministrativeArea = () => {
   const api = usePimsApi();
-  const { data: lookupData } = useContext(LookupContext);
+  const { data: lookupData, refreshLookup } = useContext(LookupContext);
   const { submit, submitting } = useDataSubmitter(api.administrativeAreas.addAdministrativeArea);
   const { goToFromStateOrSetRoute } = useHistoryAwareNavigate();
   const formMethods = useForm({
@@ -68,7 +68,10 @@ const AddAdministrativeArea = () => {
                 IsDisabled: false,
                 ProvinceId: 'BC',
               }).then((resp) => {
-                if (resp && resp.ok) goToFromStateOrSetRoute('/admin/adminAreas');
+                if (resp && resp.ok) {
+                  refreshLookup();
+                  goToFromStateOrSetRoute('/admin/adminAreas');
+                }
               });
             } else {
               console.log('Error!');

--- a/react-app/src/components/adminAreas/AdministrativeAreaDetail.tsx
+++ b/react-app/src/components/adminAreas/AdministrativeAreaDetail.tsx
@@ -25,7 +25,7 @@ const AdministrativeAreaDetail = (props: IAdministrativeAreaDetail) => {
   const { data, refreshData, isLoading } = useDataLoader(() =>
     api.administrativeAreas.getAdminAreaById(Number(id)),
   );
-  const { data: lookupData, getLookupValueById } = useContext(LookupContext);
+  const { data: lookupData, getLookupValueById, refreshLookup } = useContext(LookupContext);
   const { submit, submitting } = useDataSubmitter(api.administrativeAreas.updateAdminArea);
 
   useEffect(() => {
@@ -105,9 +105,12 @@ const AdministrativeAreaDetail = (props: IAdministrativeAreaDetail) => {
             submit(idAsNumber, {
               ...formValues,
               Id: idAsNumber,
-            }).then(() => {
-              refreshData();
-              setOpenEditDialog(false);
+            }).then((resp) => {
+              if (resp && resp.ok) {
+                refreshLookup();
+                refreshData();
+                setOpenEditDialog(false);
+              }
             });
           }
         }}

--- a/react-app/src/components/agencies/AddAgency.tsx
+++ b/react-app/src/components/agencies/AddAgency.tsx
@@ -17,7 +17,7 @@ const AddAgency = () => {
   const api = usePimsApi();
   const { goToFromStateOrSetRoute } = useHistoryAwareNavigate();
   const { submit, submitting } = useDataSubmitter(api.agencies.addAgency);
-  const agencyOptions = useAgencyOptions().agencyOptions;
+  const { agencyOptions } = useAgencyOptions();
 
   const formMethods = useForm({
     defaultValues: {

--- a/react-app/src/components/agencies/AddAgency.tsx
+++ b/react-app/src/components/agencies/AddAgency.tsx
@@ -1,7 +1,7 @@
 import TextFormField from '@/components/form/TextFormField';
 import { Box, Grid, Typography } from '@mui/material';
 import { FormProvider, useForm } from 'react-hook-form';
-import React from 'react';
+import React, { useContext } from 'react';
 import AutocompleteFormField from '@/components/form/AutocompleteFormField';
 import usePimsApi from '@/hooks/usePimsApi';
 import useAgencyOptions from '@/hooks/useAgencyOptions';
@@ -12,12 +12,14 @@ import { AgencyAdd } from '@/hooks/api/useAgencyApi';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
 import { LoadingButton } from '@mui/lab';
 import useHistoryAwareNavigate from '@/hooks/useHistoryAwareNavigate';
+import { LookupContext } from '@/contexts/lookupContext';
 
 const AddAgency = () => {
   const api = usePimsApi();
   const { goToFromStateOrSetRoute } = useHistoryAwareNavigate();
   const { submit, submitting } = useDataSubmitter(api.agencies.addAgency);
   const { agencyOptions } = useAgencyOptions();
+  const { refreshLookup } = useContext(LookupContext);
 
   const formMethods = useForm({
     defaultValues: {
@@ -118,7 +120,10 @@ const AddAgency = () => {
               SortOrder: 0,
             };
             submit(newAgency).then((res) => {
-              if (res && res.ok) goToFromStateOrSetRoute('/admin/agencies');
+              if (res && res.ok) {
+                refreshLookup(); // Refresh lookup data so this new agency is included
+                goToFromStateOrSetRoute('/admin/agencies');
+              }
             });
           }
         }}

--- a/react-app/src/components/agencies/AddAgency.tsx
+++ b/react-app/src/components/agencies/AddAgency.tsx
@@ -4,7 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import React from 'react';
 import AutocompleteFormField from '@/components/form/AutocompleteFormField';
 import usePimsApi from '@/hooks/usePimsApi';
-import useGroupedAgenciesApi from '@/hooks/api/useGroupedAgenciesApi';
+import useAgencyOptions from '@/hooks/useAgencyOptions';
 import EmailChipFormField from '@/components/form/EmailChipFormField';
 import SingleSelectBoxFormField from '@/components/form/SingleSelectBoxFormField';
 import { NavigateBackButton } from '@/components/display/DetailViewNavigation';
@@ -17,7 +17,7 @@ const AddAgency = () => {
   const api = usePimsApi();
   const { goToFromStateOrSetRoute } = useHistoryAwareNavigate();
   const { submit, submitting } = useDataSubmitter(api.agencies.addAgency);
-  const agencyOptions = useGroupedAgenciesApi().agencyOptions;
+  const agencyOptions = useAgencyOptions().agencyOptions;
 
   const formMethods = useForm({
     defaultValues: {

--- a/react-app/src/components/agencies/AgencyDetails.tsx
+++ b/react-app/src/components/agencies/AgencyDetails.tsx
@@ -10,7 +10,7 @@ import useDataLoader from '@/hooks/useDataLoader';
 import { Agency } from '@/hooks/api/useAgencyApi';
 import TextFormField from '../form/TextFormField';
 import DetailViewNavigation from '../display/DetailViewNavigation';
-import { useGroupedAgenciesApi } from '@/hooks/api/useGroupedAgenciesApi';
+import { useAgencyOptions } from '@/hooks/useAgencyOptions';
 import { useParams } from 'react-router-dom';
 import EmailChipFormField from '@/components/form/EmailChipFormField';
 import SingleSelectBoxFormField from '@/components/form/SingleSelectBoxFormField';
@@ -38,7 +38,7 @@ const AgencyDetail = ({ onClose }: IAgencyDetail) => {
   const { data, refreshData, isLoading } = useDataLoader(() => api.agencies.getAgencyById(+id));
   const { submit, submitting } = useDataSubmitter(api.agencies.updateAgencyById);
 
-  const { agencyOptions } = useGroupedAgenciesApi();
+  const { agencyOptions } = useAgencyOptions();
   const isParent = agencyOptions.some((agency) => agency.parentId === +id);
 
   const agencyStatusData = {

--- a/react-app/src/components/agencies/AgencyDetails.tsx
+++ b/react-app/src/components/agencies/AgencyDetails.tsx
@@ -30,7 +30,7 @@ interface AgencyStatus extends Agency {
 const AgencyDetail = ({ onClose }: IAgencyDetail) => {
   const { id } = useParams();
   const api = usePimsApi();
-  const { getLookupValueById } = useContext(LookupContext);
+  const { getLookupValueById, refreshLookup } = useContext(LookupContext);
 
   const [openStatusDialog, setOpenStatusDialog] = useState(false);
   const [openNotificationsDialog, setOpenNotificationsDialog] = useState(false);
@@ -186,9 +186,12 @@ const AgencyDetail = ({ onClose }: IAgencyDetail) => {
               Name,
               Code,
               Description,
-            }).then(() => {
-              refreshData();
-              setOpenStatusDialog(false);
+            }).then((resp) => {
+              if (resp && resp.ok) {
+                refreshLookup(); // so current agency info is available
+                refreshData();
+                setOpenStatusDialog(false);
+              }
             });
           }
         }}

--- a/react-app/src/components/agencies/AgencyDetails.tsx
+++ b/react-app/src/components/agencies/AgencyDetails.tsx
@@ -122,6 +122,26 @@ const AgencyDetail = ({ onClose }: IAgencyDetail) => {
     });
   }, [data]);
 
+  // When the parent agency is already disabled, it won't show up in the select options otherwise.
+  // We add this to the options if it's not already there. It only seems to apply while this page is up.
+  useEffect(() => {
+    const parentAgency = getLookupValueById('Agencies', data?.ParentId);
+    if (
+      parentAgency &&
+      parentAgency.IsDisabled &&
+      !agencyOptions.find((a) => a.value === parentAgency.Id)
+    ) {
+      agencyOptions.push({
+        label: parentAgency.Name,
+        value: parentAgency.Id,
+      });
+      // Not ideal to sort again here, but cases where agency is disabled are rare.
+      agencyOptions.sort((a, b) =>
+        a.label.localeCompare(b.label, undefined, { numeric: true, sensitivity: 'base' }),
+      );
+    }
+  }, [data, agencyOptions]);
+
   return (
     <Box
       display={'flex'}

--- a/react-app/src/components/map/controls/FilterControl.tsx
+++ b/react-app/src/components/map/controls/FilterControl.tsx
@@ -3,7 +3,7 @@ import TextFormField from '@/components/form/TextFormField';
 import { Roles } from '@/constants/roles';
 import { UserContext } from '@/contexts/userContext';
 import { LookupContext } from '@/contexts/lookupContext';
-import useGroupedAgenciesApi from '@/hooks/api/useGroupedAgenciesApi';
+import useAgencyOptions from '@/hooks/useAgencyOptions';
 import { MapFilter } from '@/hooks/api/usePropertiesApi';
 import useDataLoader from '@/hooks/useDataLoader';
 import usePimsApi from '@/hooks/usePimsApi';
@@ -34,7 +34,7 @@ const FilterControl = (props: FilterControlProps) => {
   const { data: lookupData } = useContext(LookupContext);
 
   // Get lists for dropdowns
-  const { agencyOptions } = useGroupedAgenciesApi();
+  const { agencyOptions } = useAgencyOptions();
   const { data: usersAgenciesData, loadOnce: loadUsersAgencies } = useDataLoader(() =>
     api.users.getUsersAgencyIds(user.pimsUser.data?.Username),
   );

--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -81,9 +81,9 @@ const ProjectDetail = (props: IProjectDetail) => {
   const navigate = useNavigate();
   const { id } = useParams();
   const { pimsUser } = useContext(UserContext);
-  const lookup = useContext(LookupContext);
   const api = usePimsApi();
   const { data: lookupData, getLookupValueById } = useContext(LookupContext);
+  const { agencyOptions } = useGroupedAgenciesApi();
   const { data, refreshData, isLoading } = useDataLoader(() =>
     api.projects.getProjectById(Number(id)),
   );
@@ -139,7 +139,6 @@ const ProjectDetail = (props: IProjectDetail) => {
     }
   }, [data]);
 
-  const { ungroupedAgencies, agencyOptions } = useGroupedAgenciesApi();
   interface IStatusHistoryStruct {
     Notes: Array<ProjectNote & { Name: string }>;
     Tasks: Array<ProjectTask & { Name: string }>;
@@ -426,9 +425,9 @@ const ProjectDetail = (props: IProjectDetail) => {
                   },
                 }}
                 rows={
-                  data?.parsedBody.AgencyResponses && ungroupedAgencies
+                  data?.parsedBody.AgencyResponses && lookupData?.Agencies
                     ? (data?.parsedBody.AgencyResponses?.map((resp) => ({
-                        ...ungroupedAgencies?.find((agc) => agc.Id === resp.AgencyId),
+                        ...lookupData?.Agencies?.find((agc) => agc.Id === resp.AgencyId),
                         ReceivedOn: resp.ReceivedOn,
                         Note: resp.Note,
                         Response: enumReverseLookup(AgencyResponseType, resp.Response),
@@ -524,7 +523,7 @@ const ProjectDetail = (props: IProjectDetail) => {
                 rows={
                   notifications?.items
                     ? notifications.items.map((resp) => ({
-                        AgencyName: lookup.getLookupValueById('Agencies', resp.ToAgencyId)?.Name,
+                        AgencyName: getLookupValueById('Agencies', resp.ToAgencyId)?.Name,
                         ChesStatusName: getStatusString(resp.Status),
                         ...resp,
                       }))
@@ -581,7 +580,6 @@ const ProjectDetail = (props: IProjectDetail) => {
           onCancel={() => setOpenDisposalPropDialog(false)}
         />
         <ProjectAgencyResponseDialog
-          agencies={ungroupedAgencies as Agency[]}
           options={agencyOptions}
           initialValues={data?.parsedBody}
           open={openAgencyInterestDialog}
@@ -595,7 +593,7 @@ const ProjectDetail = (props: IProjectDetail) => {
           }}
         />
         <ProjectNotificationDialog
-          ungroupedAgencies={ungroupedAgencies as Agency[]}
+          ungroupedAgencies={lookupData?.Agencies as Agency[]}
           initialValues={notifications?.items ?? []}
           open={openNotificationDialog}
           onRowCancelClick={(id: number) =>

--- a/react-app/src/components/projects/ProjectDetail.tsx
+++ b/react-app/src/components/projects/ProjectDetail.tsx
@@ -38,7 +38,7 @@ import {
 } from './ProjectDialog';
 import { AgencySimpleTable } from './AgencyResponseSearchTable';
 import CollapsibleSidebar from '../layout/CollapsibleSidebar';
-import useGroupedAgenciesApi from '@/hooks/api/useGroupedAgenciesApi';
+import useAgencyOptions from '@/hooks/useAgencyOptions';
 import { enumReverseLookup } from '@/utilities/helperFunctions';
 import { AgencyResponseType } from '@/constants/agencyResponseTypes';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
@@ -83,7 +83,7 @@ const ProjectDetail = (props: IProjectDetail) => {
   const { pimsUser } = useContext(UserContext);
   const api = usePimsApi();
   const { data: lookupData, getLookupValueById } = useContext(LookupContext);
-  const { agencyOptions } = useGroupedAgenciesApi();
+  const { agencyOptions } = useAgencyOptions();
   const { data, refreshData, isLoading } = useDataLoader(() =>
     api.projects.getProjectById(Number(id)),
   );

--- a/react-app/src/components/projects/ProjectDialog.tsx
+++ b/react-app/src/components/projects/ProjectDialog.tsx
@@ -40,7 +40,7 @@ interface IProjectGeneralInfoDialog {
 export const ProjectGeneralInfoDialog = (props: IProjectGeneralInfoDialog) => {
   const { open, postSubmit, onCancel, initialValues } = props;
   const api = usePimsApi();
-  const { data: lookupData } = useContext(LookupContext);
+  const { data: lookupData, getLookupValueById } = useContext(LookupContext);
   const { submit, submitting } = useDataSubmitter(api.projects.updateProject);
   const [approvedStatus, setApprovedStatus] = useState<number>(null);
   const projectFormMethods = useForm({
@@ -80,6 +80,27 @@ export const ProjectGeneralInfoDialog = (props: IProjectGeneralInfoDialog) => {
       RiskId: initialValues?.RiskId,
     });
   }, [initialValues]);
+  const { agencyOptions } = useAgencyOptions();
+
+  // When the agency is already disabled, it won't show up in the select options otherwise.
+  // We add this to the options if it's not already there. It only seems to apply while this page is up.
+  useEffect(() => {
+    const startingAgency = getLookupValueById('Agencies', initialValues?.AgencyId);
+    if (
+      startingAgency &&
+      startingAgency.IsDisabled &&
+      !agencyOptions.find((a) => a.value === startingAgency.Id)
+    ) {
+      agencyOptions.push({
+        label: startingAgency.Name,
+        value: startingAgency.Id,
+      });
+      // Not ideal to sort again here, but cases where agency is disabled are rare.
+      agencyOptions.sort((a, b) =>
+        a.label.localeCompare(b.label, undefined, { numeric: true, sensitivity: 'base' }),
+      );
+    }
+  }, [initialValues, agencyOptions]);
 
   const [statusTypes, setStatusTypes] = useState({
     Tasks: [],
@@ -199,6 +220,7 @@ export const ProjectGeneralInfoDialog = (props: IProjectGeneralInfoDialog) => {
             value: st.Id,
             label: st.Name,
           }))}
+          agencyOptions={agencyOptions ?? []}
         />
         {initialValues && statusTypes.Tasks?.length > 0 && (
           <Box mt={'1rem'}>

--- a/react-app/src/components/projects/ProjectDialog.tsx
+++ b/react-app/src/components/projects/ProjectDialog.tsx
@@ -28,7 +28,7 @@ import { getStatusString } from '@/constants/chesNotificationStatus';
 import { MonetaryType } from '@/constants/monetaryTypes';
 import BaseDialog from '../dialog/BaseDialog';
 import { NotificationQueue } from '@/hooks/api/useProjectNotificationApi';
-import useGroupedAgenciesApi from '@/hooks/api/useGroupedAgenciesApi';
+import useAgencyOptions from '@/hooks/useAgencyOptions';
 
 interface IProjectGeneralInfoDialog {
   initialValues: Project;
@@ -465,7 +465,7 @@ interface IProjectAgencyResponseDialog {
 export const ProjectAgencyResponseDialog = (props: IProjectAgencyResponseDialog) => {
   const api = usePimsApi();
   const { data: lookupData } = useContext(LookupContext);
-  const { activeAgencies } = useGroupedAgenciesApi();
+  const { activeAgencies } = useAgencyOptions();
   const { initialValues, open, postSubmit, onCancel, options } = props;
   const { submit, submitting } = useDataSubmitter(api.projects.updateProject);
   const [rows, setRows] = useState([]);

--- a/react-app/src/components/projects/ProjectDialog.tsx
+++ b/react-app/src/components/projects/ProjectDialog.tsx
@@ -28,6 +28,7 @@ import { getStatusString } from '@/constants/chesNotificationStatus';
 import { MonetaryType } from '@/constants/monetaryTypes';
 import BaseDialog from '../dialog/BaseDialog';
 import { NotificationQueue } from '@/hooks/api/useProjectNotificationApi';
+import useGroupedAgenciesApi from '@/hooks/api/useGroupedAgenciesApi';
 
 interface IProjectGeneralInfoDialog {
   initialValues: Project;
@@ -456,7 +457,6 @@ export const ProjectPropertiesDialog = (props: IProjectPropertiesDialog) => {
 interface IProjectAgencyResponseDialog {
   initialValues: ProjectGet;
   open: boolean;
-  agencies: Agency[];
   options: ISelectMenuItem[];
   postSubmit: () => void;
   onCancel: () => void;
@@ -464,21 +464,23 @@ interface IProjectAgencyResponseDialog {
 
 export const ProjectAgencyResponseDialog = (props: IProjectAgencyResponseDialog) => {
   const api = usePimsApi();
-  const { initialValues, open, postSubmit, onCancel, options, agencies } = props;
+  const { data: lookupData } = useContext(LookupContext);
+  const { activeAgencies } = useGroupedAgenciesApi();
+  const { initialValues, open, postSubmit, onCancel, options } = props;
   const { submit, submitting } = useDataSubmitter(api.projects.updateProject);
   const [rows, setRows] = useState([]);
   useEffect(() => {
-    if (initialValues && agencies) {
+    if (initialValues && lookupData?.Agencies) {
       setRows(
         initialValues.AgencyResponses?.map((resp) => ({
-          ...agencies.find((agc) => agc.Id === resp.AgencyId),
+          ...lookupData?.Agencies.find((agc) => agc.Id === resp.AgencyId),
           ReceivedOn: resp.ReceivedOn,
           Note: resp.Note,
           Response: enumReverseLookup(AgencyResponseType, resp.Response),
         })),
       );
     }
-  }, [initialValues, agencies]);
+  }, [initialValues, lookupData?.Agencies]);
   return (
     <ConfirmDialog
       dialogProps={{ maxWidth: 'lg' }}
@@ -501,7 +503,12 @@ export const ProjectAgencyResponseDialog = (props: IProjectAgencyResponseDialog)
       onCancel={async () => onCancel()}
     >
       <Box paddingTop={'1rem'}>
-        <AgencySearchTable agencies={agencies} options={options} rows={rows} setRows={setRows} />
+        <AgencySearchTable
+          agencies={activeAgencies as Agency[]}
+          options={options}
+          rows={rows}
+          setRows={setRows}
+        />
       </Box>
     </ConfirmDialog>
   );

--- a/react-app/src/components/projects/ProjectForms.tsx
+++ b/react-app/src/components/projects/ProjectForms.tsx
@@ -14,9 +14,11 @@ import Help from '@mui/icons-material/Help';
 
 interface IProjectGeneralInfoForm {
   projectStatuses: ISelectMenuItem[];
+  agencyOptions: ISelectMenuItem[];
 }
 
 export const ProjectGeneralInfoForm = (props: IProjectGeneralInfoForm) => {
+  const { agencyOptions } = props;
   const { data: lookupData } = useContext(LookupContext);
   const { pimsUser } = useContext(UserContext);
   const canEdit = pimsUser.hasOneOfRoles([Roles.ADMIN]);
@@ -68,9 +70,7 @@ export const ProjectGeneralInfoForm = (props: IProjectGeneralInfoForm) => {
             <AutocompleteFormField
               name={'AgencyId'}
               label={'Agency'}
-              options={
-                lookupData?.Agencies.map((agc) => ({ value: agc.Id, label: agc.Name })) ?? []
-              }
+              options={agencyOptions ?? []}
             />
           </Grid>
           <Grid item xs={4}>

--- a/react-app/src/components/property/AddProperty.tsx
+++ b/react-app/src/components/property/AddProperty.tsx
@@ -28,6 +28,7 @@ import { LookupContext } from '@/contexts/lookupContext';
 import { Classification } from '@/hooks/api/useLookupApi';
 import useHistoryAwareNavigate from '@/hooks/useHistoryAwareNavigate';
 import useUserAgencies from '@/hooks/api/useUserAgencies';
+import useAdministrativeAreaOptions from '@/hooks/useAdministrativeAreaOptions';
 
 const AddProperty = () => {
   //const years = [new Date().getFullYear(), new Date().getFullYear() - 1];
@@ -35,6 +36,7 @@ const AddProperty = () => {
   const [showErrorText, setShowErrorText] = useState(false);
   const { goToFromStateOrSetRoute } = useHistoryAwareNavigate();
   const api = usePimsApi();
+  const { adminAreaOptions } = useAdministrativeAreaOptions();
   const { data: lookupData } = useContext(LookupContext);
   const { submit: submitParcel, submitting: submittingParcel } = useDataSubmitter(
     api.parcels.addParcel,
@@ -115,10 +117,7 @@ const AddProperty = () => {
           agencies={agencyOptions}
           defaultLocationValue={undefined}
           propertyType={propertyType}
-          adminAreas={
-            lookupData?.AdministrativeAreas.map((area) => ({ label: area.Name, value: area.Id })) ??
-            []
-          }
+          adminAreas={adminAreaOptions ?? []}
         />
         {propertyType === 'Parcel' ? (
           <ParcelInformationForm

--- a/react-app/src/components/property/PropertyDetail.tsx
+++ b/react-app/src/components/property/PropertyDetail.tsx
@@ -273,7 +273,7 @@ const PropertyDetail = (props: IPropertyDetail) => {
       info.Tenancy = (data as Building)?.BuildingTenancy;
       info.TenancyDate = dateFormatter((data as Building)?.BuildingTenancyUpdatedOn);
     } else {
-      info.LandArea = (data as Parcel)?.LandArea;
+      info.LandArea = (data as Parcel)?.LandArea ?? '0';
     }
     return info;
   }, [parcel, building, getLookupValueById]);

--- a/react-app/src/components/users/UserDetail.tsx
+++ b/react-app/src/components/users/UserDetail.tsx
@@ -12,7 +12,7 @@ import { UserContext } from '@/contexts/userContext';
 import { Agency } from '@/hooks/api/useAgencyApi';
 import TextFormField from '../form/TextFormField';
 import DetailViewNavigation from '../display/DetailViewNavigation';
-import { useGroupedAgenciesApi } from '@/hooks/api/useGroupedAgenciesApi';
+import { useAgencyOptions } from '@/hooks/useAgencyOptions';
 import { useParams } from 'react-router-dom';
 import useDataSubmitter from '@/hooks/useDataSubmitter';
 import { Role, Roles } from '@/constants/roles';
@@ -39,7 +39,7 @@ const UserDetail = ({ onClose }: IUserDetail) => {
   const { data, refreshData, isLoading } = useDataLoader(() => api.users.getUserById(id));
   const { submit, submitting } = useDataSubmitter(api.users.updateUser);
 
-  const agencyOptions = useGroupedAgenciesApi().agencyOptions;
+  const agencyOptions = useAgencyOptions().agencyOptions;
 
   const rolesOptions = useMemo(
     () => lookupData?.Roles?.map((role) => ({ label: role.Name, value: role.Name })) ?? [],

--- a/react-app/src/components/users/UserDetail.tsx
+++ b/react-app/src/components/users/UserDetail.tsx
@@ -121,6 +121,26 @@ const UserDetail = ({ onClose }: IUserDetail) => {
     });
   }, [data]);
 
+  // When the agency is already disabled, it won't show up in the select options otherwise.
+  // We add this to the options if it's not already there. It only seems to apply while this page is up.
+  useEffect(() => {
+    const startingAgency = getLookupValueById('Agencies', data?.AgencyId);
+    if (
+      startingAgency &&
+      startingAgency.IsDisabled &&
+      !agencyOptions.find((a) => a.value === startingAgency.Id)
+    ) {
+      agencyOptions.push({
+        label: startingAgency.Name,
+        value: startingAgency.Id,
+      });
+      // Not ideal to sort again here, but cases where agency is disabled are rare.
+      agencyOptions.sort((a, b) =>
+        a.label.localeCompare(b.label, undefined, { numeric: true, sensitivity: 'base' }),
+      );
+    }
+  }, [data, agencyOptions]);
+
   return (
     <Box
       display={'flex'}

--- a/react-app/src/contexts/lookupContext.tsx
+++ b/react-app/src/contexts/lookupContext.tsx
@@ -8,6 +8,7 @@ import React, { createContext, useCallback, useMemo } from 'react';
 type LookupContextValue = {
   data: LookupAll | undefined;
   getLookupValueById: (a: keyof LookupAll, b: number) => any | undefined;
+  refreshLookup: () => void;
 };
 export const LookupContext = createContext<LookupContextValue>(undefined);
 
@@ -19,7 +20,7 @@ export const LookupContext = createContext<LookupContextValue>(undefined);
  */
 export const LookupContextProvider: React.FC<React.PropsWithChildren> = (props) => {
   const api = usePimsApi();
-  const { data, loadOnce, isLoading } = useDataLoader(api.lookup.getAll);
+  const { data, loadOnce, isLoading, refreshData } = useDataLoader(api.lookup.getAll);
   const sso = useSSO();
   if (!data && sso.isAuthenticated) {
     loadOnce();
@@ -55,7 +56,7 @@ export const LookupContextProvider: React.FC<React.PropsWithChildren> = (props) 
     [data],
   );
 
-  const contextValue = { data, getLookupValueById };
+  const contextValue = { data, getLookupValueById, refreshLookup: refreshData };
   if (isLoading) return <CircularProgress sx={{ position: 'fixed', top: '50%', left: '50%' }} />;
   return <LookupContext.Provider value={contextValue}>{props.children}</LookupContext.Provider>;
 };

--- a/react-app/src/hooks/api/useGroupedAgenciesApi.ts
+++ b/react-app/src/hooks/api/useGroupedAgenciesApi.ts
@@ -6,6 +6,10 @@ import { LookupContext } from '@/contexts/lookupContext';
 export const useGroupedAgenciesApi = () => {
   const { data: lookupData } = useContext(LookupContext);
 
+  const activeAgencies = useMemo(() => {
+    return lookupData?.Agencies?.filter((agency: Agency) => !agency.IsDisabled);
+  }, [lookupData?.Agencies]);
+
   const groupedAgencies = useMemo(() => {
     const groups: { [parentName: string]: Agency[] } = {};
     const parentAgencies: Agency[] = [];
@@ -66,7 +70,11 @@ export const useGroupedAgenciesApi = () => {
     return options;
   }, [groupedAgencies]);
 
-  return { groupedAgencies, ungroupedAgencies: lookupData?.Agencies, agencyOptions };
+  return {
+    groupedAgencies,
+    activeAgencies,
+    agencyOptions,
+  };
 };
 
 export default useGroupedAgenciesApi;

--- a/react-app/src/hooks/api/useProjectsApi.ts
+++ b/react-app/src/hooks/api/useProjectsApi.ts
@@ -169,7 +169,6 @@ export interface ProjectAgencyResponse {
   CreatedOn: string;
   UpdatedById: string | null;
   UpdatedOn: string | null;
-  Id: number;
   ProjectId: number;
   AgencyId: number;
   OfferAmount: string | number;

--- a/react-app/src/hooks/api/useUserAgencies.ts
+++ b/react-app/src/hooks/api/useUserAgencies.ts
@@ -4,7 +4,7 @@ import { useContext, useEffect, useMemo } from 'react';
 import useDataLoader from '../useDataLoader';
 import { UserContext } from '@/contexts/userContext';
 import usePimsApi from '../usePimsApi';
-import useGroupedAgenciesApi from './useGroupedAgenciesApi';
+import useAgencyOptions from '../useAgencyOptions';
 import { useSSO } from '@bcgov/citz-imb-sso-react';
 import { LookupContext } from '@/contexts/lookupContext';
 
@@ -12,7 +12,7 @@ const useUserAgencies = () => {
   const { pimsUser } = useContext(UserContext);
   const { data: lookupData } = useContext(LookupContext);
   const sso = useSSO();
-  const { agencyOptions } = useGroupedAgenciesApi();
+  const { agencyOptions } = useAgencyOptions();
   const api = usePimsApi();
   const isAdmin = pimsUser?.hasOneOfRoles([Roles.ADMIN]);
   const { data: userAgencies, refreshData: refreshUserAgencies } = useDataLoader(() =>

--- a/react-app/src/hooks/api/useUserAgencies.ts
+++ b/react-app/src/hooks/api/useUserAgencies.ts
@@ -6,11 +6,13 @@ import { UserContext } from '@/contexts/userContext';
 import usePimsApi from '../usePimsApi';
 import useGroupedAgenciesApi from './useGroupedAgenciesApi';
 import { useSSO } from '@bcgov/citz-imb-sso-react';
+import { LookupContext } from '@/contexts/lookupContext';
 
 const useUserAgencies = () => {
   const { pimsUser } = useContext(UserContext);
+  const { data: lookupData } = useContext(LookupContext);
   const sso = useSSO();
-  const { ungroupedAgencies, agencyOptions } = useGroupedAgenciesApi();
+  const { agencyOptions } = useGroupedAgenciesApi();
   const api = usePimsApi();
   const isAdmin = pimsUser?.hasOneOfRoles([Roles.ADMIN]);
   const { data: userAgencies, refreshData: refreshUserAgencies } = useDataLoader(() =>
@@ -22,12 +24,12 @@ const useUserAgencies = () => {
   }, [sso]);
 
   const userAgencyObjects = useMemo(() => {
-    if (ungroupedAgencies && userAgencies) {
-      return ungroupedAgencies.filter((a) => userAgencies.includes(a.Id));
+    if (lookupData?.Agencies && userAgencies) {
+      return lookupData?.Agencies.filter((a) => userAgencies.includes(a.Id));
     } else {
       return [];
     }
-  }, [ungroupedAgencies, userAgencies]);
+  }, [lookupData?.Agencies, userAgencies]);
 
   const menuItems: ISelectMenuItem[] = useMemo(() => {
     if (isAdmin) {

--- a/react-app/src/hooks/useAdministrativeAreaOptions.ts
+++ b/react-app/src/hooks/useAdministrativeAreaOptions.ts
@@ -1,0 +1,32 @@
+import { useContext, useMemo } from 'react';
+import { ISelectMenuItem } from '@/components/form/SelectFormField';
+import { LookupContext } from '@/contexts/lookupContext';
+import { AdministrativeArea } from '@/hooks/api/useAdministrativeAreaApi';
+
+const useAdministrativeAreaOptions = () => {
+  const { data: lookupData } = useContext(LookupContext);
+
+  const activeAdminAreas = useMemo(() => {
+    return lookupData?.AdministrativeAreas?.filter((a: AdministrativeArea) => !a.IsDisabled);
+  }, [lookupData?.AdministrativeAreas]);
+
+  const adminAreaOptions: ISelectMenuItem[] = useMemo(() => {
+    const options: ISelectMenuItem[] = [];
+
+    activeAdminAreas.forEach((a) => {
+      options.push({
+        label: a.Name,
+        value: a.Id,
+      });
+    });
+
+    return options;
+  }, [activeAdminAreas]);
+
+  return {
+    activeAdminAreas,
+    adminAreaOptions,
+  };
+};
+
+export default useAdministrativeAreaOptions;

--- a/react-app/src/hooks/useAdministrativeAreaOptions.ts
+++ b/react-app/src/hooks/useAdministrativeAreaOptions.ts
@@ -10,18 +10,14 @@ const useAdministrativeAreaOptions = () => {
     return lookupData?.AdministrativeAreas?.filter((a: AdministrativeArea) => !a.IsDisabled);
   }, [lookupData?.AdministrativeAreas]);
 
-  const adminAreaOptions: ISelectMenuItem[] = useMemo(() => {
-    const options: ISelectMenuItem[] = [];
-
-    activeAdminAreas.forEach((a) => {
-      options.push({
+  const adminAreaOptions: ISelectMenuItem[] = useMemo(
+    () =>
+      activeAdminAreas.map((a) => ({
         label: a.Name,
         value: a.Id,
-      });
-    });
-
-    return options;
-  }, [activeAdminAreas]);
+      })),
+    [activeAdminAreas],
+  );
 
   return {
     activeAdminAreas,

--- a/react-app/src/hooks/useAgencyOptions.ts
+++ b/react-app/src/hooks/useAgencyOptions.ts
@@ -3,7 +3,7 @@ import { Agency } from '@/hooks/api/useAgencyApi';
 import { ISelectMenuItem } from '@/components/form/SelectFormField';
 import { LookupContext } from '@/contexts/lookupContext';
 
-export const useGroupedAgenciesApi = () => {
+export const useAgencyOptions = () => {
   const { data: lookupData } = useContext(LookupContext);
 
   const activeAgencies = useMemo(() => {
@@ -77,4 +77,4 @@ export const useGroupedAgenciesApi = () => {
   };
 };
 
-export default useGroupedAgenciesApi;
+export default useAgencyOptions;

--- a/react-app/src/pages/AccessRequest.tsx
+++ b/react-app/src/pages/AccessRequest.tsx
@@ -15,7 +15,7 @@ import { AccessRequest as AccessRequestType } from '@/hooks/api/useUsersApi';
 import { UserContext } from '@/contexts/userContext';
 import { Navigate } from 'react-router-dom';
 import TextFormField from '@/components/form/TextFormField';
-import { useGroupedAgenciesApi } from '@/hooks/api/useGroupedAgenciesApi';
+import { useAgencyOptions } from '@/hooks/useAgencyOptions';
 import { SnackBarContext } from '@/contexts/snackbarContext';
 import { LookupContext } from '@/contexts/lookupContext';
 import { getProvider, validateEmail } from '@/utilities/helperFunctions';
@@ -43,7 +43,7 @@ const StatusPageTemplate = (props: StatusPageTemplateProps) => {
 
 const RequestForm = ({ submitHandler }: { submitHandler: (d: any) => void }) => {
   const sso = useSSO();
-  const agencyOptions = useGroupedAgenciesApi().agencyOptions;
+  const agencyOptions = useAgencyOptions().agencyOptions;
   const lookup = useContext(LookupContext);
   const theme = useTheme();
 


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2310](https://citz-imb.atlassian.net/browse/PIMS-2310)
Ticket is to address recent issue where a disabled agency would cause a rendering error when the application attempted to find it in the lookup map in the frontend (lookup map only contained active agencies by design).

_Technically_, this same issue could apply to any list in the lookup context, but only agencies and administrative areas are disabled by admin users, so they are the biggest risk. If we start disabling other things through migrations, Tier Levels for example, we need to include migrations to also change those values where present.

## Changes
- Disabled agencies and admin areas are now returned from the `lookup/all` endpoint. This does reveal which agencies are disabled, but that is unlikely to be a concern about "over-sharing" information.
- Adjusted the hook used for grouping agencies. It now only groups based on the active agencies. If you need a list of all agencies (disabled or not) use the lookup context.
- Created a similar hook for administrative areas. It doesn't have groups, but it provides active admin areas for select inputs.
- Applied these new options where necessary.
- Added useEffects in areas where the existing value might be disabled as well. This disabled value isn't normally in the list of active values, but it needs to be in the list of options for the input, otherwise the input is blank. These useEffect blocks add this option to the list if it's disabled and not already in there.
- Added `refreshLookup` calls in a few places where agencies and admin areas are created/edited. I realized that the lookup map was not refreshed, so it would sometimes contain out-of-date data. This was mostly an issue when disabling/enabling a record, as it would not disappear/appear from the options otherwise.

## Testing
- Best way to test is through having an agency that you disable/enable and then check if it's available in dropdown select inputs. These exist in the User, Agency, Administrative Area, Project, and Property areas in one way or another.
- You should not be able to select a disabled item unless it was already the current item (e.g. this property already belonged to a disabled agency).
- Adding or editing agencies or admin areas should immediately take effect elsewhere in the application without refreshing the page.

<!-- PROVIDE BELOW an explanation of your changes -->

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
