### PR TITLE
PIMS-2347 Project Agency Response Date Saving Bug

### DIFF
--- a/express-api/src/controllers/projects/projectsController.ts
+++ b/express-api/src/controllers/projects/projectsController.ts
@@ -215,11 +215,21 @@ export const updateProjectAgencyResponses = async (req: Request, res: Response) 
     return res.status(403).send('Projects only editable by Administrator role.');
   }
 
-  const notificationsSent = await projectServices.updateProjectAgencyResponses(
+  const updateResults = await projectServices.updateProjectAgencyResponses(
     projectId,
     req.body.responses,
     req.pimsUser,
   );
 
-  return res.status(200).send(notificationsSent);
+  // Let requestor know if any of the responses were not updated due to invalid changes.
+  // This can happen if they are trying to subscribe an agency that is disabled, has no email, or has opted out of notifications.
+  if (updateResults.invalidResponseChanges > 0) {
+    return res
+      .status(400)
+      .send(
+        `${updateResults.invalidResponseChanges} of the responses were not updated due to invalid changes.`,
+      );
+  }
+
+  return res.status(200).send(updateResults);
 };

--- a/express-api/src/services/notifications/notificationServices.ts
+++ b/express-api/src/services/notifications/notificationServices.ts
@@ -677,8 +677,9 @@ const generateProjectWatchNotifications = async (
           const agency = await query.manager.findOne(Agency, {
             where: { Id: response.AgencyId },
           });
-          //No use in queueing an email for an agency with no email address or that doesn't want notifications
-          if (agency?.SendEmail && agency?.Email && agency?.Email.length) {
+          // No use in queueing an email for an agency with no email address or that doesn't want notifications
+          // Don't queue notifications for disabled agencies either.
+          if (agency?.SendEmail && agency?.Email && agency?.Email.length && !agency.IsDisabled) {
             const dateInERP = project.ApprovedOn;
             const daysSinceThisStatus = getDaysBetween(dateInERP, new Date());
             const statusNotifs = await query.manager.find(ProjectStatusNotification, {

--- a/react-app/src/components/projects/AgencyResponseSearchTable.tsx
+++ b/react-app/src/components/projects/AgencyResponseSearchTable.tsx
@@ -13,7 +13,7 @@ import {
   useTheme,
   Tooltip,
 } from '@mui/material';
-import { GridColDef, DataGrid, DataGridProps } from '@mui/x-data-grid';
+import { GridColDef, DataGrid, DataGridProps, useGridApiRef } from '@mui/x-data-grid';
 import { useState } from 'react';
 import { ISelectMenuItem } from '../form/SelectFormField';
 import { Agency } from '@/hooks/api/useAgencyApi';
@@ -46,6 +46,7 @@ interface IAgencySimpleTable {
 
 export const AgencySimpleTable = (props: IAgencySimpleTable) => {
   const theme = useTheme();
+  const apiRef = useGridApiRef();
   const edit = props.editMode;
   const columns: GridColDef[] = [
     {
@@ -128,6 +129,7 @@ export const AgencySimpleTable = (props: IAgencySimpleTable) => {
   ];
   return (
     <DataGrid
+      apiRef={apiRef}
       getRowId={(row) => row.Id}
       editMode="row"
       hideFooter
@@ -156,6 +158,11 @@ export const AgencySimpleTable = (props: IAgencySimpleTable) => {
         }
         // For other columns, use their editable property
         return params.colDef.editable === true;
+      }}
+      initialState={{
+        sorting: {
+          sortModel: [{ field: 'Name', sort: 'asc' }],
+        },
       }}
       {...props.dataGridProps}
     />

--- a/react-app/src/components/projects/AgencyResponseSearchTable.tsx
+++ b/react-app/src/components/projects/AgencyResponseSearchTable.tsx
@@ -71,6 +71,8 @@ export const AgencySimpleTable = (props: IAgencySimpleTable) => {
       field: 'Note',
       headerName: 'Note',
       flex: 1,
+      minWidth: 200,
+      maxWidth: 400,
       editable: edit,
       type: 'string',
       renderCell: (params) =>
@@ -83,7 +85,7 @@ export const AgencySimpleTable = (props: IAgencySimpleTable) => {
     {
       field: 'Response',
       headerName: 'Response',
-      flex: 1,
+      flex: 0.4,
       editable: edit,
       type: 'singleSelect',
       valueOptions: Object.keys(AgencyResponseType).filter((key) => isNaN(Number(key))),
@@ -92,7 +94,7 @@ export const AgencySimpleTable = (props: IAgencySimpleTable) => {
   return (
     <DataGrid
       getRowId={(row) => row.Id}
-      autoHeight
+      editMode="row"
       hideFooter
       disableRowSelectionOnClick
       columns={[...columns, ...(props.additionalColumns ?? [])]}

--- a/react-app/src/components/projects/AgencyResponseSearchTable.tsx
+++ b/react-app/src/components/projects/AgencyResponseSearchTable.tsx
@@ -13,7 +13,7 @@ import {
   useTheme,
   Tooltip,
 } from '@mui/material';
-import { GridColDef, DataGrid, DataGridProps, useGridApiRef } from '@mui/x-data-grid';
+import { GridColDef, DataGrid, DataGridProps } from '@mui/x-data-grid';
 import { useState } from 'react';
 import { ISelectMenuItem } from '../form/SelectFormField';
 import { Agency } from '@/hooks/api/useAgencyApi';
@@ -46,7 +46,6 @@ interface IAgencySimpleTable {
 
 export const AgencySimpleTable = (props: IAgencySimpleTable) => {
   const theme = useTheme();
-  const apiRef = useGridApiRef();
   const edit = props.editMode;
   const columns: GridColDef[] = [
     {
@@ -129,9 +128,8 @@ export const AgencySimpleTable = (props: IAgencySimpleTable) => {
   ];
   return (
     <DataGrid
-      apiRef={apiRef}
       getRowId={(row) => row.Id}
-      editMode="row"
+      editMode="cell"
       hideFooter
       disableRowSelectionOnClick
       disableColumnResize

--- a/react-app/src/components/projects/ProjectDialog.tsx
+++ b/react-app/src/components/projects/ProjectDialog.tsx
@@ -505,7 +505,7 @@ export const ProjectAgencyResponseDialog = (props: IProjectAgencyResponseDialog)
   }, [initialValues, lookupData?.Agencies]);
   return (
     <ConfirmDialog
-      dialogProps={{ maxWidth: 'lg' }}
+      dialogProps={{ maxWidth: 'xl' }}
       title={'Edit Agency Interest Responses'}
       open={open}
       confirmButtonProps={{ loading: submitting }}
@@ -524,7 +524,7 @@ export const ProjectAgencyResponseDialog = (props: IProjectAgencyResponseDialog)
       }}
       onCancel={async () => onCancel()}
     >
-      <Box paddingTop={'1rem'}>
+      <Box paddingTop={'1rem'} width={'70vw'} height={'80vh'}>
         <AgencySearchTable
           agencies={activeAgencies as Agency[]}
           options={options}

--- a/react-app/src/components/projects/ProjectDialog.tsx
+++ b/react-app/src/components/projects/ProjectDialog.tsx
@@ -518,6 +518,7 @@ export const ProjectAgencyResponseDialog = (props: IProjectAgencyResponseDialog)
             Response: Number(AgencyResponseType[agc.Response]),
             Note: agc.Note,
             ProjectId: initialValues.Id,
+            ReceivedOn: agc.ReceivedOn,
           })),
         ).then(() => postSubmit());
       }}

--- a/react-app/src/constants/agencyResponseTypes.ts
+++ b/react-app/src/constants/agencyResponseTypes.ts
@@ -2,3 +2,8 @@ export enum AgencyResponseType {
   Unsubscribe = 0,
   Subscribe = 1,
 }
+
+export const AgencyResponseTypeLabels: Record<AgencyResponseType, string> = {
+  [AgencyResponseType.Unsubscribe]: 'Unsubscribe',
+  [AgencyResponseType.Subscribe]: 'Subscribe',
+};


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
Example: PIMS-700: A great ticket                                       
-->  

## 🎯 Summary

<!-- EDIT JIRA LINK BELOW -->  
[PIMS-2347](https://citz-imb.atlassian.net/browse/PIMS-2347)
Initial concern was that the Received On date field wasn't being saved. 
In fixing this, I noticed two additional problems:
1. If an agency is already in the response list but then becomes disabled, it's still possible to change its response to Subscribed.
2. If an agency is already in the response list but then opts out of emails system-wide, it's still possible to change its response to Subscribed.

## Changes
- Now sending Received On date with the Agency Responses.
- Backend logic that prevents agency responses from getting that Subscribed status if the agency is disabled, missing an email, or has opted out of emails.
- Frontend UI changes for better viewing of agency responses.
- Frontend styling to clearly display that an agency response cannot be changed to Subscribe and prevent the user from doing so.

## Testing
- Check that you can now save the Received On date
- Check if you cannot set an agency response to Subscribed when it shouldn't be able to. AKA agency is disabled or opted out of emails.
- Check that you can still subscribe and unsubscribe other agencies as expected.
<!-- PROVIDE BELOW an explanation of your changes -->

<!-- PROVIDE ABOVE an explanation of your changes -->

## 🔰 Checklist

- [ ] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - My changes generate no new warnings.
