### PR TITLE
PIMS-2339c Add retries to CHES cancellation attempt

### DIFF
--- a/express-api/src/services/ches/chesServices.ts
+++ b/express-api/src/services/ches/chesServices.ts
@@ -303,6 +303,17 @@ const cancelEmailByIdAsync = async (messageId: string) => {
     const confirmation = await getStatusByIdAsync(messageId);
     if (confirmation.status === 'cancelled') {
       response.status = 'cancelled';
+    } else {
+      // Because the status is not necessarily updated immediately in CHES, we must have retries.
+      // Retry up to 3 times to confirm cancellation.
+      for (let i = 0; i < 3; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait 1 second before retrying
+        const retryConfirmation = await getStatusByIdAsync(messageId);
+        if (retryConfirmation.status === 'cancelled') {
+          response.status = 'cancelled';
+          break;
+        }
+      }
     }
   }
   return response;


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2339](https://citz-imb.atlassian.net/browse/PIMS-2339)

<!-- PROVIDE BELOW an explanation of your changes -->
What I hope is the last addition to this ticket.
To account for the time differences in CHES (DEV seems to be fast to cancel, but TEST is slow), it will now try another three times if the first status request doesn't return cancelled. Hopefully this will resolve the race condition problem where their TEST server takes an additional second to actually cancel the notification behind the scenes.

## Changes
- Added else statement that retries up to three times if the initial status request after cancelation isn't successful.

## Testing
- Try to requeue a notification in the Pending status.
<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
