### PR TITLE
PIMS-2313 BUG: Emails Sent to System User

### DIFF
--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -19,7 +19,6 @@ import { ProjectAgencyResponse } from '@/typeorm/Entities/ProjectAgencyResponse'
 import logger from '@/utilities/winstonLogger';
 import getConfig from '@/constants/config';
 import { getDaysBetween } from '@/utilities/helperFunctions';
-import { PimsRequestUser } from '@/middleware/userAuthCheck';
 
 export interface AccessRequestData {
   FirstName: string;
@@ -386,7 +385,7 @@ const generateProjectNotifications = async (
  */
 const sendNotification = async (
   notification: NotificationQueue,
-  user: User,
+  user?: User,
   queryRunner?: QueryRunner,
 ) => {
   const query = queryRunner ?? AppDataSource.createQueryRunner();
@@ -767,10 +766,7 @@ const resendNotificationWithNewProperties = async (
   if (postCancelNotification.Status === NotificationStatus.Cancelled) {
     // Cancelled successfully, then requeue with new properties
     if (requeue) {
-      const newNotif = await sendNotification(
-        { ...notif, ...newProperties },
-        system as PimsRequestUser,
-      );
+      const newNotif = await sendNotification({ ...notif, ...newProperties });
       if (newNotif.Status === NotificationStatus.Failed) {
         const error = `resendNotificationWithNewProperties: Failed to requeue notification Id ${newNotif.Id} (originally ${notif.Id}).`;
         logger.error(error);

--- a/express-api/src/utilities/failedEmailCheck.ts
+++ b/express-api/src/utilities/failedEmailCheck.ts
@@ -9,7 +9,6 @@ import { IsNull, LessThan, Not } from 'typeorm';
 import nunjucks from 'nunjucks';
 import getConfig from '@/constants/config';
 import chesServices, { EmailBody, IEmail } from '@/services/ches/chesServices';
-import { PimsRequestUser } from '@/middleware/userAuthCheck';
 import { Project } from '@/typeorm/Entities/Project';
 import networking from '@/constants/networking';
 
@@ -75,7 +74,7 @@ const failedEmailCheck = async () => {
         subject: 'PIMS Notifications Warning',
         body: emailBody,
       };
-      const sendResult = await chesServices.sendEmailAsync(email, system as PimsRequestUser);
+      const sendResult = await chesServices.sendEmailAsync(email);
       // If the email fails to send, throw an error for logging purposes.
       if (sendResult == null) {
         throw new Error('Email was attempted but not sent. This feature could be disabled.');


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2313](https://citz-imb.atlassian.net/browse/PIMS-2313)
The system user was being used to send emails in cases where there wasn't an obvious user triggering the email. This was a problem when any of these conditions were met:
  - CHES_OVERRIDE_TO is set
  - CHES_SEND_TO_LIVE is not "true"
  - CHES_BCC_USER is "true"

Any of these could cause the system user's email to potentially be included in the TO, CC, or BCC fields. Because the system user's email isn't a real email, actually using it in a sent email caused the email to bounce back, which notified the PO. 
<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Made the user an optional argument for sendEmailAsync function.
- Removed system user from calls to this function.
- Tried to make sendEmailAsync function have more specific handling in case the system user is fed to it intentionally.

## Testing
Make sure CHES_SEND_TO_LIVE is **_not_** "true" for testing.
Make sure CHES_OVERRIDE_TO is set to your email.
The two cases where the system user was sent an email was when reporting failed resends or when requeuing notifications after an agency email is changed. It's easier to trigger that second one by having an agency with Pending notifications and changing its email address.

This should re-trigger those emails, but it shouldn't add the system user (or any user other than your override setting).
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
