### PR TITLE
PIMS-2341 Table Row Count Bug

### DIFF
--- a/react-app/src/components/table/DataTable.tsx
+++ b/react-app/src/components/table/DataTable.tsx
@@ -203,7 +203,6 @@ export const FilterSearchDataGrid = (props: FilterSearchDataGridProps) => {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [dataSourceRows, setDataSourceRows] = useState([]);
-  const [rowCount, setRowCount] = useState<number>(0);
   const [keywordSearchContents, setKeywordSearchContents] = useState<string>('');
   const [gridFilterItems, setGridFilterItems] = useState([]);
   const [selectValue, setSelectValue] = useState<string>(props.defaultFilter);
@@ -434,10 +433,8 @@ export const FilterSearchDataGrid = (props: FilterSearchDataGridProps) => {
   }, [tableApiRef]);
 
   const tableHeaderRowCount = useMemo(() => {
-    return props.tableOperationMode === 'client'
-      ? `(${rowCount ?? 0} rows)`
-      : `(${props.rowCountProp ?? 0} rows)`;
-  }, [props.tableOperationMode, rowCount, props.rowCountProp]);
+    return `(${props.rowCountProp ?? 0} rows)`;
+  }, [props.rowCountProp]);
 
   const { pimsUser } = useContext(UserContext);
   const isAuditor = pimsUser.hasOneOfRoles([Roles.AUDITOR]);
@@ -590,12 +587,6 @@ export const FilterSearchDataGrid = (props: FilterSearchDataGridProps) => {
         </Box>
       </Box>
       <CustomDataGrid
-        onStateChange={(e) => {
-          // Keep track of row count separately
-          if (!props.dataSource) {
-            setRowCount(Object.values(e.filter.filteredRowsLookup).filter((value) => value).length);
-          }
-        }}
         onFilterModelChange={(e) => {
           // Can only filter by 1 at a time without DataGrid Pro
           const model: ITableModelCollection = {};

--- a/react-app/src/components/users/UsersTable.tsx
+++ b/react-app/src/components/users/UsersTable.tsx
@@ -258,14 +258,10 @@ const UsersTable = (props: IUsersTable) => {
           customExcelMap={excelDataMap}
           addTooltip="Adding a new user from this table is not supported yet. Please advise users to use the access request form."
           getRowId={(row) => row.Id}
+          rowCountProp={users.length}
           columns={columns}
           rows={users}
           loading={isLoading}
-          // initialState={{
-          //   sorting: {
-          //     sortModel: [{ field: 'Status', sort: 'desc' }],
-          //   },
-          // }}
           onPresetFilterChange={selectPresetFilter}
           presetFilterSelectOptions={[
             <CustomMenuItem key={'All Users'} value={'All Users'}>


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2341](https://citz-imb.atlassian.net/browse/PIMS-2341)
Row count wasn't showing on the User table (the only one still using client-side logic).
<!-- PROVIDE BELOW an explanation of your changes -->
## Changes
- Adjusted source of row count. It was more complicated before, but this simpler method seems to work too.

## Testing
- Look at the main pages with tables (users, project, properties, agencies, admin areas) and see if the table row count is displayed correctly.

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
