### PR TITLE
PIMS-2323 Private notes no longer visible on export

### DIFF
--- a/express-api/src/controllers/projects/projectsController.ts
+++ b/express-api/src/controllers/projects/projectsController.ts
@@ -172,7 +172,7 @@ export const getProjects = async (req: Request, res: Response) => {
       const privateNoteType = await AppDataSource.getRepository(NoteType).findOne({
         where: { Name: 'Private' },
       });
-      // If private notes aren't found, skip filtering.
+      // If private note type doesn't exist, skip filtering.
       if (!privateNoteType) {
         logger.warn('Controller getProjects: Private note type not found.');
       } else {

--- a/express-api/src/controllers/projects/projectsController.ts
+++ b/express-api/src/controllers/projects/projectsController.ts
@@ -9,6 +9,10 @@ import { Roles } from '@/constants/roles';
 import notificationServices from '@/services/notifications/notificationServices';
 import { exposedProjectStatuses } from '@/constants/projectStatus';
 import { ProjectAgencyResponseSchema } from '@/services/projects/projectAgencyResponseSchema';
+import { ProjectNote } from '@/typeorm/Entities/ProjectNote';
+import { NoteType } from '@/typeorm/Entities/NoteType';
+import { AppDataSource } from '@/appDataSource';
+import logger from '@/utilities/winstonLogger';
 
 /**
  * @description Get disposal project by either the numeric id or projectNumber.
@@ -161,10 +165,33 @@ export const getProjects = async (req: Request, res: Response) => {
     filterResult.agencyId = usersAgencies;
   }
   // Get projects associated with agencies of the requesting user
-  const projects = forExcelExport
-    ? await projectServices.getProjectsForExport(filterResult as ProjectFilter)
-    : await projectServices.getProjects(filterResult as ProjectFilter);
-  return res.status(200).send(projects);
+  const filterPrivateNotes = async (notes: ProjectNote[]) => {
+    const privateNoteType = await AppDataSource.getRepository(NoteType).findOne({
+      where: { Name: 'Private' },
+    });
+    if (privateNoteType) {
+      return notes.filter((note: ProjectNote) => note.NoteTypeId !== privateNoteType.Id);
+    } else {
+      logger.error('filterPrivateNotes: Private note type not found.');
+      return notes;
+    }
+  };
+
+  if (forExcelExport) {
+    const projects = await projectServices.getProjectsForExport(filterResult as ProjectFilter);
+    // If the user is not an admin, filter out notes with Private type
+    if (!isAdmin) {
+      const promises = projects.map(async (project) => {
+        project.Notes = await filterPrivateNotes(project.Notes);
+      });
+      await Promise.all(promises);
+    }
+    return res.status(200).send(projects);
+  } else {
+    const projects = await projectServices.getProjects(filterResult as ProjectFilter);
+    // Notes are not returned in this case, so no need to filter them
+    return res.status(200).send(projects);
+  }
 };
 
 /**


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2323](https://citz-imb.atlassian.net/browse/PIMS-2323)

<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Filters out old private note field data when exporting projects if the user isn't an admin. The column remains, but there will be no data for it.

## Testing
- Try exporting the projects as an admin and see the Private Notes field
- Change self to General User and try again. Private Notes cells should be blank.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
